### PR TITLE
Add non-coordinating readonly followers

### DIFF
--- a/p/model/Drivers.p
+++ b/p/model/Drivers.p
@@ -258,7 +258,8 @@ machine HistoricalMaintenanceRepairDriver {
             // applied before the repair coordinator reads the zones.
             send buckets[1], eCorruptRecord, (offset=0,);
             send buckets[1], eRead, (
-                caller=this, segment=historical.base, gen=-1);
+                caller=this, segment=historical.base, gen=-1,
+                readonly=false);
             receive { case eReadResponse: (r: tReadResponse) {
                 dataResponse = r;
             } }

--- a/p/model/Monitors.p
+++ b/p/model/Monitors.p
@@ -444,6 +444,153 @@ spec StartupReplayAndTruncation observes eRecordFormed,
     }
 }
 
+// A readonly follower is a non-coordinating observer of sealed directory
+// entries and the manifest-selected active tail. Sealed records come from the
+// published immutable prefix. Active records must be complete, identical
+// observations on a strict majority, which makes that prefix recovery-stable
+// by quorum intersection even if writer acknowledgment has not yet run.
+spec ReadonlyFollowerSafety observes eRecordPersisted, eRecordCommitted,
+    eEpochClaimed, eReadonlyOpened, eReadonlySnapshot,
+    eReadonlyActiveSnapshot, eReadonlyRecord, eReadonlyLagged {
+    var support: map[(offset: int, value: int, segment: int), set[int]];
+    var committed: map[int, tRecord];
+    var next: map[int, int];
+    var readers: set[int];
+    var lagged: set[int];
+    var snapshotEnd: map[int, int];
+    var snapshotTrunc: map[int, int];
+    var snapshotSegmentBase: map[int, int];
+    var snapshotSegmentId: map[int, int];
+    var snapshotSegmentEnd: map[int, int];
+    var snapshotActive: map[int, bool];
+
+    start state Observing {
+        on eRecordPersisted do (payload: (
+            zone: int, writerId: int, record: tRecord, gen: int
+        )) {
+            var key: (offset: int, value: int, segment: int);
+            key = RecordKey(payload.record);
+            if (!(key in support)) {
+                support[key] = default(set[int]);
+            }
+            support[key] += (payload.zone);
+        }
+
+        on eRecordCommitted do (payload: (
+            writerId: int, record: tRecord
+        )) {
+            committed[payload.record.offset] = payload.record;
+        }
+
+        on eEpochClaimed do (payload: (epoch: int, writerId: int)) {
+            assert !(payload.writerId in readers),
+                "readonly follower claimed a writer epoch";
+        }
+
+        on eReadonlyOpened do (payload: (
+            reader: int, nextOffset: int
+        )) {
+            assert !(payload.reader in readers),
+                "readonly follower opened twice";
+            readers += (payload.reader);
+            next[payload.reader] = payload.nextOffset;
+        }
+
+        on eReadonlySnapshot do (payload: (
+            reader: int,
+            nextOffset: int,
+            trunc: int,
+            publishedEnd: int,
+            segmentBase: int,
+            segmentId: int,
+            segmentEnd: int
+        )) {
+            assert payload.reader in readers &&
+                !(payload.reader in lagged) &&
+                payload.nextOffset == next[payload.reader],
+                "readonly snapshot did not start at the follower cursor";
+            snapshotEnd[payload.reader] = payload.publishedEnd;
+            snapshotTrunc[payload.reader] = payload.trunc;
+            snapshotSegmentBase[payload.reader] = payload.segmentBase;
+            snapshotSegmentId[payload.reader] = payload.segmentId;
+            snapshotSegmentEnd[payload.reader] = payload.segmentEnd;
+            snapshotActive[payload.reader] = false;
+        }
+
+        on eReadonlyActiveSnapshot do (payload: (
+            reader: int,
+            nextOffset: int,
+            trunc: int,
+            segmentBase: int,
+            segmentId: int
+        )) {
+            assert payload.reader in readers &&
+                !(payload.reader in lagged) &&
+                payload.nextOffset == next[payload.reader],
+                "readonly active snapshot did not start at the follower cursor";
+            snapshotTrunc[payload.reader] = payload.trunc;
+            snapshotSegmentBase[payload.reader] = payload.segmentBase;
+            snapshotSegmentId[payload.reader] = payload.segmentId;
+            snapshotActive[payload.reader] = true;
+        }
+
+        on eReadonlyRecord do (payload: (
+            reader: int,
+            record: tRecord,
+            segmentId: int
+        )) {
+            var key: (offset: int, value: int, segment: int);
+            assert payload.reader in readers &&
+                !(payload.reader in lagged) &&
+                payload.record.offset == next[payload.reader],
+                "readonly follower skipped or duplicated a record";
+            assert payload.reader in snapshotActive &&
+                payload.reader in snapshotTrunc &&
+                snapshotTrunc[payload.reader] <= payload.record.offset &&
+                payload.segmentId == snapshotSegmentId[payload.reader],
+                "readonly follower emitted outside its manifest-selected segment";
+            if (snapshotActive[payload.reader]) {
+                key = RecordKey(payload.record);
+                assert payload.record.segment ==
+                    snapshotSegmentBase[payload.reader] &&
+                    key in support && sizeof(support[key]) >= 2,
+                    "readonly follower emitted an active record without majority support";
+            } else {
+                assert payload.record.offset in committed &&
+                    committed[payload.record.offset] == payload.record,
+                    "readonly follower emitted a changed sealed record";
+                assert payload.reader in snapshotEnd &&
+                    snapshotSegmentBase[payload.reader] <=
+                        payload.record.offset &&
+                    payload.record.offset <=
+                        snapshotSegmentEnd[payload.reader] &&
+                    snapshotSegmentEnd[payload.reader] <
+                        snapshotEnd[payload.reader],
+                    "readonly follower emitted outside its published sealed segment";
+            }
+            next[payload.reader] = payload.record.offset + 1;
+        }
+
+        on eReadonlyLagged do (payload: (
+            reader: int, nextOffset: int, trunc: int
+        )) {
+            assert payload.reader in readers &&
+                !(payload.reader in lagged) &&
+                payload.nextOffset == next[payload.reader] &&
+                payload.trunc > payload.nextOffset,
+                "readonly follower reported lag without an overtaking floor";
+            lagged += (payload.reader);
+        }
+    }
+
+    fun RecordKey(record: tRecord): (
+        offset: int, value: int, segment: int
+    ) {
+        return (offset=record.offset, value=record.value,
+            segment=record.segment);
+    }
+}
+
 spec GetSizeExcludesOpenTail observes eGetSizeObserved {
     start state Observing {
         on eGetSizeObserved do (payload: (

--- a/p/model/Monitors.p
+++ b/p/model/Monitors.p
@@ -450,6 +450,7 @@ spec StartupReplayAndTruncation observes eRecordFormed,
 // observations on a strict majority, which makes that prefix recovery-stable
 // by quorum intersection even if writer acknowledgment has not yet run.
 spec ReadonlyFollowerSafety observes eRecordPersisted, eRecordCommitted,
+    eRecoverySelected, eRecoveryCompleted,
     eEpochClaimed, eReadonlyOpened, eReadonlySnapshot,
     eReadonlyActiveSnapshot, eReadonlyRecord, eReadonlyLagged {
     var support: map[(offset: int, value: int, segment: int), set[int]];
@@ -463,6 +464,8 @@ spec ReadonlyFollowerSafety observes eRecordPersisted, eRecordCommitted,
     var snapshotSegmentId: map[int, int];
     var snapshotSegmentEnd: map[int, int];
     var snapshotActive: map[int, bool];
+    var activeEmitted: map[int, tRecord];
+    var recovered: map[(writerId: int, offset: int), tRecord];
 
     start state Observing {
         on eRecordPersisted do (payload: (
@@ -480,6 +483,31 @@ spec ReadonlyFollowerSafety observes eRecordPersisted, eRecordCommitted,
             writerId: int, record: tRecord
         )) {
             committed[payload.record.offset] = payload.record;
+        }
+
+        on eRecoverySelected do (payload: (
+            writerId: int, record: tRecord
+        )) {
+            recovered[(writerId=payload.writerId,
+                offset=payload.record.offset)] = payload.record;
+        }
+
+        on eRecoveryCompleted do (payload: (
+            writerId: int, segment: int, startOffset: int, endOffset: int
+        )) {
+            var offset: int;
+            // Emission creates a retention obligation even without a writer
+            // commit. Check the whole segment, including an empty recovery.
+            foreach (offset in keys(activeEmitted)) {
+                if (activeEmitted[offset].segment == payload.segment) {
+                    assert payload.startOffset <= offset &&
+                        offset < payload.endOffset &&
+                        (writerId=payload.writerId, offset=offset) in recovered &&
+                        recovered[(writerId=payload.writerId, offset=offset)] ==
+                            activeEmitted[offset],
+                        "recovery omitted or changed a readonly active record";
+                }
+            }
         }
 
         on eEpochClaimed do (payload: (epoch: int, writerId: int)) {
@@ -555,6 +583,11 @@ spec ReadonlyFollowerSafety observes eRecordPersisted, eRecordCommitted,
                     snapshotSegmentBase[payload.reader] &&
                     key in support && sizeof(support[key]) >= 2,
                     "readonly follower emitted an active record without majority support";
+                if (payload.record.offset in activeEmitted) {
+                    assert activeEmitted[payload.record.offset] == payload.record,
+                        "readonly followers emitted different active records at one offset";
+                }
+                activeEmitted[payload.record.offset] = payload.record;
             } else {
                 assert payload.record.offset in committed &&
                     committed[payload.record.offset] == payload.record,

--- a/p/model/Monitors.p
+++ b/p/model/Monitors.p
@@ -449,8 +449,8 @@ spec StartupReplayAndTruncation observes eRecordFormed,
 // published immutable prefix. Active records must be complete, identical
 // observations on a strict majority, which makes that prefix recovery-stable
 // by quorum intersection even if writer acknowledgment has not yet run.
-spec ReadonlyFollowerSafety observes eRecordPersisted, eRecordCommitted,
-    eRecoverySelected, eRecoveryCompleted,
+spec ReadonlyFollowerSafety observes eRecordPersisted, eCanonicalPersisted,
+    eRecordCommitted, eRecoverySelected, eRecoveryCompleted,
     eEpochClaimed, eReadonlyOpened, eReadonlySnapshot,
     eReadonlyActiveSnapshot, eReadonlyRecord, eReadonlyLagged {
     var support: map[(offset: int, value: int, segment: int), set[int]];
@@ -466,10 +466,28 @@ spec ReadonlyFollowerSafety observes eRecordPersisted, eRecordCommitted,
     var snapshotActive: map[int, bool];
     var activeEmitted: map[int, tRecord];
     var recovered: map[(writerId: int, offset: int), tRecord];
+    // Records a recovery selected for retention. A sealed segment may hold a
+    // record the original writer never acknowledged, so sealed replay is
+    // checked against this as well as against writer commits.
+    var retained: map[int, tRecord];
 
     start state Observing {
         on eRecordPersisted do (payload: (
             zone: int, writerId: int, record: tRecord, gen: int
+        )) {
+            var key: (offset: int, value: int, segment: int);
+            key = RecordKey(payload.record);
+            if (!(key in support)) {
+                support[key] = default(set[int]);
+            }
+            support[key] += (payload.zone);
+        }
+
+        // Recovery writes the canonical bytes back onto a quorum. Those copies
+        // support a follower's active read the same way the writer's own
+        // appends do.
+        on eCanonicalPersisted do (payload: (
+            zone: int, writerId: int, record: tRecord
         )) {
             var key: (offset: int, value: int, segment: int);
             key = RecordKey(payload.record);
@@ -490,6 +508,7 @@ spec ReadonlyFollowerSafety observes eRecordPersisted, eRecordCommitted,
         )) {
             recovered[(writerId=payload.writerId,
                 offset=payload.record.offset)] = payload.record;
+            retained[payload.record.offset] = payload.record;
         }
 
         on eRecoveryCompleted do (payload: (
@@ -589,8 +608,10 @@ spec ReadonlyFollowerSafety observes eRecordPersisted, eRecordCommitted,
                 }
                 activeEmitted[payload.record.offset] = payload.record;
             } else {
-                assert payload.record.offset in committed &&
-                    committed[payload.record.offset] == payload.record,
+                assert (payload.record.offset in committed &&
+                        committed[payload.record.offset] == payload.record) ||
+                    (payload.record.offset in retained &&
+                        retained[payload.record.offset] == payload.record),
                     "readonly follower emitted a changed sealed record";
                 assert payload.reader in snapshotEnd &&
                     snapshotSegmentBase[payload.reader] <=

--- a/p/model/Monitors.p
+++ b/p/model/Monitors.p
@@ -737,9 +737,17 @@ spec DirectoryEnforcement observes eSealQuorumEnforced, eDirectoryAdopted,
                 "directory replay used an entry before adoption";
         }
 
+        // Scoped to coordinating reads. The property is that a recovering
+        // writer which adopted an entry on finalized-quorum evidence does not
+        // then download it, keeping repair off the startup path. A readonly
+        // follower never adopts, so its reads are outside the boundary; it
+        // reads whatever segment its own cursor still needs, including one a
+        // later writer has since adopted unread.
         on eRead do (request: tReadRequest) {
-            assert !(request.segment in adoptedUnreadBases),
-                "recovery reread an older adopted directory entry";
+            if (!request.readonly) {
+                assert !(request.segment in adoptedUnreadBases),
+                    "recovery reread an older adopted directory entry";
+            }
         }
     }
 }

--- a/p/model/PipelinedWal.p
+++ b/p/model/PipelinedWal.p
@@ -983,7 +983,8 @@ machine HistoricalMaintenanceCoordinator {
             zone = 0;
             while (zone < sizeof(payload.buckets)) {
                 send payload.buckets[zone], eRead, (
-                    caller=this, segment=payload.directoryEntry.base, gen=-1);
+                    caller=this, segment=payload.directoryEntry.base, gen=-1,
+                    readonly=false);
                 zone = zone + 1;
             }
             replies = 0;

--- a/p/model/ReadonlyFollower.p
+++ b/p/model/ReadonlyFollower.p
@@ -1,0 +1,459 @@
+// Persistent readonly follower over the manifest-selected segment chain.
+//
+// The follower never claims an epoch and never sends a mutating storage
+// request. Each poll reads one linearizable manifest snapshot, detects an
+// overtaking truncation floor, reads finalized directory segments, then reads
+// the active tail without requiring finalization. Active records are emitted
+// only after identical bytes are visible on two zones. The active read returns
+// as soon as the first matching majority arrives; a slow third response is not
+// on the publication path. Polling the same machine again discovers later
+// appends and seals without writer coordination.
+machine ReadonlyFollower {
+    var reader: int;
+    var manifest: ManifestRegister;
+    var segmentBuckets: seq[seq[ZonalBucket]];
+    var parent: machine;
+    var nextOffset: int;
+    var pauseAfterSnapshot: bool;
+    var paused: bool;
+
+    start state Following {
+        entry (payload: (
+            reader: int,
+            manifest: ManifestRegister,
+            segmentBuckets: seq[seq[ZonalBucket]],
+            nextOffset: int,
+            pauseAfterSnapshot: bool,
+            parent: machine
+        )) {
+            reader = payload.reader;
+            manifest = payload.manifest;
+            segmentBuckets = payload.segmentBuckets;
+            nextOffset = payload.nextOffset;
+            pauseAfterSnapshot = payload.pauseAfterSnapshot;
+            parent = payload.parent;
+            announce eReadonlyOpened, (
+                reader=reader, nextOffset=nextOffset);
+        }
+
+        on eReadonlyPoll do Poll;
+
+        ignore eManifestReadResponse, eReadResponse, eReadonlyContinue;
+    }
+
+    fun Poll() {
+        var readResponse: tManifestReadResponse;
+        var emitted: int;
+        var index: int;
+        var endOffset: int;
+        var found: bool;
+
+        send manifest, eManifestRead, (caller=this,);
+        receive { case eManifestReadResponse: (r: tManifestReadResponse) {
+            readResponse = r;
+        } }
+        if (readResponse.status != STATUS_OK) {
+            Done(0, false);
+            return;
+        }
+        if (readResponse.rec.trunc > nextOffset) {
+            announce eReadonlyLagged, (
+                reader=reader, nextOffset=nextOffset,
+                trunc=readResponse.rec.trunc);
+            Done(0, true);
+            return;
+        }
+
+        emitted = 0;
+        while (nextOffset < readResponse.rec.tailBase) {
+            found = false;
+            index = 0;
+            while (index < sizeof(readResponse.rec.directory)) {
+                endOffset = DirectoryEnd(readResponse.rec, index);
+                if (readResponse.rec.directory[index].base <= nextOffset &&
+                    nextOffset <= endOffset) {
+                    found = true;
+                    break;
+                }
+                index = index + 1;
+            }
+            assert found,
+                "manifest published end without a directory segment";
+
+            announce eReadonlySnapshot, (
+                reader=reader,
+                nextOffset=nextOffset,
+                trunc=readResponse.rec.trunc,
+                publishedEnd=readResponse.rec.tailBase,
+                segmentBase=readResponse.rec.directory[index].base,
+                segmentId=readResponse.rec.directory[index].id,
+                segmentEnd=endOffset);
+            if (pauseAfterSnapshot && !paused) {
+                paused = true;
+                send parent, eReadonlySnapshotPaused;
+                receive { case eReadonlyContinue: {} }
+            }
+
+            if (!ReadOne(
+                readResponse.rec.directory[index],
+                endOffset
+            )) {
+                Done(emitted, false);
+                return;
+            }
+            nextOffset = nextOffset + 1;
+            emitted = emitted + 1;
+        }
+        if (readResponse.rec.tailBase < sizeof(segmentBuckets)) {
+            announce eReadonlyActiveSnapshot, (
+                reader=reader,
+                nextOffset=nextOffset,
+                trunc=readResponse.rec.trunc,
+                segmentBase=readResponse.rec.tailBase,
+                segmentId=readResponse.rec.tailGen);
+            if (ReadActive(
+                readResponse.rec.tailBase,
+                readResponse.rec.tailGen
+            )) {
+                nextOffset = nextOffset + 1;
+                emitted = emitted + 1;
+            }
+        }
+        Done(emitted, false);
+    }
+
+    fun ReadOne(directoryEntry: tDirectoryEntry, endOffset: int): bool {
+        var zone: int;
+        var replies: int;
+        var response: tReadResponse;
+        var record: tRecord;
+        var candidate: tRecord;
+        var foundRecord: bool;
+        var key: (offset: int, value: int, segment: int);
+        var support: map[
+            (offset: int, value: int, segment: int), set[int]
+        ];
+
+        zone = 0;
+        while (zone < sizeof(segmentBuckets[directoryEntry.base])) {
+            send segmentBuckets[directoryEntry.base][zone], eRead, (
+                caller=this, segment=directoryEntry.base, gen=-1);
+            zone = zone + 1;
+        }
+        replies = 0;
+        foundRecord = false;
+        while (replies < sizeof(segmentBuckets[directoryEntry.base])) {
+            receive { case eReadResponse: (r: tReadResponse) {
+                response = r;
+            } }
+            replies = replies + 1;
+            if (response.status == STATUS_OK && response.finalized) {
+                foreach (record in response.records) {
+                    if (record.offset == nextOffset &&
+                        record.offset <= endOffset) {
+                        key = (
+                            offset=record.offset,
+                            value=record.value,
+                            segment=record.segment);
+                        if (!(key in support)) {
+                            support[key] = default(set[int]);
+                        }
+                        support[key] += (response.zone);
+                        if (sizeof(support[key]) >= 2) {
+                            candidate = record;
+                            foundRecord = true;
+                        }
+                    }
+                }
+            }
+        }
+        if (!foundRecord) { return false; }
+        announce eReadonlyRecord, (
+            reader=reader, record=candidate, segmentId=directoryEntry.id);
+        return true;
+    }
+
+    fun ReadActive(segmentBase: int, segmentId: int): bool {
+        var zone: int;
+        var replies: int;
+        var response: tReadResponse;
+        var record: tRecord;
+        var key: (offset: int, value: int, segment: int);
+        var support: map[
+            (offset: int, value: int, segment: int), set[int]
+        ];
+
+        zone = 0;
+        while (zone < sizeof(segmentBuckets[segmentBase])) {
+            send segmentBuckets[segmentBase][zone], eRead, (
+                caller=this, segment=segmentBase, gen=segmentId);
+            zone = zone + 1;
+        }
+        replies = 0;
+        while (replies < sizeof(segmentBuckets[segmentBase])) {
+            receive { case eReadResponse: (r: tReadResponse) {
+                response = r;
+            } }
+            replies = replies + 1;
+            if (response.status == STATUS_OK) {
+                foreach (record in response.records) {
+                    if (record.offset == nextOffset) {
+                        key = (
+                            offset=record.offset,
+                            value=record.value,
+                            segment=record.segment);
+                        if (!(key in support)) {
+                            support[key] = default(set[int]);
+                        }
+                        support[key] += (response.zone);
+                        if (sizeof(support[key]) >= 2) {
+                            announce eReadonlyRecord, (
+                                reader=reader, record=record,
+                                segmentId=segmentId);
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    fun DirectoryEnd(record: tManifestRecord, index: int): int {
+        if (index + 1 < sizeof(record.directory)) {
+            return record.directory[index + 1].base - 1;
+        }
+        return record.tailBase - 1;
+    }
+
+    fun Done(emitted: int, lagged: bool) {
+        send parent, eReadonlyPollDone, (
+            reader=reader, nextOffset=nextOffset,
+            emitted=emitted, lagged=lagged);
+    }
+}
+
+machine ReadonlyFollowerDriver {
+    start state Init {
+        entry {
+            var segmentBuckets: seq[seq[ZonalBucket]];
+            var buckets: seq[ZonalBucket];
+            var manifest: ManifestRegister;
+            var follower: ReadonlyFollower;
+            var base: int;
+            var zone: int;
+            var writerId: int;
+            var stopped: (
+                writerId: int, committed: bool,
+                sealed: bool, crashed: bool
+            );
+            var poll: (
+                reader: int, nextOffset: int,
+                emitted: int, lagged: bool
+            );
+
+            base = 0;
+            while (base < 2) {
+                buckets = default(seq[ZonalBucket]);
+                zone = 0;
+                while (zone < 3) {
+                    buckets += (zone,
+                        new ZonalBucket((zone=zone, failures=0)));
+                    zone = zone + 1;
+                }
+                segmentBuckets += (base, buckets);
+                base = base + 1;
+            }
+            manifest = new ManifestRegister((failures=0,));
+            follower = new ReadonlyFollower((
+                reader=100, manifest=manifest,
+                segmentBuckets=segmentBuckets, nextOffset=0,
+                pauseAfterSnapshot=false, parent=this));
+
+            // Opening and polling before the first seal observes an empty
+            // published prefix without creating or claiming anything.
+            send follower, eReadonlyPoll;
+            receive { case eReadonlyPollDone: (payload: (
+                reader: int, nextOffset: int,
+                emitted: int, lagged: bool
+            )) { poll = payload; } }
+            assert poll.nextOffset == 0 && poll.emitted == 0 &&
+                !poll.lagged;
+
+            writerId = 1;
+            base = 0;
+            while (base < 2) {
+                new DirectoryRotation((
+                    writerId=writerId, base=base,
+                    value=700 + base, manifest=manifest,
+                    buckets=segmentBuckets[base], parent=this));
+                receive { case eWriterDone: (payload: (
+                    writerId: int, committed: bool,
+                    sealed: bool, crashed: bool
+                )) { stopped = payload; } }
+                assert stopped.committed;
+                writerId = writerId + 1;
+                if (!stopped.sealed) {
+                    new WriterProcess((
+                        writerId=writerId, value=-1,
+                        buckets=segmentBuckets[base], segBase=base,
+                        manifest=manifest, parent=this,
+                        shouldSeal=true, recoverExisting=true,
+                        crashBudget=0));
+                    receive { case eWriterDone: (payload: (
+                        writerId: int, committed: bool,
+                        sealed: bool, crashed: bool
+                    )) { stopped = payload; } }
+                    assert stopped.sealed;
+                    writerId = writerId + 1;
+                }
+
+                send follower, eReadonlyPoll;
+                receive { case eReadonlyPollDone: (payload: (
+                    reader: int, nextOffset: int,
+                    emitted: int, lagged: bool
+                )) { poll = payload; } }
+                assert poll.nextOffset == base + 1 &&
+                    poll.emitted == 1 && !poll.lagged,
+                    "readonly follower did not discover the next seal";
+                base = base + 1;
+            }
+        }
+    }
+}
+
+machine ReadonlyActiveTailDriver {
+    start state Init {
+        entry {
+            var segmentBuckets: seq[seq[ZonalBucket]];
+            var buckets: seq[ZonalBucket];
+            var manifest: ManifestRegister;
+            var follower: ReadonlyFollower;
+            var zone: int;
+            var stopped: (
+                writerId: int, committed: bool,
+                sealed: bool, crashed: bool
+            );
+            var poll: (
+                reader: int, nextOffset: int,
+                emitted: int, lagged: bool
+            );
+
+            zone = 0;
+            while (zone < 3) {
+                buckets += (zone,
+                    new ZonalBucket((zone=zone, failures=0)));
+                zone = zone + 1;
+            }
+            segmentBuckets += (0, buckets);
+            manifest = new ManifestRegister((failures=0,));
+            new WriterProcess((
+                writerId=1, value=750,
+                buckets=buckets, segBase=0,
+                manifest=manifest, parent=this,
+                shouldSeal=false, recoverExisting=false,
+                crashBudget=0));
+            receive { case eWriterDone: (payload: (
+                writerId: int, committed: bool,
+                sealed: bool, crashed: bool
+            )) { stopped = payload; } }
+            assert stopped.committed && !stopped.sealed;
+
+            follower = new ReadonlyFollower((
+                reader=102, manifest=manifest,
+                segmentBuckets=segmentBuckets, nextOffset=0,
+                pauseAfterSnapshot=false, parent=this));
+            send follower, eReadonlyPoll;
+            receive { case eReadonlyPollDone: (payload: (
+                reader: int, nextOffset: int,
+                emitted: int, lagged: bool
+            )) { poll = payload; } }
+            assert poll.nextOffset == 1 && poll.emitted == 1 &&
+                !poll.lagged,
+                "readonly follower did not read the quorum-visible active tail";
+
+            // A later recovery must retain and seal the majority-visible frame.
+            new WriterProcess((
+                writerId=2, value=-1,
+                buckets=buckets, segBase=0,
+                manifest=manifest, parent=this,
+                shouldSeal=true, recoverExisting=true,
+                crashBudget=0));
+            receive { case eWriterDone: (payload: (
+                writerId: int, committed: bool,
+                sealed: bool, crashed: bool
+            )) { stopped = payload; } }
+            assert stopped.sealed;
+        }
+    }
+}
+
+machine ReadonlyTruncationRaceDriver {
+    start state Init {
+        entry {
+            var segmentBuckets: seq[seq[ZonalBucket]];
+            var buckets: seq[ZonalBucket];
+            var manifest: ManifestRegister;
+            var follower: ReadonlyFollower;
+            var zone: int;
+            var stopped: (
+                writerId: int, committed: bool,
+                sealed: bool, crashed: bool
+            );
+            var poll: (
+                reader: int, nextOffset: int,
+                emitted: int, lagged: bool
+            );
+
+            zone = 0;
+            while (zone < 3) {
+                buckets += (zone,
+                    new ZonalBucket((zone=zone, failures=0)));
+                zone = zone + 1;
+            }
+            segmentBuckets += (0, buckets);
+            manifest = new ManifestRegister((failures=0,));
+
+            new DirectoryRotation((
+                writerId=1, base=0, value=800,
+                manifest=manifest, buckets=buckets, parent=this));
+            receive { case eWriterDone: (payload: (
+                writerId: int, committed: bool,
+                sealed: bool, crashed: bool
+            )) { stopped = payload; } }
+            assert stopped.committed;
+
+            follower = new ReadonlyFollower((
+                reader=101, manifest=manifest,
+                segmentBuckets=segmentBuckets, nextOffset=0,
+                pauseAfterSnapshot=true, parent=this));
+            send follower, eReadonlyPoll;
+            receive { case eReadonlySnapshotPaused: {} }
+
+            // The follower holds a valid old snapshot while truncation raises
+            // the floor and deletes every copy. Its stale object read fails;
+            // the next poll must refresh and report lag, never skip to one.
+            new DirectoryCleanupCoordinator((
+                buckets=buckets, manifest=manifest,
+                directoryEntry=(base=0, id=1),
+                floor=1, raiseFloor=true, parent=this));
+            receive { case eTruncationDone: {} }
+            send follower, eReadonlyContinue;
+            receive { case eReadonlyPollDone: (payload: (
+                reader: int, nextOffset: int,
+                emitted: int, lagged: bool
+            )) { poll = payload; } }
+            assert poll.nextOffset == 0 && poll.emitted == 0 &&
+                !poll.lagged;
+
+            send follower, eReadonlyPoll;
+            receive { case eReadonlyPollDone: (payload: (
+                reader: int, nextOffset: int,
+                emitted: int, lagged: bool
+            )) { poll = payload; } }
+            assert poll.nextOffset == 0 && poll.emitted == 0 &&
+                poll.lagged,
+                "readonly follower skipped an overtaking truncation floor";
+        }
+    }
+}

--- a/p/model/ReadonlyFollower.p
+++ b/p/model/ReadonlyFollower.p
@@ -435,6 +435,7 @@ machine ReadonlyActiveTailDriver {
                 reader: int, nextOffset: int,
                 emitted: int, lagged: bool
             );
+            var attempts: int;
 
             zone = 0;
             while (zone < 3) {
@@ -494,6 +495,27 @@ machine ReadonlyActiveTailDriver {
                 sealed: bool, crashed: bool
             )) { stopped = payload; } }
             assert stopped.sealed;
+
+            // The sealed segment now holds a record the original writer never
+            // acknowledged. A follower replaying it from the start must emit
+            // that record from the sealed path.
+            follower = new ReadonlyFollower((
+                reader=103, manifest=manifest,
+                segmentBuckets=segmentBuckets, nextOffset=0,
+                pauseAfterSnapshot=false, parent=this));
+            attempts = 0;
+            poll = (reader=0, nextOffset=-1, emitted=0, lagged=false);
+            while (attempts < 3 && poll.nextOffset != 1) {
+                send follower, eReadonlyPoll;
+                receive { case eReadonlyPollDone: (payload: (
+                    reader: int, nextOffset: int,
+                    emitted: int, lagged: bool
+                )) { poll = payload; } }
+                assert !poll.lagged;
+                attempts = attempts + 1;
+            }
+            assert poll.nextOffset == 1,
+                "readonly follower did not replay a recovery-retained sealed record";
         }
     }
 }

--- a/p/model/ReadonlyFollower.p
+++ b/p/model/ReadonlyFollower.p
@@ -24,9 +24,11 @@ machine ReadonlyFollower {
     // fall between manifest refreshes.
     var cached: tManifestRecord;
     var haveCached: bool;
-    // Consecutive polls served from `cached`. Manifest refresh is driven by a
-    // timer, so a snapshot cannot go unrefreshed forever; bounding the run
-    // keeps that finite here.
+    // Consecutive polls served from `cached`. The bound of two is a
+    // finite-model restriction, not a production refresh guarantee.
+    // Production can advance the cursor on many polls under one snapshot
+    // between timed refreshes or while unavailable manifest reads retry.
+    // Those longer cursor-advancing runs are excluded from this model.
     var stalePolls: int;
 
     start state Following {
@@ -353,6 +355,69 @@ machine ReadonlyFollowerDriver {
     }
 }
 
+event eReadonlyWriterReady: bool;
+
+// This writer executes the claim, create, and append protocol but pauses
+// before commit notification. The driver crashes it after follower emission.
+machine ReadonlyUncommittedWriter {
+    start state Run {
+        entry (config: (
+            manifest: ManifestRegister, buckets: seq[ZonalBucket], parent: machine
+        )) {
+            var response: tManifestReadResponse;
+            var candidate: tManifestRecord;
+            var record: tRecord;
+            var zone: int;
+            send config.manifest, eManifestRead, (caller=this,);
+            receive { case eManifestReadResponse: (r: tManifestReadResponse) {
+                response = r;
+            } }
+            assert response.status == STATUS_OK;
+            candidate = response.rec;
+            candidate.epoch = candidate.epoch + 1;
+            candidate.owner = 1;
+            send config.manifest, eManifestCas, (
+                caller=this, expMetagen=response.metagen, rec=candidate);
+            receive { case eManifestCasResponse: (r: tManifestCasResponse) {
+                assert r.status == STATUS_OK;
+            } }
+            announce eEpochClaimed, (epoch=candidate.epoch, writerId=1);
+            zone = 0;
+            while (zone < 2) {
+                send config.buckets[zone], eCreateSegment, (
+                    caller=this, writerId=1, epoch=candidate.epoch,
+                    segment=0, gen=candidate.tailGen);
+                receive { case eCreateResponse: (r: tCreateResponse) {
+                    assert r.status == STATUS_OK;
+                } }
+                zone = zone + 1;
+            }
+            announce eSegmentOpened, (
+                segment=0, writerId=1, epoch=candidate.epoch,
+                gen=candidate.tailGen);
+            send config.parent, eReadonlyWriterReady, false;
+            receive { case eReadonlyContinue: {} }
+            record = (offset=0, value=750, segment=0);
+            announce eRecordFormed, (writerId=1, record=record);
+            zone = 0;
+            while (zone < 2) {
+                send config.buckets[zone], eAppend, (
+                    caller=this, writerId=1, epoch=candidate.epoch,
+                    gen=candidate.tailGen, record=record);
+                receive { case eAppendResponse: (r: tAppendResponse) {
+                    assert r.status == STATUS_OK;
+                } }
+                zone = zone + 1;
+            }
+            send config.parent, eReadonlyWriterReady, true;
+            receive { case eCrash: {} }
+            send config.parent, eWriterDone, (
+                writerId=1, committed=false, sealed=false, crashed=true);
+            raise halt;
+        }
+    }
+}
+
 machine ReadonlyActiveTailDriver {
     start state Init {
         entry {
@@ -360,6 +425,7 @@ machine ReadonlyActiveTailDriver {
             var buckets: seq[ZonalBucket];
             var manifest: ManifestRegister;
             var follower: ReadonlyFollower;
+            var writer: ReadonlyUncommittedWriter;
             var zone: int;
             var stopped: (
                 writerId: int, committed: bool,
@@ -369,7 +435,6 @@ machine ReadonlyActiveTailDriver {
                 reader: int, nextOffset: int,
                 emitted: int, lagged: bool
             );
-            var attempts: int;
 
             zone = 0;
             while (zone < 3) {
@@ -379,22 +444,28 @@ machine ReadonlyActiveTailDriver {
             }
             segmentBuckets += (0, buckets);
             manifest = new ManifestRegister((failures=0,));
-            new WriterProcess((
-                writerId=1, value=750,
-                buckets=buckets, segBase=0,
-                manifest=manifest, parent=this,
-                shouldSeal=false, recoverExisting=false,
-                crashBudget=0));
-            receive { case eWriterDone: (payload: (
-                writerId: int, committed: bool,
-                sealed: bool, crashed: bool
-            )) { stopped = payload; } }
-            assert stopped.committed && !stopped.sealed;
+            writer = new ReadonlyUncommittedWriter((
+                manifest=manifest, buckets=buckets, parent=this));
+            receive { case eReadonlyWriterReady: (persisted: bool) {
+                assert !persisted;
+            } }
 
             follower = new ReadonlyFollower((
                 reader=102, manifest=manifest,
                 segmentBuckets=segmentBuckets, nextOffset=0,
                 pauseAfterSnapshot=false, parent=this));
+            // Cache the manifest before append. The next poll can emit the
+            // new record using this same snapshot through the stale branch.
+            send follower, eReadonlyPoll;
+            receive { case eReadonlyPollDone: (payload: (
+                reader: int, nextOffset: int,
+                emitted: int, lagged: bool
+            )) { poll = payload; } }
+            assert poll.nextOffset == 0 && poll.emitted == 0 && !poll.lagged;
+            send writer, eReadonlyContinue;
+            receive { case eReadonlyWriterReady: (persisted: bool) {
+                assert persisted;
+            } }
             send follower, eReadonlyPoll;
             receive { case eReadonlyPollDone: (payload: (
                 reader: int, nextOffset: int,
@@ -404,7 +475,14 @@ machine ReadonlyActiveTailDriver {
                 !poll.lagged,
                 "readonly follower did not read the quorum-visible active tail";
 
-            // A later recovery must retain and seal the majority-visible frame.
+            // The writer stops without eRecordCommitted. Recovery must retain
+            // the record already delivered from the two durable copies.
+            send writer, eCrash;
+            receive { case eWriterDone: (payload: (
+                writerId: int, committed: bool,
+                sealed: bool, crashed: bool
+            )) { stopped = payload; } }
+            assert stopped.crashed && !stopped.committed && !stopped.sealed;
             new WriterProcess((
                 writerId=2, value=-1,
                 buckets=buckets, segBase=0,

--- a/p/model/ReadonlyFollower.p
+++ b/p/model/ReadonlyFollower.p
@@ -1,9 +1,13 @@
 // Persistent readonly follower over the manifest-selected segment chain.
 //
 // The follower never claims an epoch and never sends a mutating storage
-// request. Each poll reads one linearizable manifest snapshot, detects an
+// request. A poll works from a linearizable manifest snapshot, detects an
 // overtaking truncation floor, reads finalized directory segments, then reads
-// the active tail without requiring finalization. Active records are emitted
+// the active tail without requiring finalization. Manifest refresh runs on its
+// own schedule, so a poll either re-reads the register or reuses the snapshot
+// an earlier poll read. Both are modeled. Every published field a poll consumes
+// only advances, so a reused snapshot delays what the poll observes and can
+// never expose a record the register had not published. Active records are emitted
 // only after identical bytes are visible on two zones. The active read returns
 // as soon as the first matching majority arrives; a slow third response is not
 // on the publication path. Polling the same machine again discovers later
@@ -16,6 +20,14 @@ machine ReadonlyFollower {
     var nextOffset: int;
     var pauseAfterSnapshot: bool;
     var paused: bool;
+    // Most recent manifest snapshot this follower read, reused by polls that
+    // fall between manifest refreshes.
+    var cached: tManifestRecord;
+    var haveCached: bool;
+    // Consecutive polls served from `cached`. Manifest refresh is driven by a
+    // timer, so a snapshot cannot go unrefreshed forever; bounding the run
+    // keeps that finite here.
+    var stalePolls: int;
 
     start state Following {
         entry (payload: (
@@ -48,13 +60,21 @@ machine ReadonlyFollower {
         var endOffset: int;
         var found: bool;
 
-        send manifest, eManifestRead, (caller=this,);
-        receive { case eManifestReadResponse: (r: tManifestReadResponse) {
-            readResponse = r;
-        } }
-        if (readResponse.status != STATUS_OK) {
-            Done(0, false);
-            return;
+        if (haveCached && stalePolls < 2 && $) {
+            readResponse = (status=STATUS_OK, metagen=0, rec=cached);
+            stalePolls = stalePolls + 1;
+        } else {
+            send manifest, eManifestRead, (caller=this,);
+            receive { case eManifestReadResponse: (r: tManifestReadResponse) {
+                readResponse = r;
+            } }
+            if (readResponse.status != STATUS_OK) {
+                Done(0, false);
+                return;
+            }
+            cached = readResponse.rec;
+            haveCached = true;
+            stalePolls = 0;
         }
         if (readResponse.rec.trunc > nextOffset) {
             announce eReadonlyLagged, (
@@ -137,7 +157,8 @@ machine ReadonlyFollower {
         zone = 0;
         while (zone < sizeof(segmentBuckets[directoryEntry.base])) {
             send segmentBuckets[directoryEntry.base][zone], eRead, (
-                caller=this, segment=directoryEntry.base, gen=-1);
+                caller=this, segment=directoryEntry.base, gen=-1,
+                readonly=true);
             zone = zone + 1;
         }
         replies = 0;
@@ -186,7 +207,8 @@ machine ReadonlyFollower {
         zone = 0;
         while (zone < sizeof(segmentBuckets[segmentBase])) {
             send segmentBuckets[segmentBase][zone], eRead, (
-                caller=this, segment=segmentBase, gen=segmentId);
+                caller=this, segment=segmentBase, gen=segmentId,
+                readonly=true);
             zone = zone + 1;
         }
         replies = 0;
@@ -251,6 +273,7 @@ machine ReadonlyFollowerDriver {
                 reader: int, nextOffset: int,
                 emitted: int, lagged: bool
             );
+            var attempts: int;
 
             base = 0;
             while (base < 2) {
@@ -308,13 +331,21 @@ machine ReadonlyFollowerDriver {
                     writerId = writerId + 1;
                 }
 
-                send follower, eReadonlyPoll;
-                receive { case eReadonlyPollDone: (payload: (
-                    reader: int, nextOffset: int,
-                    emitted: int, lagged: bool
-                )) { poll = payload; } }
-                assert poll.nextOffset == base + 1 &&
-                    poll.emitted == 1 && !poll.lagged,
+                // A poll served from an unrefreshed snapshot emits nothing.
+                // Refresh is bounded, so polling again discovers the seal.
+                attempts = 0;
+                poll = (reader=0, nextOffset=-1, emitted=0, lagged=false);
+                while (attempts < 3 && poll.nextOffset != base + 1) {
+                    send follower, eReadonlyPoll;
+                    receive { case eReadonlyPollDone: (payload: (
+                        reader: int, nextOffset: int,
+                        emitted: int, lagged: bool
+                    )) { poll = payload; } }
+                    assert !poll.lagged,
+                        "readonly follower lagged while discovering a seal";
+                    attempts = attempts + 1;
+                }
+                assert poll.nextOffset == base + 1,
                     "readonly follower did not discover the next seal";
                 base = base + 1;
             }
@@ -338,6 +369,7 @@ machine ReadonlyActiveTailDriver {
                 reader: int, nextOffset: int,
                 emitted: int, lagged: bool
             );
+            var attempts: int;
 
             zone = 0;
             while (zone < 3) {
@@ -404,6 +436,7 @@ machine ReadonlyTruncationRaceDriver {
                 reader: int, nextOffset: int,
                 emitted: int, lagged: bool
             );
+            var attempts: int;
 
             zone = 0;
             while (zone < 3) {
@@ -446,13 +479,21 @@ machine ReadonlyTruncationRaceDriver {
             assert poll.nextOffset == 0 && poll.emitted == 0 &&
                 !poll.lagged;
 
-            send follower, eReadonlyPoll;
-            receive { case eReadonlyPollDone: (payload: (
-                reader: int, nextOffset: int,
-                emitted: int, lagged: bool
-            )) { poll = payload; } }
-            assert poll.nextOffset == 0 && poll.emitted == 0 &&
-                poll.lagged,
+            // A poll served from an unrefreshed snapshot has not seen the
+            // raised floor yet. That is safe as long as it publishes nothing;
+            // refresh is bounded, so a later poll reports the lag.
+            attempts = 0;
+            while (attempts < 3 && !poll.lagged) {
+                send follower, eReadonlyPoll;
+                receive { case eReadonlyPollDone: (payload: (
+                    reader: int, nextOffset: int,
+                    emitted: int, lagged: bool
+                )) { poll = payload; } }
+                assert poll.nextOffset == 0 && poll.emitted == 0,
+                    "readonly follower advanced past an overtaking truncation floor";
+                attempts = attempts + 1;
+            }
+            assert poll.lagged,
                 "readonly follower skipped an overtaking truncation floor";
         }
     }

--- a/p/model/Tests.p
+++ b/p/model/Tests.p
@@ -117,3 +117,27 @@ test tcPendingSegmentRotation [main=PendingSegmentRotationDriver]:
     (union { PendingSegmentWriter }, { PendingChainRecovery },
         { ZonalBucket }, { ManifestRegister },
         { PendingSegmentRotationDriver });
+
+test tcReadonlyFollower [main=ReadonlyFollowerDriver]:
+    assert QuorumLinearizability, SingleWriterPerSegment,
+        SealAndPrefixSafety, ManifestSafety, RotationGateSafety,
+        DirectoryStructure, DirectoryEnforcement,
+        ReadonlyFollowerSafety in
+    (union { ReadonlyFollower }, { DirectoryRotation }, { WriterProcess },
+        { ZonalBucket }, { ManifestRegister }, { ReadonlyFollowerDriver });
+
+test tcReadonlyActiveTail [main=ReadonlyActiveTailDriver]:
+    assert QuorumLinearizability, SingleWriterPerSegment,
+        SealAndPrefixSafety, ManifestSafety,
+        ReadonlyFollowerSafety in
+    (union { ReadonlyFollower }, { WriterProcess },
+        { ZonalBucket }, { ManifestRegister },
+        { ReadonlyActiveTailDriver });
+
+test tcReadonlyTruncationRace [main=ReadonlyTruncationRaceDriver]:
+    assert QuorumLinearizability, SingleWriterPerSegment,
+        SealAndPrefixSafety, ManifestSafety,
+        ReadonlyFollowerSafety in
+    (union { ReadonlyFollower }, { DirectoryRotation },
+        { DirectoryCleanupCoordinator }, { ZonalBucket },
+        { ManifestRegister }, { ReadonlyTruncationRaceDriver });

--- a/p/model/Tests.p
+++ b/p/model/Tests.p
@@ -130,7 +130,7 @@ test tcReadonlyActiveTail [main=ReadonlyActiveTailDriver]:
     assert QuorumLinearizability, SingleWriterPerSegment,
         SealAndPrefixSafety, ManifestSafety,
         ReadonlyFollowerSafety in
-    (union { ReadonlyFollower }, { WriterProcess },
+    (union { ReadonlyFollower }, { ReadonlyUncommittedWriter }, { WriterProcess },
         { ZonalBucket }, { ManifestRegister },
         { ReadonlyActiveTailDriver });
 

--- a/p/model/Types.p
+++ b/p/model/Types.p
@@ -273,6 +273,35 @@ event eSegmentDeleted: (
 event eReplayOpened: (reader: int, startOffset: int, endOffset: int);
 event eReplayRecord: (reader: int, offset: int);
 event eReplayClosed: int;
+event eReadonlyOpened: (reader: int, nextOffset: int);
+event eReadonlySnapshot: (
+    reader: int,
+    nextOffset: int,
+    trunc: int,
+    publishedEnd: int,
+    segmentBase: int,
+    segmentId: int,
+    segmentEnd: int
+);
+event eReadonlyActiveSnapshot: (
+    reader: int,
+    nextOffset: int,
+    trunc: int,
+    segmentBase: int,
+    segmentId: int
+);
+event eReadonlyRecord: (
+    reader: int,
+    record: tRecord,
+    segmentId: int
+);
+event eReadonlyLagged: (reader: int, nextOffset: int, trunc: int);
+event eReadonlyPoll;
+event eReadonlyPollDone: (
+    reader: int, nextOffset: int, emitted: int, lagged: bool
+);
+event eReadonlySnapshotPaused;
+event eReadonlyContinue;
 event eGetSizeObserved: (zone: int, size: int, finalized: bool);
 event eReplayDone;
 event eProgressRequested: int;

--- a/p/model/Types.p
+++ b/p/model/Types.p
@@ -31,7 +31,10 @@ type tTakeoverRequest = (
 type tTakeoverResponse = (
     zone: int, status: tStatus, persistedSize: int
 );
-type tReadRequest = (caller: machine, segment: int, gen: int);
+// `readonly` marks a read issued by a non-coordinating follower. Directory
+// trust invariants constrain what a recovering writer may re-read after
+// adopting an entry unread; a follower's reads are outside that boundary.
+type tReadRequest = (caller: machine, segment: int, gen: int, readonly: bool);
 type tReadResponse = (
     zone: int,
     status: tStatus,

--- a/p/model/WriterProcess.p
+++ b/p/model/WriterProcess.p
@@ -97,6 +97,9 @@ machine WriterProcess {
                         // the register before declaring the tail empty
                         if (MaybeCrash()) { return; }
                         if (CommitRetire()) {
+                            announce eRecoveryCompleted, (
+                                writerId=writerId, segment=segBase,
+                                startOffset=segBase, endOffset=segBase);
                             announce eProgressCompleted, writerId;
                         }
                     }
@@ -143,6 +146,9 @@ machine WriterProcess {
                     // can see
                     if (MaybeCrash()) { return; }
                     if (CommitRetire()) {
+                        announce eRecoveryCompleted, (
+                            writerId=writerId, segment=segBase,
+                            startOffset=segBase, endOffset=segBase);
                         if (MaybeCrash()) { return; }
                         DiscardWitnesses();
                         announce eProgressCompleted, writerId;

--- a/p/model/WriterProcess.p
+++ b/p/model/WriterProcess.p
@@ -500,7 +500,7 @@ machine WriterProcess {
         zone = 0;
         while (zone < sizeof(buckets)) {
             send buckets[zone], eRead, (
-                caller=this, segment=segBase, gen=gen);
+                caller=this, segment=segBase, gen=gen, readonly=false);
             zone = zone + 1;
         }
         replies = 0;
@@ -569,7 +569,7 @@ machine WriterProcess {
         var response: tReadResponse;
         foreach (zone in lanes) {
             send buckets[zone], eRead, (
-                caller=this, segment=segBase, gen=gen);
+                caller=this, segment=segBase, gen=gen, readonly=false);
         }
         replies = 0;
         while (replies < sizeof(lanes)) {
@@ -907,7 +907,7 @@ machine PendingChainRecovery {
         // prior acknowledged record among the reachable reads.
         foreach (zone in prepared) {
             send segmentBuckets[id][zone], eRead, (
-                caller=this, segment=base, gen=id);
+                caller=this, segment=base, gen=id, readonly=false);
         }
         replies = 0;
         found = false;

--- a/p/proof/QuorumProof.p
+++ b/p/proof/QuorumProof.p
@@ -4,6 +4,7 @@ event eMaintenanceStep;
 event eRecordStep;
 event eManifestStep;
 event eRotationGateStep;
+event eReadonlyStep;
 
 machine SegmentChainProofModel {
     var creator0: int;
@@ -25,7 +26,8 @@ machine SegmentChainProofModel {
     start state Running {
         entry { send this, eChainStep; }
         on eChainStep do ChooseOperation;
-        ignore eRecoveryStep, eMaintenanceStep, eRecordStep, eManifestStep;
+        ignore eRecoveryStep, eMaintenanceStep, eRecordStep, eManifestStep,
+            eRotationGateStep, eReadonlyStep;
     }
 
     fun ChooseOperation() {
@@ -103,7 +105,8 @@ machine RecoveryProofModel {
     start state Running {
         entry { send this, eRecoveryStep; }
         on eRecoveryStep do ChooseOperation;
-        ignore eChainStep, eMaintenanceStep, eRecordStep, eManifestStep;
+        ignore eChainStep, eMaintenanceStep, eRecordStep, eManifestStep,
+            eRotationGateStep, eReadonlyStep;
     }
 
     fun ChooseOperation() {
@@ -156,7 +159,8 @@ machine SealedMaintenanceProofModel {
     start state Running {
         entry { send this, eMaintenanceStep; }
         on eMaintenanceStep do ChooseOperation;
-        ignore eChainStep, eRecoveryStep, eRecordStep, eManifestStep;
+        ignore eChainStep, eRecoveryStep, eRecordStep, eManifestStep,
+            eRotationGateStep, eReadonlyStep;
     }
 
     fun ChooseOperation() {
@@ -202,7 +206,8 @@ machine RecordStartupReplayTruncationProofModel {
     start state Running {
         entry { send this, eRecordStep; }
         on eRecordStep do ChooseOperation;
-        ignore eChainStep, eRecoveryStep, eMaintenanceStep, eManifestStep;
+        ignore eChainStep, eRecoveryStep, eMaintenanceStep, eManifestStep,
+            eRotationGateStep, eReadonlyStep;
     }
 
     fun ChooseOperation() {
@@ -282,7 +287,8 @@ machine ManifestProofModel {
     start state Running {
         entry { send this, eManifestStep; }
         on eManifestStep do ChooseOperation;
-        ignore eChainStep, eRecoveryStep, eMaintenanceStep, eRecordStep;
+        ignore eChainStep, eRecoveryStep, eMaintenanceStep, eRecordStep,
+            eRotationGateStep, eReadonlyStep;
     }
 
     fun ChooseOperation() {
@@ -356,7 +362,7 @@ machine RotationGateProofModel {
         entry { send this, eRotationGateStep; }
         on eRotationGateStep do ChooseOperation;
         ignore eChainStep, eRecoveryStep, eMaintenanceStep, eRecordStep,
-            eManifestStep;
+            eManifestStep, eReadonlyStep;
     }
 
     fun ChooseOperation() {
@@ -376,6 +382,109 @@ machine RotationGateProofModel {
             }
         }
         send this, eRotationGateStep;
+    }
+}
+
+// Reduced readonly follower. Each zone grows an immutable byte/record prefix;
+// quorumEnd is the largest prefix visible on at least two zones. Publishing
+// moves a subset of that prefix into the sealed directory, while the follower
+// may also load directly below quorumEnd from the active tail. Since zone
+// prefixes and quorumEnd only grow, any emitted active record remains in every
+// later recovery quorum intersection. The readonly role has no transition that
+// writes the manifest or claims an epoch.
+machine ReadonlyFollowerProofModel {
+    var durable0: int;
+    var durable1: int;
+    var durable2: int;
+    var quorumEnd: int;
+    var publishedEnd: int;
+    var floor: int;
+    var next: int;
+    var snapshotEnd: int;
+    var snapshotFloor: int;
+    var loaded: bool;
+    var loadedActive: bool;
+    var loadedOffset: int;
+    var emitted: int;
+    var lagged: bool;
+    var manifestWrites: int;
+    var epochClaims: int;
+
+    start state Running {
+        entry { send this, eReadonlyStep; }
+        on eReadonlyStep do ChooseOperation;
+        ignore eChainStep, eRecoveryStep, eMaintenanceStep, eRecordStep,
+            eManifestStep, eRotationGateStep;
+    }
+
+    fun ChooseOperation() {
+        if ($) {
+            if (durable0 < 3) {
+                durable0 = durable0 + 1;
+                RefreshQuorumEnd();
+            }
+        } else if ($) {
+            if (durable1 < 3) {
+                durable1 = durable1 + 1;
+                RefreshQuorumEnd();
+            }
+        } else if ($) {
+            if (durable2 < 3) {
+                durable2 = durable2 + 1;
+                RefreshQuorumEnd();
+            }
+        } else if ($) {
+            if (publishedEnd < quorumEnd) {
+                publishedEnd = publishedEnd + 1;
+            }
+        } else if ($) {
+            if (!loaded) {
+                snapshotEnd = publishedEnd;
+                snapshotFloor = floor;
+            }
+        } else if ($) {
+            if (floor < publishedEnd) {
+                floor = floor + 1;
+            }
+        } else if ($) {
+            if (!lagged && !loaded &&
+                snapshotFloor <= next && next < snapshotEnd) {
+                loaded = true;
+                loadedActive = false;
+                loadedOffset = next;
+            }
+        } else if ($) {
+            if (!lagged && !loaded &&
+                snapshotFloor <= next && next >= snapshotEnd &&
+                next < quorumEnd) {
+                loaded = true;
+                loadedActive = true;
+                loadedOffset = next;
+            }
+        } else if ($) {
+            if (!lagged && !loaded && floor > next) {
+                lagged = true;
+            }
+        } else {
+            if (!lagged && loaded) {
+                next = next + 1;
+                emitted = emitted + 1;
+                loaded = false;
+                loadedActive = false;
+            }
+        }
+        send this, eReadonlyStep;
+    }
+
+    fun RefreshQuorumEnd() {
+        var candidate: int;
+        var support: int;
+        candidate = quorumEnd + 1;
+        support = 0;
+        if (durable0 >= candidate) { support = support + 1; }
+        if (durable1 >= candidate) { support = support + 1; }
+        if (durable2 >= candidate) { support = support + 1; }
+        if (support >= 2) { quorumEnd = candidate; }
     }
 }
 
@@ -411,6 +520,15 @@ init-condition forall (m: ManifestProofModel) ::
 
 init-condition forall (g: RotationGateProofModel) ::
     g.currentSeal == 0 && g.finalizedQuorum == 0 && g.nextSeal == 0;
+
+init-condition forall (r: ReadonlyFollowerProofModel) ::
+    r.durable0 == 0 && r.durable1 == 0 && r.durable2 == 0 &&
+    r.quorumEnd == 0 && r.publishedEnd == 0 &&
+    r.floor == 0 && r.next == 0 &&
+    r.snapshotEnd == 0 && r.snapshotFloor == 0 &&
+    !r.loaded && !r.loadedActive &&
+    r.loadedOffset == 0 && r.emitted == 0 &&
+    !r.lagged && r.manifestWrites == 0 && r.epochClaims == 0;
 
 Lemma reduced_quorum_wal_inductive {
     invariant at_most_one_creator_quorum:
@@ -580,6 +698,64 @@ Lemma reduced_quorum_wal_inductive {
 
     invariant manifest_delete_after_committed_floor:
         forall (m: ManifestProofModel) :: m.deleted ==> m.floor != 0;
+
+    // ---- readonly follower ----
+
+    invariant readonly_cursor_is_exact_emitted_prefix:
+        forall (r: ReadonlyFollowerProofModel) ::
+            r.next == r.emitted &&
+            r.next >= 0 && r.next <= r.quorumEnd;
+
+    invariant readonly_quorum_end_has_majority_support:
+        forall (r: ReadonlyFollowerProofModel) ::
+            r.quorumEnd >= 0 && r.quorumEnd <= 3 &&
+            ((r.durable0 >= r.quorumEnd &&
+              r.durable1 >= r.quorumEnd) ||
+             (r.durable0 >= r.quorumEnd &&
+              r.durable2 >= r.quorumEnd) ||
+             (r.durable1 >= r.quorumEnd &&
+              r.durable2 >= r.quorumEnd));
+
+    invariant readonly_durable_prefixes_are_bounded:
+        forall (r: ReadonlyFollowerProofModel) ::
+            r.durable0 >= 0 && r.durable0 <= 3 &&
+            r.durable1 >= 0 && r.durable1 <= 3 &&
+            r.durable2 >= 0 && r.durable2 <= 3;
+
+    invariant readonly_floor_is_published:
+        forall (r: ReadonlyFollowerProofModel) ::
+            r.floor >= 0 && r.floor <= r.publishedEnd;
+
+    invariant readonly_publication_is_quorum_visible:
+        forall (r: ReadonlyFollowerProofModel) ::
+            r.publishedEnd >= 0 &&
+            r.publishedEnd <= r.quorumEnd;
+
+    invariant readonly_snapshot_is_a_published_prefix:
+        forall (r: ReadonlyFollowerProofModel) ::
+            r.snapshotFloor >= 0 &&
+            r.snapshotFloor <= r.snapshotEnd &&
+            r.snapshotEnd <= r.publishedEnd;
+
+    invariant readonly_load_is_snapshot_bound:
+        forall (r: ReadonlyFollowerProofModel) :: r.loaded ==>
+            !r.lagged &&
+            r.loadedOffset == r.next &&
+            r.snapshotFloor <= r.loadedOffset &&
+            ((r.loadedActive &&
+              r.snapshotEnd <= r.loadedOffset &&
+              r.loadedOffset < r.quorumEnd) ||
+             (!r.loadedActive &&
+              r.loadedOffset < r.snapshotEnd &&
+              r.snapshotEnd <= r.publishedEnd));
+
+    invariant readonly_lag_is_overtaking_floor:
+        forall (r: ReadonlyFollowerProofModel) :: r.lagged ==>
+            !r.loaded && r.floor > r.next;
+
+    invariant readonly_never_coordinates_with_writer:
+        forall (r: ReadonlyFollowerProofModel) ::
+            r.manifestWrites == 0 && r.epochClaims == 0;
 }
 
 Proof {

--- a/rust/bin/chorus-cli/README.md
+++ b/rust/bin/chorus-cli/README.md
@@ -131,3 +131,24 @@ runtime, DNS, TLS, or provider caches.
 Set `--target-sealed-segments 0` to keep one large active segment.
 `--replay-records 0` measures no replay; a value at or above
 `--populate-records` replays the full log.
+
+`benchmark readonly` runs a writer and an independent readonly client against
+the same prefix while keeping the workload in one active appendable segment.
+It reports writer throughput, subscriber catch-up throughput, and per-record
+commit-to-subscribe latency through quorum `BidiReadObject` polls:
+
+```sh
+cargo run --release -p chorus-cli --bin chorus -- \
+  --endpoints https://storage.googleapis.com,https://storage.googleapis.com,https://storage.googleapis.com \
+  --buckets projects/_/buckets/zone-a,projects/_/buckets/zone-b,projects/_/buckets/zone-c \
+  --manifest-endpoint https://storage.googleapis.com \
+  --manifest-bucket projects/_/buckets/regional-control \
+  --prefix benchmarks/readonly-001 \
+  benchmark readonly \
+  --records 4096 \
+  --poll-interval-ms 100 \
+  --payload-bytes 4096
+```
+
+The prefix must be unused. The benchmark fails if the workload rotates, ensuring
+the reported latency is active-tail delivery rather than sealed-segment replay.

--- a/rust/bin/chorus-cli/README.md
+++ b/rust/bin/chorus-cli/README.md
@@ -153,8 +153,6 @@ cargo run --release -p chorus-cli --bin chorus -- \
 The prefix must be unused. The benchmark fails if the workload rotates, ensuring
 the reported latency is active-tail delivery rather than sealed-segment replay.
 
-`--poll-interval-ms` applies only after a read that delivered no records.
-`--manifest-poll-interval-ms` paces manifest re-reads separately. Pass
-`--fixed-poll-cadence` to sleep the poll interval between every read, including
-reads that delivered records, which is the comparison point for how much of the
-measured latency the poll interval contributes.
+`--poll-interval-ms` applies only after a read that delivered no records; a
+read that delivered is followed immediately by the next one.
+`--manifest-poll-interval-ms` paces manifest re-reads separately.

--- a/rust/bin/chorus-cli/README.md
+++ b/rust/bin/chorus-cli/README.md
@@ -152,3 +152,9 @@ cargo run --release -p chorus-cli --bin chorus -- \
 
 The prefix must be unused. The benchmark fails if the workload rotates, ensuring
 the reported latency is active-tail delivery rather than sealed-segment replay.
+
+`--poll-interval-ms` applies only after a read that delivered no records.
+`--manifest-poll-interval-ms` paces manifest re-reads separately. Pass
+`--fixed-poll-cadence` to sleep the poll interval between every read, including
+reads that delivered records, which is the comparison point for how much of the
+measured latency the poll interval contributes.

--- a/rust/bin/chorus-cli/src/benchmark/mod.rs
+++ b/rust/bin/chorus-cli/src/benchmark/mod.rs
@@ -5,11 +5,13 @@ use std::sync::{Arc, Mutex};
 use chorus_client::{CounterFn, GaugeFn, HistogramFn, MetricsRecorder, UpDownCounterFn};
 
 pub(crate) mod append;
+pub(crate) mod readonly;
 pub(crate) mod recovery;
 
 #[derive(Default)]
 pub(crate) struct BenchMetrics {
     counters: Mutex<HashMap<String, Arc<AtomicU64>>>,
+    histogram_samples: Mutex<HashMap<String, Arc<AtomicU64>>>,
 }
 
 impl BenchMetrics {
@@ -21,13 +23,31 @@ impl BenchMetrics {
             .map(|counter| counter.load(Ordering::Relaxed))
             .unwrap_or(0)
     }
+
+    /// Number of values recorded into `name`.
+    pub(crate) fn histogram_samples(&self, name: &str) -> u64 {
+        self.histogram_samples
+            .lock()
+            .unwrap()
+            .get(name)
+            .map(|samples| samples.load(Ordering::Relaxed))
+            .unwrap_or(0)
+    }
+
+    /// Segments sealed so far. Every rotation seals the segment it rotates
+    /// away from, so a non-zero count means the active segment moved.
+    pub(crate) fn seal_count(&self) -> u64 {
+        self.histogram_samples("chorus.wal.seal.duration_seconds")
+    }
 }
 
-struct BenchCounter(Arc<AtomicU64>);
+struct BenchCounter {
+    counter: Arc<AtomicU64>,
+}
 
 impl CounterFn for BenchCounter {
     fn increment(&self, value: u64) {
-        self.0.fetch_add(value, Ordering::Relaxed);
+        self.counter.fetch_add(value, Ordering::SeqCst);
     }
 }
 
@@ -45,6 +65,16 @@ impl HistogramFn for NoopMetric {
     fn record(&self, _value: f64) {}
 }
 
+struct BenchHistogram {
+    samples: Arc<AtomicU64>,
+}
+
+impl HistogramFn for BenchHistogram {
+    fn record(&self, _value: f64) {
+        self.samples.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
 impl MetricsRecorder for BenchMetrics {
     fn register_counter(
         &self,
@@ -59,7 +89,7 @@ impl MetricsRecorder for BenchMetrics {
             .entry(name.to_string())
             .or_default()
             .clone();
-        Arc::new(BenchCounter(metric))
+        Arc::new(BenchCounter { counter: metric })
     }
 
     fn register_gauge(
@@ -82,11 +112,36 @@ impl MetricsRecorder for BenchMetrics {
 
     fn register_histogram(
         &self,
-        _name: &str,
+        name: &str,
         _description: &str,
         _labels: &[(&str, &str)],
         _boundaries: &[f64],
     ) -> Arc<dyn HistogramFn> {
-        Arc::new(NoopMetric)
+        let samples = self
+            .histogram_samples
+            .lock()
+            .unwrap()
+            .entry(name.to_string())
+            .or_default()
+            .clone();
+        Arc::new(BenchHistogram { samples })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn benchmark_metrics_count_seals() {
+        let metrics = BenchMetrics::default();
+        let seals =
+            metrics.register_histogram("chorus.wal.seal.duration_seconds", "test", &[], &[]);
+
+        assert_eq!(metrics.seal_count(), 0);
+        seals.record(0.5);
+        seals.record(1.5);
+
+        assert_eq!(metrics.seal_count(), 2);
     }
 }

--- a/rust/bin/chorus-cli/src/benchmark/readonly.rs
+++ b/rust/bin/chorus-cli/src/benchmark/readonly.rs
@@ -30,6 +30,8 @@ pub(crate) struct ReadOnlyArgs {
     records: usize,
     #[arg(long, default_value_t = 4096)]
     payload_bytes: usize,
+    /// Records the writer keeps in flight before awaiting a completion. The
+    /// engine's byte-bounded window and queue are sized from this.
     #[arg(long, default_value_t = 64)]
     pipeline_window: usize,
     /// Delay before the next active-tail read when the previous one delivered
@@ -207,19 +209,30 @@ pub(crate) async fn run(
     }
     while recovery.try_next().await?.is_some() {}
 
-    let active_segment_bytes = (args.payload_bytes + 4)
+    let encoded_record_bytes = args.payload_bytes + 4;
+    let active_segment_bytes = encoded_record_bytes
         .checked_mul(args.records)
         .and_then(|bytes| bytes.checked_mul(2))
         .context("readonly benchmark active segment size overflowed usize")?;
+    // `--pipeline-window` counts records this benchmark keeps in flight on the
+    // client side. The engine bounds admission by encoded bytes, so its window
+    // must admit at least that many encoded records, and its queue keeps the
+    // same eight-window headroom the record-count configuration had.
+    let pipeline_window_bytes = encoded_record_bytes
+        .checked_mul(args.pipeline_window)
+        .context("readonly benchmark pipeline window overflowed usize")?;
+    let queue_capacity_bytes = pipeline_window_bytes
+        .checked_mul(8)
+        .context("readonly benchmark queue capacity overflowed usize")?;
     let mut writer = recovery
         .start(WalEngineConfig {
-            queue_capacity: args.pipeline_window.saturating_mul(8),
+            queue_capacity_bytes,
             // The workload appends one fixed payload size. Raising this to the
             // library default would force `max_active_segment_bytes` to cover a
             // maximum-size record the benchmark never writes, which rejects
             // every small configuration.
             max_record_bytes: args.payload_bytes,
-            pipeline_window_records: args.pipeline_window,
+            pipeline_window_bytes,
             max_inflight_bytes: WalEngineConfig::default().max_inflight_bytes,
             max_replica_lag_bytes: WalEngineConfig::default().max_replica_lag_bytes,
             lane_stall_timeout: WalEngineConfig::default().lane_stall_timeout,
@@ -302,6 +315,8 @@ pub(crate) async fn run(
             "records": args.records,
             "payload_bytes": args.payload_bytes,
             "pipeline_window": args.pipeline_window,
+            "pipeline_window_bytes": pipeline_window_bytes,
+            "queue_capacity_bytes": queue_capacity_bytes,
             "active_segment_bytes": active_segment_bytes,
             "poll_interval_ms": args.poll_interval_ms,
             "manifest_poll_interval_ms": args.manifest_poll_interval_ms,

--- a/rust/bin/chorus-cli/src/benchmark/readonly.rs
+++ b/rust/bin/chorus-cli/src/benchmark/readonly.rs
@@ -41,10 +41,6 @@ pub(crate) struct ReadOnlyArgs {
     /// Delay between readonly manifest re-reads.
     #[arg(long, default_value_t = 1000)]
     manifest_poll_interval_ms: u64,
-    /// Poll on a fixed cadence even while records are being delivered, instead
-    /// of reading again immediately after a read that produced records.
-    #[arg(long, default_value_t = false)]
-    fixed_poll_cadence: bool,
     /// Maximum wait for writer completion and follower catch-up.
     #[arg(long, default_value_t = 180)]
     timeout_seconds: u64,
@@ -249,7 +245,6 @@ pub(crate) async fn run(
             ReadOnlyConfig {
                 poll_interval: Duration::from_millis(args.poll_interval_ms),
                 manifest_poll_interval: Duration::from_millis(args.manifest_poll_interval_ms),
-                continuous_when_active: !args.fixed_poll_cadence,
             },
         )
         .await?;
@@ -320,7 +315,6 @@ pub(crate) async fn run(
             "active_segment_bytes": active_segment_bytes,
             "poll_interval_ms": args.poll_interval_ms,
             "manifest_poll_interval_ms": args.manifest_poll_interval_ms,
-            "continuous_when_active": !args.fixed_poll_cadence,
             "worker_threads": args.worker_threads,
         }
     });

--- a/rust/bin/chorus-cli/src/benchmark/readonly.rs
+++ b/rust/bin/chorus-cli/src/benchmark/readonly.rs
@@ -1,0 +1,310 @@
+//! Live writer-plus-readonly-follower benchmark.
+//!
+//! The workload remains in one appendable segment. Each writer completion is
+//! timestamped, and the independent follower consumes the same record through
+//! quorum bidirectional reads. The latency histogram therefore measures
+//! commit completion to subscriber delivery without segment-rotation delay.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use anyhow::{bail, Context, Result};
+use bytes::Bytes;
+use chorus_client::{
+    ClientConfig, MetricsRecorder, ReadOnlyConfig, ReadOnlyFollower, SegmentedVolume,
+    WalEngineConfig, WalHandle, WalSeqNo,
+};
+use futures::stream::FuturesUnordered;
+use futures::{StreamExt, TryStreamExt};
+use hdrhistogram::Histogram;
+use tokio::sync::Notify;
+
+use super::BenchMetrics;
+use crate::ConnectedStorage;
+
+#[derive(clap::Args, Debug)]
+pub(crate) struct ReadOnlyArgs {
+    /// Number of records to append and deliver through the active segment.
+    #[arg(long, default_value_t = 4096)]
+    records: usize,
+    #[arg(long, default_value_t = 4096)]
+    payload_bytes: usize,
+    #[arg(long, default_value_t = 64)]
+    pipeline_window: usize,
+    /// Delay between readonly active-tail polls.
+    #[arg(long, default_value_t = 100)]
+    poll_interval_ms: u64,
+    /// Maximum wait for writer completion and follower catch-up.
+    #[arg(long, default_value_t = 180)]
+    timeout_seconds: u64,
+    #[arg(long, default_value_t = 4)]
+    worker_threads: usize,
+}
+
+impl ReadOnlyArgs {
+    pub(crate) fn worker_threads(&self) -> usize {
+        self.worker_threads
+    }
+
+    pub(crate) fn validate(&self) -> Result<()> {
+        if self.records == 0
+            || self.payload_bytes == 0
+            || self.pipeline_window == 0
+            || self.poll_interval_ms == 0
+            || self.timeout_seconds == 0
+            || self.worker_threads == 0
+        {
+            bail!("all readonly benchmark counts and intervals must be positive");
+        }
+        self.payload_bytes
+            .checked_add(4)
+            .and_then(|encoded| encoded.checked_mul(self.records))
+            .and_then(|bytes| bytes.checked_mul(2))
+            .context("readonly benchmark active segment size overflowed usize")?;
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct CommitTimeline {
+    committed_at: Mutex<HashMap<u64, Instant>>,
+    notify: Notify,
+}
+
+impl CommitTimeline {
+    fn publish(&self, record_index: u64, at: Instant) {
+        self.committed_at.lock().unwrap().insert(record_index, at);
+        self.notify.notify_waiters();
+    }
+
+    async fn take(&self, record_index: u64) -> Instant {
+        loop {
+            let notified = self.notify.notified();
+            if let Some(at) = self.committed_at.lock().unwrap().remove(&record_index) {
+                return at;
+            }
+            notified.await;
+        }
+    }
+}
+
+struct SubscriberStats {
+    records: u64,
+    commit_to_subscribe: Histogram<u64>,
+}
+
+impl SubscriberStats {
+    fn new() -> Result<Self> {
+        Ok(Self {
+            records: 0,
+            commit_to_subscribe: Histogram::new_with_bounds(1, 600_000_000, 3)?,
+        })
+    }
+}
+
+async fn append_records(
+    handle: &mut WalHandle,
+    count: u64,
+    payload: &Bytes,
+    window: usize,
+    commits: &CommitTimeline,
+) -> Result<()> {
+    let mut next = 0u64;
+    let mut inflight = FuturesUnordered::new();
+    while inflight.len() < window && next < count {
+        inflight.push(
+            handle
+                .enqueue_append(WalSeqNo::record(next), payload.clone())
+                .await?,
+        );
+        next += 1;
+    }
+    while let Some(result) = inflight.next().await {
+        let receipt = result?;
+        commits.publish(receipt.seqno.record_index, Instant::now());
+        if next < count {
+            inflight.push(
+                handle
+                    .enqueue_append(WalSeqNo::record(next), payload.clone())
+                    .await?,
+            );
+            next += 1;
+        }
+    }
+    Ok(())
+}
+
+async fn run_subscriber(
+    mut follower: ReadOnlyFollower,
+    commits: Arc<CommitTimeline>,
+    target: u64,
+) -> Result<SubscriberStats> {
+    let mut stats = SubscriberStats::new()?;
+    let mut next = follower.from.record_index;
+    while next < target {
+        let record = follower
+            .try_next()
+            .await?
+            .context("readonly follower ended unexpectedly")?;
+        if record.seqno.record_index != next {
+            bail!(
+                "readonly follower returned {}, expected {next}",
+                record.seqno.record_index
+            );
+        }
+        let observed_at = Instant::now();
+        let committed_at = commits.take(next).await;
+        record_us(
+            &mut stats.commit_to_subscribe,
+            observed_at.saturating_duration_since(committed_at),
+        )?;
+        stats.records += 1;
+        next += 1;
+    }
+    Ok(stats)
+}
+
+pub(crate) async fn run(
+    storage: ConnectedStorage,
+    prefix: String,
+    args: ReadOnlyArgs,
+) -> Result<()> {
+    let metrics = Arc::new(BenchMetrics::default());
+    let metrics_recorder: Arc<dyn MetricsRecorder> = metrics.clone();
+    let writer_volume = SegmentedVolume::new_with_metrics_recorder(
+        storage.factories.clone(),
+        storage.manifest_factory.clone(),
+        &prefix,
+        ClientConfig::default(),
+        metrics_recorder,
+    )?;
+    let reader_volume = SegmentedVolume::new(
+        storage.factories,
+        storage.manifest_factory,
+        &prefix,
+        ClientConfig::default(),
+    )?;
+
+    let mut recovery = writer_volume.recover(WalSeqNo::ZERO).await?;
+    if recovery.end != WalSeqNo::ZERO {
+        bail!("readonly benchmark requires an unused prefix");
+    }
+    while recovery.try_next().await?.is_some() {}
+
+    let active_segment_bytes = (args.payload_bytes + 4)
+        .checked_mul(args.records)
+        .and_then(|bytes| bytes.checked_mul(2))
+        .context("readonly benchmark active segment size overflowed usize")?;
+    let mut writer = recovery
+        .start(WalEngineConfig {
+            queue_capacity: args.pipeline_window.saturating_mul(8),
+            max_record_bytes: args
+                .payload_bytes
+                .max(WalEngineConfig::default().max_record_bytes),
+            pipeline_window_records: args.pipeline_window,
+            max_inflight_bytes: WalEngineConfig::default().max_inflight_bytes,
+            max_replica_lag_bytes: WalEngineConfig::default().max_replica_lag_bytes,
+            lane_stall_timeout: WalEngineConfig::default().lane_stall_timeout,
+            max_segment_bytes: active_segment_bytes,
+            max_active_segment_bytes: active_segment_bytes,
+            repair_interval: None,
+            shutdown_timeout: WalEngineConfig::default().shutdown_timeout,
+        })
+        .await?;
+
+    let follower = reader_volume
+        .open_readonly_with_config(
+            WalSeqNo::ZERO,
+            ReadOnlyConfig {
+                poll_interval: Duration::from_millis(args.poll_interval_ms),
+            },
+        )
+        .await?;
+    let commits = Arc::new(CommitTimeline::default());
+    let subscriber_commits = Arc::clone(&commits);
+    let target = u64::try_from(args.records).context("record count overflowed u64")?;
+    let subscriber =
+        tokio::spawn(async move { run_subscriber(follower, subscriber_commits, target).await });
+
+    let payload = Bytes::from(vec![0x5a; args.payload_bytes]);
+    let benchmark_started = Instant::now();
+    let writer_started = Instant::now();
+    let timeout = Duration::from_secs(args.timeout_seconds);
+    tokio::time::timeout(
+        timeout,
+        append_records(
+            &mut writer,
+            target,
+            &payload,
+            args.pipeline_window,
+            &commits,
+        ),
+    )
+    .await
+    .context("timed out writing readonly benchmark records")??;
+    let writer_elapsed = writer_started.elapsed();
+
+    let subscriber_stats = tokio::time::timeout(timeout, subscriber)
+        .await
+        .context("timed out waiting for readonly follower")??
+        .context("readonly follower task failed")?;
+    let total_elapsed = benchmark_started.elapsed();
+    writer.shutdown().await?;
+
+    if metrics.seal_count() != 0 {
+        bail!(
+            "readonly active-tail benchmark unexpectedly rotated away from its active \
+             segment, sealing {} segments",
+            metrics.seal_count()
+        );
+    }
+
+    let payload_mib = args.payload_bytes as f64 / (1024.0 * 1024.0);
+    let report = serde_json::json!({
+        "benchmark": "readonly-active-tail",
+        "writer": {
+            "committed_records": target,
+            "duration_seconds": writer_elapsed.as_secs_f64(),
+            "record_iops": target as f64 / writer_elapsed.as_secs_f64(),
+            "payload_mib_per_second":
+                target as f64 * payload_mib / writer_elapsed.as_secs_f64(),
+        },
+        "subscriber": {
+            "delivered_records": subscriber_stats.records,
+            "end_to_end_duration_seconds": total_elapsed.as_secs_f64(),
+            "record_iops": target as f64 / total_elapsed.as_secs_f64(),
+            "payload_mib_per_second":
+                target as f64 * payload_mib / total_elapsed.as_secs_f64(),
+        },
+        "commit_to_subscribe_latency_us":
+            summarize(&subscriber_stats.commit_to_subscribe),
+        "configuration": {
+            "records": args.records,
+            "payload_bytes": args.payload_bytes,
+            "pipeline_window": args.pipeline_window,
+            "active_segment_bytes": active_segment_bytes,
+            "poll_interval_ms": args.poll_interval_ms,
+            "worker_threads": args.worker_threads,
+        }
+    });
+    println!("{}", serde_json::to_string_pretty(&report)?);
+    Ok(())
+}
+
+fn summarize(histogram: &Histogram<u64>) -> serde_json::Value {
+    serde_json::json!({
+        "samples": histogram.len(),
+        "p50": histogram.value_at_quantile(0.50),
+        "p90": histogram.value_at_quantile(0.90),
+        "p99": histogram.value_at_quantile(0.99),
+        "p99_9": histogram.value_at_quantile(0.999),
+        "max": histogram.max(),
+        "mean": histogram.mean().round() as u64,
+    })
+}
+
+fn record_us(histogram: &mut Histogram<u64>, duration: Duration) -> Result<()> {
+    histogram.record((duration.as_micros().max(1) as u64).min(599_000_000))?;
+    Ok(())
+}

--- a/rust/bin/chorus-cli/src/benchmark/readonly.rs
+++ b/rust/bin/chorus-cli/src/benchmark/readonly.rs
@@ -32,9 +32,17 @@ pub(crate) struct ReadOnlyArgs {
     payload_bytes: usize,
     #[arg(long, default_value_t = 64)]
     pipeline_window: usize,
-    /// Delay between readonly active-tail polls.
+    /// Delay before the next active-tail read when the previous one delivered
+    /// no records.
     #[arg(long, default_value_t = 100)]
     poll_interval_ms: u64,
+    /// Delay between readonly manifest re-reads.
+    #[arg(long, default_value_t = 1000)]
+    manifest_poll_interval_ms: u64,
+    /// Poll on a fixed cadence even while records are being delivered, instead
+    /// of reading again immediately after a read that produced records.
+    #[arg(long, default_value_t = false)]
+    fixed_poll_cadence: bool,
     /// Maximum wait for writer completion and follower catch-up.
     #[arg(long, default_value_t = 180)]
     timeout_seconds: u64,
@@ -52,6 +60,7 @@ impl ReadOnlyArgs {
             || self.payload_bytes == 0
             || self.pipeline_window == 0
             || self.poll_interval_ms == 0
+            || self.manifest_poll_interval_ms == 0
             || self.timeout_seconds == 0
             || self.worker_threads == 0
         {
@@ -80,7 +89,13 @@ impl CommitTimeline {
 
     async fn take(&self, record_index: u64) -> Instant {
         loop {
+            // Register before checking the map. `notify_waiters` wakes only
+            // waiters already registered and stores no permit, so a publish
+            // between the check and the await would otherwise be lost and the
+            // last record would never be timestamped.
             let notified = self.notify.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
             if let Some(at) = self.committed_at.lock().unwrap().remove(&record_index) {
                 return at;
             }
@@ -199,9 +214,11 @@ pub(crate) async fn run(
     let mut writer = recovery
         .start(WalEngineConfig {
             queue_capacity: args.pipeline_window.saturating_mul(8),
-            max_record_bytes: args
-                .payload_bytes
-                .max(WalEngineConfig::default().max_record_bytes),
+            // The workload appends one fixed payload size. Raising this to the
+            // library default would force `max_active_segment_bytes` to cover a
+            // maximum-size record the benchmark never writes, which rejects
+            // every small configuration.
+            max_record_bytes: args.payload_bytes,
             pipeline_window_records: args.pipeline_window,
             max_inflight_bytes: WalEngineConfig::default().max_inflight_bytes,
             max_replica_lag_bytes: WalEngineConfig::default().max_replica_lag_bytes,
@@ -218,6 +235,8 @@ pub(crate) async fn run(
             WalSeqNo::ZERO,
             ReadOnlyConfig {
                 poll_interval: Duration::from_millis(args.poll_interval_ms),
+                manifest_poll_interval: Duration::from_millis(args.manifest_poll_interval_ms),
+                continuous_when_active: !args.fixed_poll_cadence,
             },
         )
         .await?;
@@ -285,6 +304,8 @@ pub(crate) async fn run(
             "pipeline_window": args.pipeline_window,
             "active_segment_bytes": active_segment_bytes,
             "poll_interval_ms": args.poll_interval_ms,
+            "manifest_poll_interval_ms": args.manifest_poll_interval_ms,
+            "continuous_when_active": !args.fixed_poll_cadence,
             "worker_threads": args.worker_threads,
         }
     });

--- a/rust/bin/chorus-cli/src/main.rs
+++ b/rust/bin/chorus-cli/src/main.rs
@@ -2,6 +2,7 @@ mod benchmark;
 
 use anyhow::{bail, Context, Result};
 use benchmark::append::AppendArgs;
+use benchmark::readonly::ReadOnlyArgs;
 use benchmark::recovery::RecoveryArgs;
 use chorus_client::{
     BearerAuth, ClientConfig, GrpcReplicaFactory, RefreshingAuthConfig, SegmentedVolume,
@@ -60,6 +61,8 @@ enum BenchmarkCommand {
     Append(AppendArgs),
     /// Measure recovery phases after populating a separate WAL.
     Recovery(RecoveryArgs),
+    /// Measure writer throughput and readonly commit-to-subscribe latency.
+    Readonly(ReadOnlyArgs),
 }
 
 impl Command {
@@ -70,6 +73,9 @@ impl Command {
             } => args.worker_threads(),
             Self::Benchmark {
                 command: BenchmarkCommand::Recovery(args),
+            } => args.worker_threads(),
+            Self::Benchmark {
+                command: BenchmarkCommand::Readonly(args),
             } => args.worker_threads(),
             _ => std::thread::available_parallelism()
                 .map(usize::from)
@@ -84,6 +90,9 @@ impl Command {
             } => args.validate(),
             Self::Benchmark {
                 command: BenchmarkCommand::Recovery(args),
+            } => args.validate(),
+            Self::Benchmark {
+                command: BenchmarkCommand::Readonly(args),
             } => args.validate(),
             _ => Ok(()),
         }
@@ -255,6 +264,9 @@ async fn run(args: Args) -> Result<()> {
         Command::Benchmark {
             command: BenchmarkCommand::Recovery(benchmark_args),
         } => benchmark::recovery::run(storage, prefix, benchmark_args).await?,
+        Command::Benchmark {
+            command: BenchmarkCommand::Readonly(benchmark_args),
+        } => benchmark::readonly::run(storage, prefix, benchmark_args).await?,
     }
     Ok(())
 }

--- a/rust/bin/chorus-cli/tests/benchmark.rs
+++ b/rust/bin/chorus-cli/tests/benchmark.rs
@@ -138,41 +138,34 @@ async fn recovery_benchmark_keeps_phase_latencies_without_operation_counts() {
 
 #[tokio::test]
 async fn readonly_benchmark_delivers_every_record_through_the_active_tail() {
-    for cadence in [&["--fixed-poll-cadence"][..], &[][..]] {
-        let mut args = vec![
-            "readonly",
-            "--records",
-            "64",
-            "--payload-bytes",
-            "32",
-            "--pipeline-window",
-            "8",
-            "--poll-interval-ms",
-            "5",
-            "--manifest-poll-interval-ms",
-            "50",
-            "--timeout-seconds",
-            "20",
-        ];
-        args.extend_from_slice(cadence);
-        let report = benchmark(&args).await;
+    let report = benchmark(&[
+        "readonly",
+        "--records",
+        "64",
+        "--payload-bytes",
+        "32",
+        "--pipeline-window",
+        "8",
+        "--poll-interval-ms",
+        "5",
+        "--manifest-poll-interval-ms",
+        "50",
+        "--timeout-seconds",
+        "20",
+    ])
+    .await;
 
-        assert_eq!(report["benchmark"], "readonly-active-tail");
-        assert_eq!(report["writer"]["committed_records"], 64);
-        assert_eq!(report["subscriber"]["delivered_records"], 64);
-        assert_latency(&report["commit_to_subscribe_latency_us"]);
-        assert!(report["subscriber"]["record_iops"].as_f64().unwrap() > 0.0);
-        assert_eq!(
-            report["configuration"]["continuous_when_active"],
-            cadence.is_empty()
-        );
-        // The workload is sized to one active segment, so the follower must
-        // have observed every record without a rotation.
-        assert!(
-            report["configuration"]["active_segment_bytes"]
-                .as_u64()
-                .unwrap()
-                > 0
-        );
-    }
+    assert_eq!(report["benchmark"], "readonly-active-tail");
+    assert_eq!(report["writer"]["committed_records"], 64);
+    assert_eq!(report["subscriber"]["delivered_records"], 64);
+    assert_latency(&report["commit_to_subscribe_latency_us"]);
+    assert!(report["subscriber"]["record_iops"].as_f64().unwrap() > 0.0);
+    // The workload is sized to one active segment, so the follower must
+    // have observed every record without a rotation.
+    assert!(
+        report["configuration"]["active_segment_bytes"]
+            .as_u64()
+            .unwrap()
+            > 0
+    );
 }

--- a/rust/bin/chorus-cli/tests/benchmark.rs
+++ b/rust/bin/chorus-cli/tests/benchmark.rs
@@ -135,3 +135,44 @@ async fn recovery_benchmark_keeps_phase_latencies_without_operation_counts() {
     assert!(report.get("manifest_cas_attempts_avg").is_none());
     assert!(report.get("segments_sealed_avg").is_none());
 }
+
+#[tokio::test]
+async fn readonly_benchmark_delivers_every_record_through_the_active_tail() {
+    for cadence in [&["--fixed-poll-cadence"][..], &[][..]] {
+        let mut args = vec![
+            "readonly",
+            "--records",
+            "64",
+            "--payload-bytes",
+            "32",
+            "--pipeline-window",
+            "8",
+            "--poll-interval-ms",
+            "5",
+            "--manifest-poll-interval-ms",
+            "50",
+            "--timeout-seconds",
+            "20",
+        ];
+        args.extend_from_slice(cadence);
+        let report = benchmark(&args).await;
+
+        assert_eq!(report["benchmark"], "readonly-active-tail");
+        assert_eq!(report["writer"]["committed_records"], 64);
+        assert_eq!(report["subscriber"]["delivered_records"], 64);
+        assert_latency(&report["commit_to_subscribe_latency_us"]);
+        assert!(report["subscriber"]["record_iops"].as_f64().unwrap() > 0.0);
+        assert_eq!(
+            report["configuration"]["continuous_when_active"],
+            cadence.is_empty()
+        );
+        // The workload is sized to one active segment, so the follower must
+        // have observed every record without a rotation.
+        assert!(
+            report["configuration"]["active_segment_bytes"]
+                .as_u64()
+                .unwrap()
+                > 0
+        );
+    }
+}

--- a/rust/bin/rapid-probe/README.md
+++ b/rust/bin/rapid-probe/README.md
@@ -56,7 +56,7 @@ Each probe uses unique scratch object names; T6 creates two objects:
 | T4 | metadata CAS does not revoke an already-open stream |
 | T5 | finalization rejects a subsequent append open |
 | T6 | newly created segment-like objects are immediately visible to listing |
-| T7 | reports open-object read and size visibility, then verifies the finalized bytes are readable |
+| T7 | requires `BidiReadObject` to return flushed open-object bytes, reports ordinary read/size visibility, then verifies finalized reads |
 | T8 | reports whether 100 per-record flushed appends on one session encounter throttling |
 | T9 | measures sequential flush latency, per-message-flush burst pacing, and one-final-flush group durability |
 | T10 | reports outcomes for 256 KiB, 1 MiB, 2 MiB, 2 MiB + 1 byte, and 4 MiB write messages |
@@ -72,8 +72,8 @@ The probe also exercises two service-specific transport requirements:
 - zonal bidi writes may return `ABORTED` with a
   `BidiWriteObjectRedirectedError`; its routing token must be replayed in
   `x-goog-request-params`;
-- the durable tail of an open appendable object comes from write-response
-  `persisted_size`, not `GetObject.size`.
+- writer-lane durability still comes from write-response `persisted_size`;
+  readonly clients observe open bytes independently through `BidiReadObject`.
 
 Expected rejections and failures include the observed gRPC status code and
 message. Successful characterization results report their relevant sizes or
@@ -109,6 +109,10 @@ The repository records these historical live-service results for
   `INVALID_ARGUMENT` stating that `append_object_spec.generation` must be
   specified. Recovery therefore retains an explicit current-generation lookup
   followed by exact-generation takeover.
+- On June 23, 2026, T7 returned all 16 flushed bytes from the unfinalized
+  appendable object through `BidiReadObject`. That run also exposed the bytes
+  through ordinary `ReadObject` and `GetObject.size`; Chorus readonly following
+  nevertheless uses the explicit bidirectional-read API.
 
 These observations are evidence for those runs, not a permanent provider
 contract. Preserve new output with validation records.

--- a/rust/bin/rapid-probe/src/main.rs
+++ b/rust/bin/rapid-probe/src/main.rs
@@ -25,7 +25,8 @@
 //!   T4  a metadata CAS does NOT fence an already-open stream.
 //!   T5  finalization rejects a subsequent append open.
 //!   T6  newly created segment-like objects are immediately visible to listing.
-//!   T7  reports open-object read/size visibility and verifies the finalized read.
+//!   T7  verifies BidiReadObject visibility of flushed open-object bytes,
+//!         reports unary read/size visibility, and verifies the finalized read.
 //!   T8  reports whether repeated flushed appends encounter throttling.
 //!   T9  measures flush latency and one-final-flush group durability.
 //!   T10 reports outcomes for a fixed matrix of write-message sizes.
@@ -50,9 +51,9 @@ use googleapis_tonic_google_storage_v2::google::storage::v2::{
     bidi_write_object_request::{Data, FirstMessage},
     bidi_write_object_response::WriteStatus,
     storage_client::StorageClient,
-    AppendObjectSpec, BidiWriteObjectRequest, BidiWriteObjectResponse, ChecksummedData,
-    DeleteObjectRequest, GetObjectRequest, ListObjectsRequest, Object, ReadObjectRequest,
-    UpdateObjectRequest, WriteObjectSpec,
+    AppendObjectSpec, BidiReadObjectRequest, BidiReadObjectSpec, BidiWriteObjectRequest,
+    BidiWriteObjectResponse, ChecksummedData, DeleteObjectRequest, GetObjectRequest,
+    ListObjectsRequest, Object, ReadObjectRequest, ReadRange, UpdateObjectRequest, WriteObjectSpec,
 };
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
@@ -295,8 +296,8 @@ struct Ctx {
     client: StorageClient<Channel>,
     auth: MetadataValue<Ascii>,
     bucket: String,
-    /// Zonal write routing token, learned from the first BidiWriteObjectRedirectedError
-    /// and replayed on every later RPC. Reuses the production client's extractor.
+    /// Zonal routing token learned from a bidirectional read or write redirect
+    /// and replayed on later RPCs. Reuses the production client's extractor.
     routing_token: Mutex<Option<String>>,
     keep: bool,
 }
@@ -326,8 +327,8 @@ impl Ctx {
         request
     }
 
-    /// If `status` is a zonal write redirect, cache its routing token (via the
-    /// production client's extractor) and report `true` so the caller retries.
+    /// If `status` is a zonal bidirectional redirect, cache its routing token
+    /// and report `true` so the caller retries.
     fn capture_redirect(&self, status: &Status) -> bool {
         match chorus_client::probe_support::redirect_routing_token(status) {
             Some(token) => {
@@ -1190,6 +1191,7 @@ async fn probe_t7(ctx: &Ctx, run_id: u128) -> Result<ProbeResult> {
     .await
     .map_err(|status| anyhow::anyhow!("append: {}", code_of(&status)))?;
     let open_read = read_all(ctx, &object, generation).await;
+    let open_bidi_read = bidi_read_all(ctx, &object, generation).await;
     let (_, _, open_stat_size) = stat(ctx, &object).await?;
     finalize_once(ctx, &object, generation, metageneration, tail)
         .await
@@ -1200,17 +1202,90 @@ async fn probe_t7(ctx: &Ctx, run_id: u128) -> Result<ProbeResult> {
         Ok(bytes) => format!("{bytes} bytes"),
         Err(status) => format!("error {}", code_of(status)),
     };
+    let open_bidi_desc = match &open_bidi_read {
+        Ok(bytes) => format!("{bytes} bytes"),
+        Err(status) => format!("error {}", code_of(status)),
+    };
     let final_desc = match &final_read {
         Ok(bytes) => format!("{bytes} bytes"),
         Err(status) => format!("error {}", code_of(status)),
     };
     let detail = format!(
-        "persisted {tail}B flushed; OPEN object: ReadObject -> {open_desc}, GetObject.size -> {open_stat_size}; FINALIZED: ReadObject -> {final_desc}"
+        "persisted {tail}B flushed; OPEN object: BidiReadObject -> {open_bidi_desc}, \
+         ReadObject -> {open_desc}, GetObject.size -> {open_stat_size}; \
+         FINALIZED: ReadObject -> {final_desc}"
     );
-    match final_read {
-        Ok(bytes) if bytes as i64 == tail => ok(detail),
+    match (open_bidi_read, final_read) {
+        (Ok(open_bytes), Ok(final_bytes))
+            if open_bytes as i64 == tail && final_bytes as i64 == tail =>
+        {
+            ok(detail)
+        }
         _ => bad(detail),
     }
+}
+
+async fn bidi_read_all(ctx: &Ctx, object: &str, generation: i64) -> Result<usize, Status> {
+    for attempt in 0..=MAX_REDIRECTS {
+        let routing_token = ctx.routing_token.lock().unwrap().clone();
+        let request = BidiReadObjectRequest {
+            read_object_spec: Some(BidiReadObjectSpec {
+                bucket: ctx.bucket.clone(),
+                object: object.to_string(),
+                generation,
+                routing_token,
+                ..Default::default()
+            }),
+            read_ranges: vec![ReadRange {
+                read_offset: 0,
+                read_length: 0,
+                read_id: 1,
+            }],
+        };
+        let open = ctx
+            .client
+            .clone()
+            .bidi_read_object(ctx.request(tokio_stream::iter([request])))
+            .await;
+        let mut stream = match open {
+            Ok(response) => response.into_inner(),
+            Err(status) => {
+                if attempt < MAX_REDIRECTS && ctx.capture_redirect(&status) {
+                    continue;
+                }
+                return Err(status);
+            }
+        };
+        let mut total = 0usize;
+        loop {
+            match stream.message().await {
+                Ok(Some(response)) => {
+                    for range in response.object_data_ranges {
+                        if let Some(data) = range.checksummed_data {
+                            let actual = crc32c::crc32c(&data.content);
+                            if data.crc32c != Some(actual) {
+                                return Err(Status::data_loss(
+                                    "BidiReadObject response CRC32C mismatch",
+                                ));
+                            }
+                            total += data.content.len();
+                        }
+                        if range.range_end {
+                            return Ok(total);
+                        }
+                    }
+                }
+                Ok(None) => return Ok(total),
+                Err(status) => {
+                    if total == 0 && attempt < MAX_REDIRECTS && ctx.capture_redirect(&status) {
+                        break;
+                    }
+                    return Err(status);
+                }
+            }
+        }
+    }
+    Err(Status::aborted("BidiReadObject exhausted zonal redirects"))
 }
 
 async fn read_all(ctx: &Ctx, object: &str, generation: i64) -> Result<usize, Status> {

--- a/rust/client/README.md
+++ b/rust/client/README.md
@@ -104,6 +104,52 @@ The database remains responsible for its checkpoint. Call
 `WalHandle::truncate_before` only after the database has durably incorporated
 all records below that boundary.
 
+## Readonly followers
+
+`SegmentedVolume::open_readonly` opens a non-coordinating follower for a read
+replica process. The returned `ReadOnlyFollower` is an ordered stream that
+remains pending when caught up and automatically polls the active tail and
+later seals:
+
+```rust,ignore
+use chorus_client::{ReadOnlyConfig, WalSeqNo};
+use futures::TryStreamExt;
+use std::time::Duration;
+
+let mut follower = volume
+    .open_readonly_with_config(
+        WalSeqNo::record(load_replica_checkpoint()?),
+        ReadOnlyConfig {
+            poll_interval: Duration::from_millis(100),
+        },
+    )
+    .await?;
+
+while let Some(record) = follower.try_next().await? {
+    apply_to_read_replica(record.payload.as_ref())?;
+    persist_replica_checkpoint(record.next_seqno())?;
+}
+```
+
+Readonly open never creates the manifest, claims a writer epoch, opens append
+streams, repairs data, or changes the truncation floor. It reads only immutable
+segments already published in the manifest directory plus the manifest-selected
+active appendable object through GCS `BidiReadObject`. A complete active frame
+is emitted only when identical bytes are visible on a strict majority, so a
+minority-only or partial suffix is never exposed. The follower keeps one
+`BidiReadObject` RPC open per zone for the current active object, sends a new
+range message on each poll, and returns as soon as the first matching strict
+majority responds; a slow remaining request stays in flight for a later poll.
+Manifest refresh runs independently and does not delay active-tail delivery.
+Freshness is therefore the configured poll interval plus the fastest matching
+majority's bidirectional-read and decoding latency; segment rotation is not
+required.
+
+Followers do not register with the writer. Retain WAL history long enough for
+every replica to advance its own durable checkpoint. If truncation overtakes a
+follower, the stream returns `Error::ReadOnlyLagged` rather than skipping
+records; resnapshot that replica before reopening it at a newer checkpoint.
+
 ## Storage setup
 
 A typical volume uses:

--- a/rust/client/README.md
+++ b/rust/client/README.md
@@ -122,7 +122,6 @@ let mut follower = volume
         ReadOnlyConfig {
             poll_interval: Duration::from_millis(100),
             manifest_poll_interval: Duration::from_secs(1),
-            continuous_when_active: true,
         },
     )
     .await?;
@@ -148,15 +147,13 @@ seals, or truncates, so that interval is normally much larger than
 `poll_interval`; polling it at the active-tail rate multiplies regional reads
 without observing anything new.
 
-With `continuous_when_active` set, a read that delivered records is followed
-immediately by the next read, so `poll_interval` bounds only how often an idle
-follower re-reads the tail. While the writer is producing faster than one
-record per round trip, freshness is then the fastest matching majority's
-bidirectional-read and decoding latency. Once the follower catches up, the next
-record still waits up to `poll_interval` to be observed, which is the latency
-against request-rate tradeoff that interval controls. Clear
-`continuous_when_active` to poll on a fixed cadence regardless of delivery.
-Segment rotation is never required for delivery.
+A read that delivered records is followed immediately by the next read, so
+`poll_interval` bounds only how often an idle follower re-reads the tail. While
+the writer is producing faster than one record per round trip, freshness is the
+fastest matching majority's bidirectional-read and decoding latency. Once the
+follower catches up, the next record still waits up to `poll_interval` to be
+observed, which is the latency against request-rate tradeoff that interval
+controls. Segment rotation is never required for delivery.
 
 Followers do not register with the writer. Retain WAL history long enough for
 every replica to advance its own durable checkpoint. If truncation overtakes a

--- a/rust/client/README.md
+++ b/rust/client/README.md
@@ -121,6 +121,8 @@ let mut follower = volume
         WalSeqNo::record(load_replica_checkpoint()?),
         ReadOnlyConfig {
             poll_interval: Duration::from_millis(100),
+            manifest_poll_interval: Duration::from_secs(1),
+            continuous_when_active: true,
         },
     )
     .await?;
@@ -140,10 +142,21 @@ minority-only or partial suffix is never exposed. The follower keeps one
 `BidiReadObject` RPC open per zone for the current active object, sends a new
 range message on each poll, and returns as soon as the first matching strict
 majority responds; a slow remaining request stays in flight for a later poll.
-Manifest refresh runs independently and does not delay active-tail delivery.
-Freshness is therefore the configured poll interval plus the fastest matching
-majority's bidirectional-read and decoding latency; segment rotation is not
-required.
+Manifest refresh runs independently on `manifest_poll_interval` and does not
+delay active-tail delivery. The manifest changes only when the writer rotates,
+seals, or truncates, so that interval is normally much larger than
+`poll_interval`; polling it at the active-tail rate multiplies regional reads
+without observing anything new.
+
+With `continuous_when_active` set, a read that delivered records is followed
+immediately by the next read, so `poll_interval` bounds only how often an idle
+follower re-reads the tail. While the writer is producing faster than one
+record per round trip, freshness is then the fastest matching majority's
+bidirectional-read and decoding latency. Once the follower catches up, the next
+record still waits up to `poll_interval` to be observed, which is the latency
+against request-rate tradeoff that interval controls. Clear
+`continuous_when_active` to poll on a fixed cadence regardless of delivery.
+Segment rotation is never required for delivery.
 
 Followers do not register with the writer. Retain WAL history long enough for
 every replica to advance its own durable checkpoint. If truncation overtakes a

--- a/rust/client/src/error.rs
+++ b/rust/client/src/error.rs
@@ -33,6 +33,9 @@ pub enum Error {
     /// The configured identity provider could not issue a token.
     #[error("access-token source failed: {0}")]
     TokenSource(String),
+    /// The WAL manifest does not exist yet.
+    #[error("WAL is not initialized")]
+    Uninitialized,
     /// A bearer token cannot be represented in an ASCII gRPC header.
     #[error("access token cannot be encoded as gRPC metadata")]
     InvalidToken,
@@ -59,6 +62,17 @@ pub enum Error {
         current: WalSeqNo,
         /// Regressing checkpoint supplied by the caller.
         requested: WalSeqNo,
+    },
+    /// A readonly follower fell behind the committed truncation floor.
+    #[error(
+        "readonly follower at {next:?} was overtaken by truncation floor {truncation_floor:?}"
+    )]
+    #[non_exhaustive]
+    ReadOnlyLagged {
+        /// First record the follower still needed.
+        next: WalSeqNo,
+        /// First record still retained by the writer.
+        truncation_floor: WalSeqNo,
     },
     /// Finalized bytes or inferred segment bounds disagree with record framing.
     #[error("invalid sealed segment data: {0}")]

--- a/rust/client/src/grpc.rs
+++ b/rust/client/src/grpc.rs
@@ -6,11 +6,11 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use googleapis_tonic_google_storage_v2::google::storage::v2::{
     bidi_write_object_request, bidi_write_object_response, storage_client::StorageClient,
-    write_object_request, write_object_response, AppendObjectSpec, BidiReadObjectRequest,
-    BidiReadObjectSpec, BidiWriteHandle, BidiWriteObjectRedirectedError, BidiWriteObjectRequest,
-    BidiWriteObjectResponse, ChecksummedData, DeleteObjectRequest, GetObjectRequest,
-    ListObjectsRequest, Object, ReadRange, UpdateObjectRequest, WriteObjectRequest,
-    WriteObjectSpec,
+    write_object_request, write_object_response, AppendObjectSpec, BidiReadObjectRedirectedError,
+    BidiReadObjectRequest, BidiReadObjectResponse, BidiReadObjectSpec, BidiWriteHandle,
+    BidiWriteObjectRedirectedError, BidiWriteObjectRequest, BidiWriteObjectResponse,
+    ChecksummedData, DeleteObjectRequest, GetObjectRequest, ListObjectsRequest, Object, ReadRange,
+    UpdateObjectRequest, WriteObjectRequest, WriteObjectSpec,
 };
 use prost::Message as _;
 use tokio::sync::{mpsc, watch, Mutex as SessionMutex};
@@ -23,12 +23,12 @@ use crate::auth::BearerAuth;
 use crate::error::Error;
 use crate::transport::{
     AppendToken, LaneDurableChange, ListedObject, PackedAppend, PackedAppendMessage, Replica,
-    ReplicaFactory, ReplicaSnapshot, TransportCode, TransportError,
+    ReplicaFactory, ReplicaRangeRead, ReplicaSnapshot, TransportCode, TransportError,
 };
 
-/// Cached zonal write routing token, learned from a `BidiWriteObjectRedirectedError`
-/// and replayed in `x-goog-request-params` to land on the bucket's location.
-/// Shared across every replica produced by one factory.
+/// Cached zonal routing token, learned from a bidirectional read or write
+/// redirect and replayed in `x-goog-request-params` to land on the bucket's
+/// location. Shared across every replica produced by one factory.
 type RoutingToken = Arc<ArcSwap<Option<Arc<String>>>>;
 
 #[derive(Clone)]
@@ -39,6 +39,8 @@ struct GrpcReplica {
     auth: Option<BearerAuth>,
     client: StorageClient<Channel>,
     routing_token: RoutingToken,
+    /// Persistent bidirectional read stream reused for successive tail ranges.
+    read_session: Arc<SessionMutex<Option<BidiReadSession>>>,
     /// The lane's persistent append session. The live service rate limits
     /// per-object *mutations*, and every fresh append open is one — so a
     /// lane opens its session once (at takeover) and streams every window
@@ -90,6 +92,13 @@ struct RedirectAwareStream {
     responses: Streaming<BidiWriteObjectResponse>,
     first: BidiWriteObjectResponse,
     attempt: u32,
+}
+
+struct BidiReadSession {
+    tx: mpsc::Sender<BidiReadObjectRequest>,
+    responses: Streaming<BidiReadObjectResponse>,
+    generation: i64,
+    next_read_id: i64,
 }
 
 struct SessionWait {
@@ -464,11 +473,9 @@ impl GrpcReplica {
         snapshot
     }
 
-    /// If `status` is a zonal write redirect, cache its routing token for replay
-    /// and report `true` so the caller retries the same guarded open. The
-    /// redirect fields are intentionally ignored: conditional creates replay
-    /// their create precondition, takeovers replay their metageneration guard,
-    /// and resumes replay their existing handle.
+    /// If `status` is a zonal bidirectional redirect, cache its routing token
+    /// for replay and report `true`. Write opens replay their original
+    /// preconditions or handles; reads replay their object spec and range.
     fn try_capture_redirect(&self, status: &Status) -> bool {
         match redirect_routing_token(status) {
             Some(token) => {
@@ -476,6 +483,54 @@ impl GrpcReplica {
                 true
             }
             None => false,
+        }
+    }
+
+    async fn collect_bidi_range(
+        &self,
+        session: &mut BidiReadSession,
+        read_id: i64,
+    ) -> Result<ReplicaRangeRead, Status> {
+        let mut bytes = Vec::new();
+        loop {
+            let response = tokio::time::timeout(RPC_TIMEOUT, session.responses.message())
+                .await
+                .map_err(|_| Status::deadline_exceeded("BidiReadObject range timed out"))??;
+            let Some(response) = response else {
+                return Err(Status::unavailable(
+                    "BidiReadObject ended before completing its range",
+                ));
+            };
+            if let Some(metadata) = response.metadata {
+                session.generation = metadata.generation;
+            }
+            for range in response.object_data_ranges {
+                if range
+                    .read_range
+                    .as_ref()
+                    .is_some_and(|range| range.read_id != read_id)
+                {
+                    return Err(Status::data_loss(
+                        "BidiReadObject returned an unexpected read id",
+                    ));
+                }
+                if let Some(data) = range.checksummed_data {
+                    if data
+                        .crc32c
+                        .is_some_and(|expected| expected != crc32c::crc32c(&data.content))
+                    {
+                        return Err(Status::data_loss("BidiReadObject response CRC32C mismatch"));
+                    }
+                    bytes.extend_from_slice(&data.content);
+                }
+                if range.range_end {
+                    return Ok(ReplicaRangeRead {
+                        zone: self.zone,
+                        generation: session.generation,
+                        bytes,
+                    });
+                }
+            }
         }
     }
 
@@ -958,6 +1013,7 @@ impl GrpcReplicaFactory {
             auth: self.auth.clone(),
             client: self.client.clone(),
             routing_token: self.routing_token.clone(),
+            read_session: Arc::new(SessionMutex::new(None)),
             session: Arc::new(SessionSlot::new()),
         }
     }
@@ -1177,6 +1233,7 @@ impl ReplicaFactory for GrpcReplicaFactory {
             auth: self.auth.clone(),
             client: self.client.clone(),
             routing_token: self.routing_token.clone(),
+            read_session: Arc::new(SessionMutex::new(None)),
             session: Arc::new(SessionSlot::new()),
         })
     }
@@ -1189,6 +1246,7 @@ impl ReplicaFactory for GrpcReplicaFactory {
             auth: self.auth.clone(),
             client: self.client.clone(),
             routing_token: self.routing_token.clone(),
+            read_session: Arc::new(SessionMutex::new(None)),
             session: Arc::new(SessionSlot::new()),
         };
         let mut page_token = String::new();
@@ -1281,6 +1339,120 @@ impl Replica for GrpcReplica {
         // zone, object and size, while bidi returned the same bytes in 53ms.
         let bytes = self.bidi_read(object.generation).await?;
         Ok(self.snapshot_from_object(object, bytes))
+    }
+
+    async fn read_range(&self, offset: i64) -> Result<ReplicaRangeRead, TransportError> {
+        if offset < 0 {
+            return Err(self.error(
+                TransportCode::InvalidArgument,
+                "bidirectional read offset must be nonnegative",
+            ));
+        }
+        for attempt in 0..=MAX_WRITE_REDIRECTS {
+            let mut slot = self.read_session.lock().await;
+            let read_id = match slot.as_mut() {
+                Some(session) => {
+                    let read_id = session.next_read_id;
+                    session.next_read_id = session.next_read_id.checked_add(1).unwrap_or(1);
+                    let request = BidiReadObjectRequest {
+                        read_object_spec: None,
+                        read_ranges: vec![ReadRange {
+                            read_offset: offset,
+                            read_length: 0,
+                            read_id,
+                        }],
+                    };
+                    match tokio::time::timeout(RPC_TIMEOUT, session.tx.send(request)).await {
+                        Ok(Ok(())) => read_id,
+                        Ok(Err(_)) | Err(_) => {
+                            *slot = None;
+                            drop(slot);
+                            continue;
+                        }
+                    }
+                }
+                None => {
+                    let read_id = 1;
+                    let routing_token = self
+                        .routing_token
+                        .load_full()
+                        .as_ref()
+                        .as_ref()
+                        .map(|token| token.as_ref().clone());
+                    let first = BidiReadObjectRequest {
+                        read_object_spec: Some(BidiReadObjectSpec {
+                            bucket: self.bucket.clone(),
+                            object: self.object.clone(),
+                            routing_token,
+                            ..Default::default()
+                        }),
+                        read_ranges: vec![ReadRange {
+                            read_offset: offset,
+                            read_length: 0,
+                            read_id,
+                        }],
+                    };
+                    let (tx, rx) = mpsc::channel(64);
+                    tx.send(first).await.map_err(|_| {
+                        self.error(
+                            TransportCode::Internal,
+                            "BidiReadObject request channel closed before open",
+                        )
+                    })?;
+                    let request = self.request_no_deadline(ReceiverStream::new(rx))?;
+                    let opened = tokio::time::timeout(
+                        RPC_TIMEOUT,
+                        self.client.clone().bidi_read_object(request),
+                    )
+                    .await;
+                    let responses = match opened {
+                        Ok(Ok(response)) => response.into_inner(),
+                        Ok(Err(status)) => {
+                            drop(slot);
+                            if attempt < MAX_WRITE_REDIRECTS && self.try_capture_redirect(&status) {
+                                continue;
+                            }
+                            return Err(self.status(status));
+                        }
+                        Err(_) => {
+                            return Err(self.error(
+                                TransportCode::DeadlineExceeded,
+                                "BidiReadObject stream open timed out",
+                            ));
+                        }
+                    };
+                    *slot = Some(BidiReadSession {
+                        tx,
+                        responses,
+                        generation: 0,
+                        next_read_id: 2,
+                    });
+                    read_id
+                }
+            };
+            let result = self
+                .collect_bidi_range(
+                    slot.as_mut()
+                        .expect("bidirectional read session was initialized"),
+                    read_id,
+                )
+                .await;
+            match result {
+                Ok(read) => return Ok(read),
+                Err(status) => {
+                    *slot = None;
+                    drop(slot);
+                    if attempt < MAX_WRITE_REDIRECTS && self.try_capture_redirect(&status) {
+                        continue;
+                    }
+                    return Err(self.status(status));
+                }
+            }
+        }
+        Err(self.error(
+            TransportCode::Aborted,
+            "BidiReadObject exhausted zonal redirects",
+        ))
     }
 
     async fn create_appendable(
@@ -1850,10 +2022,10 @@ struct RichStatus {
     details: ::prost::alloc::vec::Vec<::prost_types::Any>,
 }
 
-/// Extract the routing token from a `BidiWriteObjectRedirectedError` attached to
-/// an ABORTED status, if present. The feature-gated `probe_support` module
-/// exports this for repository probes that must replay redirects exactly like
-/// the production transport.
+/// Extract the routing token from a zonal bidirectional read or write redirect
+/// attached to an ABORTED status, if present. The feature-gated `probe_support`
+/// module exports this for repository probes that must replay redirects exactly
+/// like the production transport.
 ///
 /// Normal users do not need this helper; the production transport consumes and
 /// caches redirects automatically.
@@ -1869,6 +2041,15 @@ pub fn redirect_routing_token(status: &Status) -> Option<String> {
             .ends_with("google.storage.v2.BidiWriteObjectRedirectedError")
         {
             if let Ok(redirect) = BidiWriteObjectRedirectedError::decode(any.value.as_slice()) {
+                if let Some(token) = redirect.routing_token {
+                    return Some(token);
+                }
+            }
+        } else if any
+            .type_url
+            .ends_with("google.storage.v2.BidiReadObjectRedirectedError")
+        {
+            if let Ok(redirect) = BidiReadObjectRedirectedError::decode(any.value.as_slice()) {
                 if let Some(token) = redirect.routing_token {
                     return Some(token);
                 }

--- a/rust/client/src/grpc_internal_tests.rs
+++ b/rust/client/src/grpc_internal_tests.rs
@@ -69,6 +69,7 @@ fn zonal_latency(seed: u64) -> LatencyProfile {
         .with_operation(Operation::Get, fast)
         .with_operation(Operation::List, fast)
         .with_operation(Operation::Read, fast)
+        .with_operation(Operation::BidiRead, fast)
         .with_operation(Operation::Update, mutation)
         .with_operation(
             Operation::BidiCreate,
@@ -360,6 +361,7 @@ async fn wait_for_repair_passes(metrics: &TestMetricsRecorder, minimum: u64) {
 
 mod engine;
 mod maintenance;
+mod readonly;
 mod recovery;
 mod topology;
 mod transport;

--- a/rust/client/src/grpc_internal_tests/readonly.rs
+++ b/rust/client/src/grpc_internal_tests/readonly.rs
@@ -1,0 +1,293 @@
+use super::*;
+use crate::ReadOnlyConfig;
+
+fn readonly_config() -> ReadOnlyConfig {
+    ReadOnlyConfig {
+        poll_interval: Duration::from_millis(10),
+    }
+}
+
+#[tokio::test]
+async fn readonly_open_does_not_initialize_the_wal() {
+    let (_servers, factories, manifest_factory) = factory_cluster().await;
+    let volume = volume(
+        factories,
+        manifest_factory.clone(),
+        "readonly-uninitialized-wal",
+    );
+
+    assert!(matches!(
+        volume
+            .open_readonly_with_config(WalSeqNo::ZERO, readonly_config())
+            .await,
+        Err(Error::Uninitialized)
+    ));
+    let error = manifest_factory
+        .replica("readonly-uninitialized-wal/manifest")
+        .stat()
+        .await
+        .expect_err("readonly open must not create the manifest");
+    assert_eq!(error.code, TransportCode::NotFound);
+}
+
+#[tokio::test]
+async fn readonly_follower_tracks_active_records_across_rotation_without_fencing_the_writer() {
+    let (servers, factories, manifest_factory) = factory_cluster().await;
+    let writer_volume = volume(
+        factories.clone(),
+        manifest_factory.clone(),
+        "readonly-follow-rotations-wal",
+    );
+    let reader_volume = volume(factories, manifest_factory, "readonly-follow-rotations-wal");
+    let mut writer = writer_volume.recover_writer().await.unwrap();
+    let mut follower = reader_volume
+        .open_readonly_with_config(WalSeqNo::ZERO, readonly_config())
+        .await
+        .unwrap();
+
+    append_one(&mut writer, b"first").await;
+    for server in &servers {
+        server.service.reset_operation_counts().await;
+    }
+    let first = tokio::time::timeout(Duration::from_secs(5), follower.try_next())
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    assert_eq!(first.seqno, WalSeqNo::ZERO);
+    assert_eq!(first.payload, b"first".as_slice());
+    assert_readonly_operations(&servers).await;
+
+    writer.rotate().await.unwrap();
+    append_one(&mut writer, b"second").await;
+    for server in &servers {
+        server.service.reset_operation_counts().await;
+    }
+    let second = tokio::time::timeout(Duration::from_secs(5), follower.try_next())
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    assert_eq!(second.seqno, WalSeqNo::record(1));
+    assert_eq!(second.payload, b"second".as_slice());
+    assert_readonly_operations(&servers).await;
+
+    assert_eq!(append_one(&mut writer, b"writer-still-live").await, 2);
+}
+
+async fn assert_readonly_operations(servers: &[chorus_fake_gcs::RunningFake]) {
+    for server in servers {
+        assert_eq!(
+            server
+                .service
+                .operation_count(Operation::BidiTakeoverOpen)
+                .await,
+            0,
+            "readonly following must never open a takeover stream"
+        );
+    }
+    let mut bidi_reads = 0;
+    for server in &servers[..3] {
+        bidi_reads += server.service.operation_count(Operation::BidiRead).await;
+    }
+    assert!(
+        bidi_reads > 0,
+        "readonly following must use bidirectional reads for the active tail"
+    );
+    assert_eq!(
+        servers[3].service.operation_count(Operation::Update).await,
+        0,
+        "readonly following must never update the manifest"
+    );
+}
+
+#[tokio::test]
+async fn readonly_active_tail_requires_a_quorum_and_complete_frames() {
+    let (_servers, factories, manifest_factory) = factory_cluster().await;
+    let prefix = "readonly-active-quorum-wal";
+    let volume = volume(factories.clone(), manifest_factory.clone(), prefix);
+    let mut writer = volume.recover_writer().await.unwrap();
+    append_one(&mut writer, b"committed").await;
+
+    let mut follower = volume
+        .open_readonly_with_config(WalSeqNo::ZERO, readonly_config())
+        .await
+        .unwrap();
+    let first = tokio::time::timeout(Duration::from_secs(5), follower.try_next())
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    assert_eq!(first.payload, b"committed".as_slice());
+
+    let (tail, _) = manifest_frontier_ids(&manifest_factory, prefix).await;
+    let object = segment_object(prefix, &tail);
+    append_raw_record(&factories[0], &object, b"minority").await;
+    assert!(
+        tokio::time::timeout(Duration::from_millis(100), follower.try_next())
+            .await
+            .is_err(),
+        "a record visible in only one zone must not be published"
+    );
+    append_raw_record(&factories[1], &object, b"minority").await;
+    let minority = tokio::time::timeout(Duration::from_secs(5), follower.try_next())
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    assert_eq!(minority.payload, b"minority".as_slice());
+
+    append_partial_raw_record(&factories[0], &object, b"partial").await;
+    append_partial_raw_record(&factories[1], &object, b"partial").await;
+    assert!(
+        tokio::time::timeout(Duration::from_millis(100), follower.try_next())
+            .await
+            .is_err(),
+        "a quorum-visible partial frame must not be published"
+    );
+    let encoded = record(b"partial").encode().unwrap();
+    let final_byte = vec![*encoded.last().unwrap()];
+    append_raw_bytes(&factories[0], &object, final_byte.clone()).await;
+    append_raw_bytes(&factories[1], &object, final_byte).await;
+    let partial = tokio::time::timeout(Duration::from_secs(5), follower.try_next())
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    assert_eq!(partial.payload, b"partial".as_slice());
+}
+
+#[tokio::test]
+async fn readonly_active_tail_returns_after_the_first_matching_quorum() {
+    let (servers, factories, manifest_factory) = factory_cluster().await;
+    let writer_volume = volume(
+        factories.clone(),
+        manifest_factory.clone(),
+        "readonly-raced-quorum-wal",
+    );
+    let reader_volume = volume(factories, manifest_factory, "readonly-raced-quorum-wal");
+    let mut writer = writer_volume.recover_writer().await.unwrap();
+    let mut follower = reader_volume
+        .open_readonly_with_config(WalSeqNo::ZERO, readonly_config())
+        .await
+        .unwrap();
+
+    append_one(&mut writer, b"first").await;
+    servers[2]
+        .service
+        .inject_delay(Operation::BidiRead, Duration::from_secs(2))
+        .await;
+    let first = tokio::time::timeout(Duration::from_millis(500), follower.try_next())
+        .await
+        .expect("a slow third replica must not delay a matching majority")
+        .unwrap()
+        .unwrap();
+    assert_eq!(first.payload, b"first".as_slice());
+
+    append_one(&mut writer, b"second").await;
+    let second = tokio::time::timeout(Duration::from_millis(500), follower.try_next())
+        .await
+        .expect("the fast majority must keep polling while the third read is outstanding")
+        .unwrap()
+        .unwrap();
+    assert_eq!(second.payload, b"second".as_slice());
+
+    for server in &servers[..3] {
+        assert_eq!(
+            server.service.operation_count(Operation::BidiRead).await,
+            1,
+            "successive range requests must reuse one BidiReadObject RPC per replica"
+        );
+    }
+}
+
+#[tokio::test]
+async fn readonly_active_tail_does_not_wait_for_manifest_refresh() {
+    let (servers, factories, manifest_factory) = factory_cluster().await;
+    let writer_volume = volume(
+        factories.clone(),
+        manifest_factory.clone(),
+        "readonly-independent-manifest-wal",
+    );
+    let reader_volume = volume(
+        factories,
+        manifest_factory,
+        "readonly-independent-manifest-wal",
+    );
+    let mut writer = writer_volume.recover_writer().await.unwrap();
+    let mut follower = reader_volume
+        .open_readonly_with_config(WalSeqNo::ZERO, readonly_config())
+        .await
+        .unwrap();
+
+    for server in &servers {
+        server.service.reset_operation_counts().await;
+    }
+    servers[3]
+        .service
+        .inject_delay(Operation::Get, Duration::from_secs(2))
+        .await;
+
+    append_one(&mut writer, b"first").await;
+    let first = tokio::time::timeout(Duration::from_millis(500), follower.try_next())
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    assert_eq!(first.payload, b"first".as_slice());
+    tokio::time::timeout(Duration::from_millis(500), async {
+        loop {
+            if servers[3].service.operation_count(Operation::Get).await > 0 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("the independent manifest refresh did not start");
+
+    append_one(&mut writer, b"second").await;
+    let second = tokio::time::timeout(Duration::from_millis(500), follower.try_next())
+        .await
+        .expect("an outstanding manifest GET must not delay active-tail reads")
+        .unwrap()
+        .unwrap();
+    assert_eq!(second.payload, b"second".as_slice());
+}
+
+#[tokio::test]
+async fn readonly_follower_reports_when_truncation_overtakes_it() {
+    let (_servers, factories, manifest_factory) = factory_cluster().await;
+    let volume = volume(factories, manifest_factory, "readonly-lagged-wal");
+    let mut writer = volume.recover_writer().await.unwrap();
+    append_one(&mut writer, b"soon-deleted").await;
+    writer.rotate().await.unwrap();
+
+    let mut follower = volume
+        .open_readonly_with_config(WalSeqNo::ZERO, readonly_config())
+        .await
+        .unwrap();
+    writer.truncate_before(WalSeqNo::record(1)).await.unwrap();
+
+    let error = tokio::time::timeout(Duration::from_secs(5), follower.try_next())
+        .await
+        .unwrap()
+        .expect_err("the follower must not skip truncated history");
+    assert!(matches!(
+        error,
+        Error::ReadOnlyLagged {
+            next: WalSeqNo { record_index: 0 },
+            truncation_floor: WalSeqNo { record_index: 1 },
+        }
+    ));
+
+    assert!(matches!(
+        volume
+            .open_readonly_with_config(WalSeqNo::ZERO, readonly_config())
+            .await,
+        Err(Error::ReadOnlyLagged {
+            next: WalSeqNo { record_index: 0 },
+            truncation_floor: WalSeqNo { record_index: 1 },
+        })
+    ));
+}

--- a/rust/client/src/grpc_internal_tests/readonly.rs
+++ b/rust/client/src/grpc_internal_tests/readonly.rs
@@ -431,3 +431,112 @@ async fn readonly_open_rejects_a_zero_poll_interval() {
         ));
     }
 }
+
+#[tokio::test]
+async fn readonly_follower_reads_a_pending_seal_before_its_copies_are_finalized() {
+    let (servers, factories, manifest_factory) = factory_cluster().await;
+    let writer_volume = volume(
+        factories.clone(),
+        manifest_factory.clone(),
+        "readonly-pending-seal-wal",
+    );
+    let reader_volume = volume(factories, manifest_factory, "readonly-pending-seal-wal");
+    let mut writer = writer_volume.recover_writer().await.unwrap();
+    append_one(&mut writer, b"sealed-before-finalize").await;
+
+    // Park every finalization so the rotated segment is listed in the manifest
+    // as the pending seal while no copy is finalized yet.
+    for server in &servers[..3] {
+        server.service.inject_finalize_hold().await;
+    }
+    let rotation = tokio::spawn(async move {
+        writer.rotate().await.unwrap();
+        writer
+    });
+    // The writer folds the seal into the manifest before it finalizes. The fake
+    // counts a finalize request before parking it, so a nonzero count means
+    // the manifest already lists the seal while every copy is still open.
+    let finalize_requested = async {
+        loop {
+            let mut requested = 0;
+            for server in &servers[..3] {
+                requested += server
+                    .service
+                    .operation_count(Operation::BidiFinalize)
+                    .await;
+            }
+            if requested > 0 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    };
+    tokio::time::timeout(Duration::from_secs(5), finalize_requested)
+        .await
+        .expect("rotation must reach seal enforcement");
+
+    let mut follower = reader_volume
+        .open_readonly_with_config(WalSeqNo::ZERO, readonly_config())
+        .await
+        .unwrap();
+    let first = tokio::time::timeout(Duration::from_secs(5), follower.try_next())
+        .await
+        .expect("a pending seal whose bytes match the committed CRC32C must be readable")
+        .unwrap()
+        .unwrap();
+    assert_eq!(first.seqno, WalSeqNo::record(0));
+    assert_eq!(first.payload, b"sealed-before-finalize".as_slice());
+
+    for server in &servers[..3] {
+        server.service.release_finalize_holds().await;
+    }
+    let mut writer = rotation.await.unwrap();
+    assert_eq!(append_one(&mut writer, b"after-finalize").await, 1);
+    let second = tokio::time::timeout(Duration::from_secs(5), follower.try_next())
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    assert_eq!(second.payload, b"after-finalize".as_slice());
+}
+
+#[tokio::test]
+async fn readonly_follower_reports_a_permission_error_instead_of_polling_forever() {
+    let (servers, factories, manifest_factory) = factory_cluster().await;
+    let writer_volume = volume(
+        factories.clone(),
+        manifest_factory.clone(),
+        "readonly-permission-wal",
+    );
+    let reader_volume = volume(factories, manifest_factory, "readonly-permission-wal");
+    let mut writer = writer_volume.recover_writer().await.unwrap();
+    append_one(&mut writer, b"unreadable").await;
+
+    // Every zonal range read is denied. That can never clear by polling, so
+    // the follower must surface it rather than treat it as a missing quorum.
+    for server in &servers[..3] {
+        for _ in 0..4 {
+            server
+                .service
+                .inject(Operation::Read, Code::PermissionDenied)
+                .await;
+        }
+    }
+    let mut follower = reader_volume
+        .open_readonly_with_config(WalSeqNo::ZERO, readonly_config())
+        .await
+        .unwrap();
+    let outcome = tokio::time::timeout(Duration::from_secs(5), follower.try_next())
+        .await
+        .expect("a denied read quorum must fail fast");
+    assert!(
+        matches!(
+            outcome,
+            Err(Error::Transport {
+                code: TransportCode::PermissionDenied,
+                ..
+            })
+        ),
+        "expected PermissionDenied, got {outcome:?}"
+    );
+}

--- a/rust/client/src/grpc_internal_tests/readonly.rs
+++ b/rust/client/src/grpc_internal_tests/readonly.rs
@@ -4,6 +4,8 @@ use crate::ReadOnlyConfig;
 fn readonly_config() -> ReadOnlyConfig {
     ReadOnlyConfig {
         poll_interval: Duration::from_millis(10),
+        manifest_poll_interval: Duration::from_millis(10),
+        ..ReadOnlyConfig::default()
     }
 }
 
@@ -290,4 +292,28 @@ async fn readonly_follower_reports_when_truncation_overtakes_it() {
             truncation_floor: WalSeqNo { record_index: 1 },
         })
     ));
+}
+
+#[tokio::test]
+async fn readonly_open_rejects_a_zero_poll_interval() {
+    let (_servers, factories, manifest_factory) = factory_cluster().await;
+    let volume = volume(factories, manifest_factory, "readonly-config-wal");
+
+    for config in [
+        ReadOnlyConfig {
+            poll_interval: Duration::ZERO,
+            ..readonly_config()
+        },
+        ReadOnlyConfig {
+            manifest_poll_interval: Duration::ZERO,
+            ..readonly_config()
+        },
+    ] {
+        assert!(matches!(
+            volume
+                .open_readonly_with_config(WalSeqNo::ZERO, config)
+                .await,
+            Err(Error::InvalidConfig(_))
+        ));
+    }
 }

--- a/rust/client/src/grpc_internal_tests/readonly.rs
+++ b/rust/client/src/grpc_internal_tests/readonly.rs
@@ -33,6 +33,120 @@ async fn readonly_open_does_not_initialize_the_wal() {
 }
 
 #[tokio::test]
+async fn readonly_open_reports_uninitialized_before_the_first_manifest_claim() {
+    let (_servers, factories, manifest_factory) = factory_cluster().await;
+    let prefix = "readonly-unclaimed-wal";
+    let manifest_replica = manifest_factory.replica(&format!("{prefix}/manifest"));
+    let mut manifest = crate::manifest::Manifest::open(
+        Arc::new(crate::manifest_store::GcsManifestStore::new(
+            manifest_replica.clone(),
+        )),
+        test_config(),
+        Arc::new(crate::metrics::Metrics::new(
+            &crate::NoopMetricsRecorder,
+            factories.len(),
+        )),
+        factories.len(),
+        factories
+            .iter()
+            .map(|factory| factory.bucket_name().to_string())
+            .collect(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(manifest.record().epoch, 0);
+    assert!(manifest.record().tail_id.is_none());
+    let before = manifest_replica.stat().await.unwrap();
+    let volume = volume(factories, manifest_factory, prefix);
+    assert!(matches!(
+        volume
+            .open_readonly_with_config(WalSeqNo::ZERO, readonly_config())
+            .await,
+        Err(Error::Uninitialized)
+    ));
+    let after = manifest_replica.stat().await.unwrap();
+    assert_eq!(after.metageneration, before.metageneration);
+    assert_eq!(after.metadata, before.metadata);
+
+    manifest.claim().await.unwrap();
+    assert!(volume
+        .open_readonly_with_config(WalSeqNo::ZERO, readonly_config())
+        .await
+        .is_ok());
+}
+
+#[tokio::test]
+async fn readonly_active_tail_survives_one_replaced_generation() {
+    let (servers, factories, manifest_factory) = factory_cluster().await;
+    let prefix = "readonly-replaced-generation-wal";
+    let volume = volume(factories.clone(), manifest_factory.clone(), prefix);
+    let writer = volume.recover_writer().await.unwrap();
+    drop(writer);
+    let (tail, _) = manifest_frontier_ids(&manifest_factory, prefix).await;
+    let object = segment_object(prefix, &tail);
+    for factory in &factories {
+        append_raw_record(factory, &object, b"first").await;
+    }
+
+    // Only zones 0 and 1 can form the first quorum, so the follower must
+    // observe zone 0's original generation before its replacement.
+    servers[2].service.set_crashed(true).await;
+    let mut follower = volume
+        .open_readonly_with_config(WalSeqNo::ZERO, readonly_config())
+        .await
+        .unwrap();
+    let first = tokio::time::timeout(Duration::from_secs(5), follower.try_next())
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    assert_eq!(first.seqno, WalSeqNo::ZERO);
+    assert_eq!(first.payload, b"first".as_slice());
+
+    let replica = factories[0].replica(&object);
+    let original = replica.snapshot().await.unwrap();
+    let mut replacement = original.bytes.to_vec();
+    replacement.extend_from_slice(&record(b"minority-only").encode().unwrap());
+    let replaced = replica
+        .replace_appendable(&original, replacement.into(), original.metadata.clone())
+        .await
+        .unwrap();
+    assert_ne!(replaced.generation.unwrap(), original.generation);
+    servers[0].service.reset_operation_counts().await;
+
+    // With no new majority record, polling must survive the old session's
+    // failure, reopen it, and observe the replacement generation.
+    assert!(
+        tokio::time::timeout(Duration::from_secs(1), follower.try_next())
+            .await
+            .is_err()
+    );
+    assert!(
+        servers[0]
+            .service
+            .operation_count(Operation::BidiRead)
+            .await
+            > 0
+    );
+    assert!(servers[0].service.operation_count(Operation::Read).await > 2);
+
+    servers[2].service.set_crashed(false).await;
+    for factory in &factories[1..] {
+        append_raw_record(factory, &object, b"second").await;
+        append_raw_record(factory, &object, b"third").await;
+    }
+    for (index, payload) in [(1, b"second".as_slice()), (2, b"third".as_slice())] {
+        let next = tokio::time::timeout(Duration::from_secs(5), follower.try_next())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(next.seqno, WalSeqNo::record(index));
+        assert_eq!(next.payload, payload);
+    }
+}
+
+#[tokio::test]
 async fn readonly_follower_tracks_active_records_across_rotation_without_fencing_the_writer() {
     let (servers, factories, manifest_factory) = factory_cluster().await;
     let writer_volume = volume(

--- a/rust/client/src/grpc_internal_tests/readonly.rs
+++ b/rust/client/src/grpc_internal_tests/readonly.rs
@@ -5,7 +5,6 @@ fn readonly_config() -> ReadOnlyConfig {
     ReadOnlyConfig {
         poll_interval: Duration::from_millis(10),
         manifest_poll_interval: Duration::from_millis(10),
-        ..ReadOnlyConfig::default()
     }
 }
 

--- a/rust/client/src/grpc_internal_tests/readonly.rs
+++ b/rust/client/src/grpc_internal_tests/readonly.rs
@@ -540,3 +540,94 @@ async fn readonly_follower_reports_a_permission_error_instead_of_polling_forever
         "expected PermissionDenied, got {outcome:?}"
     );
 }
+
+#[tokio::test]
+async fn readonly_follower_keeps_reading_when_one_zone_denies_it() {
+    let (servers, factories, manifest_factory) = factory_cluster().await;
+    let writer_volume = volume(
+        factories.clone(),
+        manifest_factory.clone(),
+        "readonly-one-zone-denied-wal",
+    );
+    let reader_volume = volume(factories, manifest_factory, "readonly-one-zone-denied-wal");
+    let mut writer = writer_volume.recover_writer().await.unwrap();
+    append_one(&mut writer, b"first").await;
+
+    // One denied zone leaves two that can still form a quorum. That is a
+    // degraded replica set, not a follower that can never make progress. A
+    // transient failure on a second zone makes the first poll miss its quorum
+    // with the denial present, which is the case that must keep polling
+    // rather than terminate.
+    for _ in 0..8 {
+        servers[0]
+            .service
+            .inject(Operation::Read, Code::PermissionDenied)
+            .await;
+    }
+    servers[1]
+        .service
+        .inject(Operation::Read, Code::Unavailable)
+        .await;
+    let mut follower = reader_volume
+        .open_readonly_with_config(WalSeqNo::ZERO, readonly_config())
+        .await
+        .unwrap();
+    let first = tokio::time::timeout(Duration::from_secs(5), follower.try_next())
+        .await
+        .expect("two authorized zones must still deliver")
+        .unwrap()
+        .unwrap();
+    assert_eq!(first.payload, b"first".as_slice());
+    append_one(&mut writer, b"second").await;
+    let second = tokio::time::timeout(Duration::from_secs(5), follower.try_next())
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    assert_eq!(second.payload, b"second".as_slice());
+}
+
+#[tokio::test]
+async fn readonly_sealed_replay_reports_a_permission_error_instead_of_polling_forever() {
+    let (servers, factories, manifest_factory) = factory_cluster().await;
+    let writer_volume = volume(
+        factories.clone(),
+        manifest_factory.clone(),
+        "readonly-sealed-permission-wal",
+    );
+    let reader_volume = volume(
+        factories,
+        manifest_factory,
+        "readonly-sealed-permission-wal",
+    );
+    let mut writer = writer_volume.recover_writer().await.unwrap();
+    append_one(&mut writer, b"sealed").await;
+    writer.rotate().await.unwrap();
+
+    // The checkpoint needs the sealed segment, and every zone denies the read.
+    for server in &servers[..3] {
+        for _ in 0..8 {
+            server
+                .service
+                .inject(Operation::Read, Code::PermissionDenied)
+                .await;
+        }
+    }
+    let mut follower = reader_volume
+        .open_readonly_with_config(WalSeqNo::ZERO, readonly_config())
+        .await
+        .unwrap();
+    let outcome = tokio::time::timeout(Duration::from_secs(5), follower.try_next())
+        .await
+        .expect("a denied sealed read quorum must fail fast");
+    assert!(
+        matches!(
+            outcome,
+            Err(Error::Transport {
+                code: TransportCode::PermissionDenied,
+                ..
+            })
+        ),
+        "expected PermissionDenied from sealed replay, got {outcome:?}"
+    );
+}

--- a/rust/client/src/lib.rs
+++ b/rust/client/src/lib.rs
@@ -29,6 +29,12 @@
 //! repaired in place, and maintenance never advances the database's checkpoint
 //! floor autonomously. See the `database_wal`
 //! example for the complete lifecycle.
+//! Independent read-replica processes can call
+//! [`SegmentedVolume::open_readonly`] to follow sealed history and the
+//! quorum-visible active tail without claiming a writer epoch. The follower
+//! automatically polls with bidirectional range reads and returns
+//! [`Error::ReadOnlyLagged`] if writer truncation overtakes its durable
+//! checkpoint.
 //! Every fallible public operation returns [`Error`].
 //!
 //! # Operational constraints
@@ -92,7 +98,8 @@ pub use metrics::{
 };
 pub use protocol::ClientConfig;
 pub use segment::{
-    Recovery, RecoveryTimings, RepairReport, SegmentedVolume, TruncationReport, WalRecord, WalSeqNo,
+    ReadOnlyConfig, ReadOnlyFollower, Recovery, RecoveryTimings, RepairReport, SegmentedVolume,
+    TruncationReport, WalRecord, WalSeqNo,
 };
 pub use transport::TransportCode;
 
@@ -100,8 +107,8 @@ pub use transport::TransportCode;
 /// supplies an in-memory `ReplicaFactory` in place of the gRPC transport.
 #[cfg(feature = "dst-support")]
 pub use transport::{
-    AppendToken, LaneDurableChange, ListedObject, Replica, ReplicaFactory, ReplicaSnapshot,
-    TransportError,
+    AppendToken, LaneDurableChange, ListedObject, Replica, ReplicaFactory, ReplicaRangeRead,
+    ReplicaSnapshot, TransportError,
 };
 
 /// Helpers for repository probes that intentionally share transport details.

--- a/rust/client/src/manifest.rs
+++ b/rust/client/src/manifest.rs
@@ -564,6 +564,44 @@ impl Manifest {
         Ok(manifest)
     }
 
+    /// Read an existing register without creating it when absent.
+    ///
+    /// This is the readonly-open path. It deliberately has no write fallback:
+    /// a caller using it can only observe a register initialized by a writer.
+    pub(crate) async fn open_existing(
+        store: Arc<dyn ManifestStore>,
+        config: ClientConfig,
+        metrics: Arc<Metrics>,
+        replica_count: usize,
+        bucket_names: Vec<String>,
+    ) -> Result<Option<Self>, ProtocolError> {
+        validate_bucket_names(&bucket_names)?;
+        if replica_count != bucket_names.len() {
+            return Err(ProtocolError::InvalidManifest(format!(
+                "volume has {replica_count} replica factories but {} bucket identities",
+                bucket_names.len()
+            )));
+        }
+        let max_directory_bytes = store.max_directory_bytes();
+        let initial = ManifestRecord::initial(bucket_names.clone());
+        initial.validate()?;
+        let mut manifest = Self {
+            store,
+            config,
+            owner: incarnation_id(),
+            epoch: 0,
+            bucket_names,
+            max_directory_bytes,
+            cache: (ManifestVersion(0), initial),
+            metrics,
+        };
+        if manifest.refresh_existing().await? {
+            Ok(Some(manifest))
+        } else {
+            Ok(None)
+        }
+    }
+
     fn validate_configuration(&self, record: &ManifestRecord) -> Result<(), ProtocolError> {
         if record.buckets.len() != self.bucket_names.len() {
             return Err(ProtocolError::InvalidManifest(format!(
@@ -605,6 +643,24 @@ impl Manifest {
                         Err(error) => return Err(error.into()),
                     }
                 }
+                Err(ManifestStoreError::Unavailable(_)) => {}
+                Err(error) => return Err(error.into()),
+            }
+            retry_sleep(&self.config, attempt).await;
+        }
+        Err(ProtocolError::ManifestUnavailable)
+    }
+
+    async fn refresh_existing(&mut self) -> Result<bool, ProtocolError> {
+        for attempt in 0..=self.config.max_retries {
+            match self.store.read().await {
+                Ok(Some(state)) => {
+                    let record = ManifestRecord::decode(&state.fields)?;
+                    self.validate_configuration(&record)?;
+                    self.install_cache(state.version, record);
+                    return Ok(true);
+                }
+                Ok(None) => return Ok(false),
                 Err(ManifestStoreError::Unavailable(_)) => {}
                 Err(error) => return Err(error.into()),
             }
@@ -1056,6 +1112,17 @@ impl Manifest {
     pub async fn refreshed_record(&mut self) -> Result<ManifestRecord, ProtocolError> {
         self.refresh().await?;
         Ok(self.record().clone())
+    }
+
+    /// Re-read an existing register without ever creating a missing one.
+    pub(crate) async fn refreshed_existing_record(
+        &mut self,
+    ) -> Result<Option<ManifestRecord>, ProtocolError> {
+        if self.refresh_existing().await? {
+            Ok(Some(self.record().clone()))
+        } else {
+            Ok(None)
+        }
     }
 
     /// Re-read the register and confirm this process still holds the epoch.

--- a/rust/client/src/metrics.rs
+++ b/rust/client/src/metrics.rs
@@ -301,6 +301,7 @@ pub(crate) struct Metrics {
 pub(crate) struct TransportRpcMetrics {
     pub(crate) snapshot: Histogram,
     pub(crate) stat: Histogram,
+    pub(crate) read_range: Histogram,
     pub(crate) create_appendable: Histogram,
     pub(crate) create_append_session: Histogram,
     pub(crate) resume_tail: Histogram,
@@ -337,6 +338,7 @@ impl TransportRpcMetrics {
         Self {
             snapshot: rpc("snapshot"),
             stat: rpc("stat"),
+            read_range: rpc("read_range"),
             create_appendable: rpc("create_appendable"),
             create_append_session: rpc("create_append_session"),
             resume_tail: rpc("resume_tail"),

--- a/rust/client/src/segment.rs
+++ b/rust/client/src/segment.rs
@@ -101,15 +101,29 @@ pub struct SegmentedVolume {
 /// Polling controls for a readonly follower.
 #[derive(Clone, Copy, Debug)]
 pub struct ReadOnlyConfig {
-    /// Delay between active-tail reads while the follower is caught up or
-    /// waiting for a complete frame to become visible on a replica quorum.
+    /// Delay before the next active-tail read when the previous one produced
+    /// no records, either because the follower is caught up or because no
+    /// complete frame is yet visible on a replica quorum.
     pub poll_interval: Duration,
+    /// Delay between manifest re-reads. The manifest changes only when the
+    /// writer rotates, seals, or truncates, so this is normally much larger
+    /// than `poll_interval`; polling it at the active-tail rate multiplies
+    /// regional reads without observing anything new.
+    pub manifest_poll_interval: Duration,
+    /// When set, a read that produced records is followed immediately by the
+    /// next read instead of by `poll_interval`. This keeps `poll_interval` out
+    /// of the commit-to-subscribe path while the writer is active, at the cost
+    /// of reading as fast as the replicas answer. Clear it to poll on a fixed
+    /// cadence regardless of whether records were delivered.
+    pub continuous_when_active: bool,
 }
 
 impl Default for ReadOnlyConfig {
     fn default() -> Self {
         Self {
             poll_interval: Duration::from_secs(1),
+            manifest_poll_interval: Duration::from_secs(1),
+            continuous_when_active: true,
         }
     }
 }
@@ -119,6 +133,11 @@ impl ReadOnlyConfig {
         if self.poll_interval == Duration::ZERO {
             return Err(Error::InvalidConfig(
                 "readonly poll_interval must be nonzero",
+            ));
+        }
+        if self.manifest_poll_interval == Duration::ZERO {
+            return Err(Error::InvalidConfig(
+                "readonly manifest_poll_interval must be nonzero",
             ));
         }
         Ok(())
@@ -153,6 +172,10 @@ struct ActiveReadState {
     replicas: Vec<Arc<dyn Replica>>,
     inflight: FuturesUnordered<BoxFuture<'static, ActiveReadResult>>,
     inflight_offsets: Vec<Option<i64>>,
+    /// Object generation each replica last reported for this active segment.
+    /// Generations are per-object, so they are comparable across polls of one
+    /// replica but never across replicas.
+    generations: Vec<Option<i64>>,
 }
 
 struct ActiveReadResult {
@@ -852,7 +875,7 @@ mod recovery {
             check_readonly_floor(manifest.record(), checkpoint)?;
             Ok(ReadOnlyFollower {
                 from: checkpoint,
-                inner: self.follow_readonly(manifest, checkpoint, config.poll_interval),
+                inner: self.follow_readonly(manifest, checkpoint, config),
             })
         }
 
@@ -860,14 +883,16 @@ mod recovery {
             &self,
             manifest: Manifest,
             checkpoint: WalSeqNo,
-            poll_interval: Duration,
+            config: ReadOnlyConfig,
         ) -> StartupReplayStream {
             let factories = self.factories.clone();
             let prefix = self.prefix.clone();
+            let metrics = Arc::clone(&self.metrics);
+            let poll_interval = config.poll_interval;
             async_stream::try_stream! {
                 let mut next = checkpoint;
                 let (mut manifest_updates, _manifest_task) =
-                    spawn_readonly_manifest_poller(manifest, poll_interval);
+                    spawn_readonly_manifest_poller(manifest, config.manifest_poll_interval);
                 let initial_record = { manifest_updates.borrow().clone() };
                 let mut record = initial_record?;
                 let mut active = None;
@@ -914,7 +939,7 @@ mod recovery {
                     });
                     if reset_active {
                         let object = format!("{prefix}/segments/{tail_id}");
-                        let replicas = replicas_for(&factories, &object);
+                        let replicas = timed_replicas_for(&factories, &object, &metrics);
                         let replica_count = replicas.len();
                         active = Some(ActiveReadState {
                             id: tail_id,
@@ -925,9 +950,11 @@ mod recovery {
                             replicas,
                             inflight: FuturesUnordered::new(),
                             inflight_offsets: vec![None; replica_count],
+                            generations: vec![None; replica_count],
                         });
                     }
                     let state = active.as_mut().expect("active state was initialized");
+                    let mut delivered = false;
                     match read_active_quorum(state).await {
                         Ok(frames) => {
                             for frame in frames {
@@ -948,6 +975,7 @@ mod recovery {
                                     payload: frame.payload,
                                 };
                                 next = wal_record.next_seqno();
+                                delivered = true;
                                 yield wal_record;
                             }
                         }
@@ -955,7 +983,13 @@ mod recovery {
                         Err(error) => Err(error)?,
                     }
 
-                    tokio::time::sleep(poll_interval).await;
+                    // A read that delivered records means the writer is active
+                    // and more bytes may already be visible, so the next read
+                    // starts immediately. `poll_interval` then bounds only how
+                    // often an idle follower re-reads the tail.
+                    if !(delivered && config.continuous_when_active) {
+                        tokio::time::sleep(poll_interval).await;
+                    }
                     let update = { manifest_updates.borrow_and_update().clone() };
                     record = update?;
                 }
@@ -2541,7 +2575,38 @@ async fn read_active_quorum(state: &mut ActiveReadState) -> Result<Vec<RecordFra
 
         observations[result.replica_index] = match result.read {
             Ok(read) => {
+                // A replica's own generation must not change while the
+                // follower is reading one active segment. If it does, the
+                // object was replaced underneath the session and this byte
+                // offset no longer denotes the same position, so the bytes
+                // must not be mixed with what was already published.
+                match state.generations[result.replica_index] {
+                    Some(seen) if seen != read.generation => {
+                        return Err(Error::InvalidSegmentData(format!(
+                            "active segment {} on zone {} moved from generation {seen} to {}",
+                            state.id, result.replica_index, read.generation
+                        )));
+                    }
+                    Some(_) => {}
+                    None => state.generations[result.replica_index] = Some(read.generation),
+                }
                 ActiveReadObservation::Records(RecordFrame::decode_complete_prefix(&read.bytes).0)
+            }
+            // A replica without a range-read implementation never becomes a
+            // usable observation, so treating it as a transient failure would
+            // poll forever without ever delivering an active record. Surface
+            // it instead of counting it towards a missing quorum.
+            Err(error) if error.code == TransportCode::Unimplemented => {
+                return Err(Error::Transport {
+                    // The trait default cannot know its own zone, so attribute
+                    // the failure to the replica this read was issued against.
+                    zone: result.replica_index,
+                    code: error.code,
+                    message: format!(
+                        "readonly following requires Replica::read_range: {}",
+                        error.message
+                    ),
+                });
             }
             Err(_) => ActiveReadObservation::Failed,
         };
@@ -3409,14 +3474,14 @@ fn readonly_segments(record: &ManifestRecord) -> Result<Vec<SegmentDescriptor>, 
 
 async fn refresh_readonly_manifest(
     manifest: &mut Manifest,
-    poll_interval: Duration,
+    retry_interval: Duration,
 ) -> Result<ManifestRecord, Error> {
     loop {
         match manifest.refreshed_existing_record().await {
             Ok(Some(record)) => return Ok(record),
             Ok(None) => return Err(Error::Uninitialized),
             Err(ProtocolError::ManifestUnavailable) => {
-                tokio::time::sleep(poll_interval).await;
+                tokio::time::sleep(retry_interval).await;
             }
             Err(error) => return Err(error.into()),
         }
@@ -3425,7 +3490,7 @@ async fn refresh_readonly_manifest(
 
 fn spawn_readonly_manifest_poller(
     mut manifest: Manifest,
-    poll_interval: Duration,
+    manifest_poll_interval: Duration,
 ) -> (
     tokio::sync::watch::Receiver<Result<ManifestRecord, Error>>,
     ReadOnlyManifestTask,
@@ -3433,8 +3498,8 @@ fn spawn_readonly_manifest_poller(
     let (updates, receiver) = tokio::sync::watch::channel(Ok(manifest.record().clone()));
     let task = tokio::spawn(async move {
         loop {
-            tokio::time::sleep(poll_interval).await;
-            let update = refresh_readonly_manifest(&mut manifest, poll_interval).await;
+            tokio::time::sleep(manifest_poll_interval).await;
+            let update = refresh_readonly_manifest(&mut manifest, manifest_poll_interval).await;
             let terminal = update.is_err();
             if updates.send(update).is_err() || terminal {
                 break;
@@ -3448,5 +3513,24 @@ fn replicas_for(factories: &[Arc<dyn ReplicaFactory>], object: &str) -> Vec<Arc<
     factories
         .iter()
         .map(|factory| factory.replica(object))
+        .collect()
+}
+
+/// [`replicas_for`] with RPC timing. The writer quorum path wraps its replicas
+/// inside `Writer`, which a readonly follower never constructs, so the
+/// follower's own reads are wrapped here to keep every provider RPC timed.
+fn timed_replicas_for(
+    factories: &[Arc<dyn ReplicaFactory>],
+    object: &str,
+    metrics: &Arc<Metrics>,
+) -> Vec<Arc<dyn Replica>> {
+    factories
+        .iter()
+        .map(|factory| {
+            Arc::new(crate::transport::TimedReplica::new(
+                factory.replica(object),
+                Arc::clone(metrics),
+            )) as Arc<dyn Replica>
+        })
         .collect()
 }

--- a/rust/client/src/segment.rs
+++ b/rust/client/src/segment.rs
@@ -5,9 +5,9 @@ use std::task::{Context, Poll};
 use std::time::Duration;
 
 use bytes::Bytes;
-use futures::future::join_all;
-use futures::stream::BoxStream;
-use futures::{Stream, StreamExt};
+use futures::future::{join_all, BoxFuture};
+use futures::stream::{BoxStream, FuturesUnordered};
+use futures::{FutureExt, Stream, StreamExt};
 use serde::{Deserialize, Serialize};
 
 use crate::error::Error;
@@ -24,7 +24,8 @@ use crate::protocol::{
 };
 use crate::record::RecordFrame;
 use crate::transport::{
-    ListedObject, Replica, ReplicaFactory, ReplicaSnapshot, TransportCode, TransportError,
+    ListedObject, Replica, ReplicaFactory, ReplicaRangeRead, ReplicaSnapshot, TransportCode,
+    TransportError,
 };
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -95,6 +96,89 @@ pub struct SegmentedVolume {
     prefix: String,
     client_config: ClientConfig,
     metrics: Arc<Metrics>,
+}
+
+/// Polling controls for a readonly follower.
+#[derive(Clone, Copy, Debug)]
+pub struct ReadOnlyConfig {
+    /// Delay between active-tail reads while the follower is caught up or
+    /// waiting for a complete frame to become visible on a replica quorum.
+    pub poll_interval: Duration,
+}
+
+impl Default for ReadOnlyConfig {
+    fn default() -> Self {
+        Self {
+            poll_interval: Duration::from_secs(1),
+        }
+    }
+}
+
+impl ReadOnlyConfig {
+    fn validate(&self) -> Result<(), Error> {
+        if self.poll_interval == Duration::ZERO {
+            return Err(Error::InvalidConfig(
+                "readonly poll_interval must be nonzero",
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Ordered stream of quorum-durable records observed from a live Chorus writer.
+///
+/// A readonly follower never claims a manifest epoch, opens an append stream,
+/// repairs data, truncates history, or otherwise coordinates with the writer.
+/// It polls the linearizable manifest, reads sealed directory entries, and
+/// observes the active appendable segment through bidirectional range reads.
+/// An active record is emitted only after identical complete frame bytes are
+/// visible on a strict majority, making the exposed prefix stable under the
+/// same quorum intersection used by recovery.
+///
+/// The stream remains pending while caught up and automatically observes later
+/// seals. If writer truncation advances beyond the follower's next checkpoint,
+/// it returns [`Error::ReadOnlyLagged`] instead of skipping missing history.
+pub struct ReadOnlyFollower {
+    /// Inclusive checkpoint supplied when the follower was opened.
+    pub from: WalSeqNo,
+    inner: StartupReplayStream,
+}
+
+struct ActiveReadState {
+    id: String,
+    epoch: u64,
+    base_record_index: u64,
+    byte_offset: i64,
+    skip_records: u64,
+    replicas: Vec<Arc<dyn Replica>>,
+    inflight: FuturesUnordered<BoxFuture<'static, ActiveReadResult>>,
+    inflight_offsets: Vec<Option<i64>>,
+}
+
+struct ActiveReadResult {
+    replica_index: usize,
+    byte_offset: i64,
+    read: Result<ReplicaRangeRead, TransportError>,
+}
+
+enum ActiveReadObservation {
+    Pending,
+    Failed,
+    Records(Vec<RecordFrame>),
+}
+
+enum ActiveReadDecision {
+    Pending,
+    Frames(Vec<RecordFrame>),
+    NoReadQuorum,
+}
+
+struct ReadOnlyManifestTask(tokio::task::JoinHandle<()>);
+
+impl Drop for ReadOnlyManifestTask {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
 }
 
 /// Wall-clock cost of the recovery phases that finish before the replay stream
@@ -293,6 +377,14 @@ impl Stream for Recovery {
             }
             Poll::Pending => Poll::Pending,
         }
+    }
+}
+
+impl Stream for ReadOnlyFollower {
+    type Item = Result<WalRecord, crate::Error>;
+
+    fn poll_next(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.inner.as_mut().poll_next(context)
     }
 }
 
@@ -717,6 +809,158 @@ mod recovery {
             )
             .await
             .map_err(Into::into)
+        }
+
+        async fn open_existing_manifest(&self) -> Result<Option<Manifest>, Error> {
+            Manifest::open_existing(
+                Arc::clone(&self.manifest_store),
+                self.client_config.clone(),
+                Arc::clone(&self.metrics),
+                self.factories.len(),
+                self.bucket_names.clone(),
+            )
+            .await
+            .map_err(Into::into)
+        }
+
+        /// Open a non-coordinating follower at `checkpoint`.
+        ///
+        /// The returned stream remains open after it catches up and polls for
+        /// newly quorum-visible records, including complete frames in the active
+        /// appendable segment.
+        ///
+        /// The application must retain WAL history until every follower has
+        /// durably advanced its own checkpoint. No reader registration is
+        /// performed; if truncation overtakes this checkpoint, the stream
+        /// returns [`crate::Error::ReadOnlyLagged`].
+        pub async fn open_readonly(&self, checkpoint: WalSeqNo) -> Result<ReadOnlyFollower, Error> {
+            self.open_readonly_with_config(checkpoint, ReadOnlyConfig::default())
+                .await
+        }
+
+        /// [`Self::open_readonly`] with explicit polling controls.
+        pub async fn open_readonly_with_config(
+            &self,
+            checkpoint: WalSeqNo,
+            config: ReadOnlyConfig,
+        ) -> Result<ReadOnlyFollower, Error> {
+            config.validate()?;
+            let manifest = self
+                .open_existing_manifest()
+                .await?
+                .ok_or(Error::Uninitialized)?;
+            check_readonly_floor(manifest.record(), checkpoint)?;
+            Ok(ReadOnlyFollower {
+                from: checkpoint,
+                inner: self.follow_readonly(manifest, checkpoint, config.poll_interval),
+            })
+        }
+
+        fn follow_readonly(
+            &self,
+            manifest: Manifest,
+            checkpoint: WalSeqNo,
+            poll_interval: Duration,
+        ) -> StartupReplayStream {
+            let factories = self.factories.clone();
+            let prefix = self.prefix.clone();
+            async_stream::try_stream! {
+                let mut next = checkpoint;
+                let (mut manifest_updates, _manifest_task) =
+                    spawn_readonly_manifest_poller(manifest, poll_interval);
+                let initial_record = { manifest_updates.borrow().clone() };
+                let mut record = initial_record?;
+                let mut active = None;
+                'follow: loop {
+                    check_readonly_floor(&record, next)?;
+                    let sealed_end = WalSeqNo::record(record.tail_base);
+                    let segments = readonly_segments(&record)?;
+                    for segment in segments {
+                        if segment.end_record_index < next.record_index
+                            || segment.base_record_index >= sealed_end.record_index
+                        {
+                            continue;
+                        }
+                        let object = format!("{prefix}/segments/{}", segment.id);
+                        let frames = match read_sealed_segment(&factories, &object, &segment).await {
+                            Ok(frames) => frames,
+                            Err(Error::NoReadQuorum) => {
+                                tokio::time::sleep(poll_interval).await;
+                                let update = { manifest_updates.borrow_and_update().clone() };
+                                record = update?;
+                                continue 'follow;
+                            }
+                            Err(error) => Err(error)?,
+                        };
+                        for wal_record in replay_records(&segment, &frames, next, sealed_end)? {
+                            next = wal_record.next_seqno();
+                            yield wal_record;
+                        }
+                    }
+                    if next.record_index < sealed_end.record_index {
+                        Err(Error::InvalidCatalog(format!(
+                            "readonly checkpoint {} is not covered through published end {}",
+                            next.record_index, sealed_end.record_index
+                        )))?;
+                    }
+
+                    let tail_id = record.tail_id.clone().ok_or_else(|| {
+                        Error::InvalidCatalog("claimed manifest is missing chorus.tail_id".into())
+                    })?;
+                    let reset_active = active.as_ref().is_none_or(|state: &ActiveReadState| {
+                        state.id != tail_id
+                            || state.epoch != record.epoch
+                            || state.base_record_index != record.tail_base
+                    });
+                    if reset_active {
+                        let object = format!("{prefix}/segments/{tail_id}");
+                        let replicas = replicas_for(&factories, &object);
+                        let replica_count = replicas.len();
+                        active = Some(ActiveReadState {
+                            id: tail_id,
+                            epoch: record.epoch,
+                            base_record_index: record.tail_base,
+                            byte_offset: 0,
+                            skip_records: next.record_index.saturating_sub(record.tail_base),
+                            replicas,
+                            inflight: FuturesUnordered::new(),
+                            inflight_offsets: vec![None; replica_count],
+                        });
+                    }
+                    let state = active.as_mut().expect("active state was initialized");
+                    match read_active_quorum(state).await {
+                        Ok(frames) => {
+                            for frame in frames {
+                                state.byte_offset = state
+                                    .byte_offset
+                                    .checked_add(frame.encoded_len()? as i64)
+                                    .ok_or_else(|| {
+                                        Error::InvalidSegmentData(
+                                            "active segment byte offset overflowed".into(),
+                                        )
+                                    })?;
+                                if state.skip_records > 0 {
+                                    state.skip_records -= 1;
+                                    continue;
+                                }
+                                let wal_record = WalRecord {
+                                    seqno: next,
+                                    payload: frame.payload,
+                                };
+                                next = wal_record.next_seqno();
+                                yield wal_record;
+                            }
+                        }
+                        Err(Error::NoReadQuorum) => {}
+                        Err(error) => Err(error)?,
+                    }
+
+                    tokio::time::sleep(poll_interval).await;
+                    let update = { manifest_updates.borrow_and_update().clone() };
+                    record = update?;
+                }
+            }
+            .boxed()
         }
 
         /// Fence and seal the prior writer, then prepare database startup replay.
@@ -2270,6 +2514,130 @@ async fn read_sealed_segment(
     Ok(records)
 }
 
+async fn read_active_quorum(state: &mut ActiveReadState) -> Result<Vec<RecordFrame>, Error> {
+    if state.replicas.is_empty() {
+        return Err(Error::InvalidCatalog(
+            "active segment has no configured replicas".into(),
+        ));
+    }
+    let byte_offset = state.byte_offset;
+    let quorum = majority(state.replicas.len());
+    let mut observations = (0..state.replicas.len())
+        .map(|_| ActiveReadObservation::Pending)
+        .collect::<Vec<_>>();
+    ensure_active_reads(state);
+
+    loop {
+        let Some(result) = state.inflight.next().await else {
+            return Err(Error::NoReadQuorum);
+        };
+        if state.inflight_offsets[result.replica_index] == Some(result.byte_offset) {
+            state.inflight_offsets[result.replica_index] = None;
+        }
+        if result.byte_offset != byte_offset {
+            start_active_read(state, result.replica_index);
+            continue;
+        }
+
+        observations[result.replica_index] = match result.read {
+            Ok(read) => {
+                ActiveReadObservation::Records(RecordFrame::decode_complete_prefix(&read.bytes).0)
+            }
+            Err(_) => ActiveReadObservation::Failed,
+        };
+        match active_read_decision(&observations, quorum)? {
+            ActiveReadDecision::Pending => {}
+            ActiveReadDecision::Frames(frames) => return Ok(frames),
+            ActiveReadDecision::NoReadQuorum => return Err(Error::NoReadQuorum),
+        }
+    }
+}
+
+fn ensure_active_reads(state: &mut ActiveReadState) {
+    for replica_index in 0..state.replicas.len() {
+        start_active_read(state, replica_index);
+    }
+}
+
+fn start_active_read(state: &mut ActiveReadState, replica_index: usize) {
+    if state.inflight_offsets[replica_index].is_some() {
+        return;
+    }
+    let byte_offset = state.byte_offset;
+    let replica = Arc::clone(&state.replicas[replica_index]);
+    state.inflight_offsets[replica_index] = Some(byte_offset);
+    let task = tokio::spawn(async move { replica.read_range(byte_offset).await });
+    state.inflight.push(
+        async move {
+            let read = task.await.unwrap_or_else(|error| {
+                Err(TransportError {
+                    zone: replica_index,
+                    code: TransportCode::Internal,
+                    message: format!("readonly active read task failed: {error}"),
+                })
+            });
+            ActiveReadResult {
+                replica_index,
+                byte_offset,
+                read,
+            }
+        }
+        .boxed(),
+    );
+}
+
+fn active_read_decision(
+    observations: &[ActiveReadObservation],
+    quorum: usize,
+) -> Result<ActiveReadDecision, Error> {
+    let successful = observations
+        .iter()
+        .filter(|observation| matches!(observation, ActiveReadObservation::Records(_)))
+        .count();
+    let pending = observations
+        .iter()
+        .filter(|observation| matches!(observation, ActiveReadObservation::Pending))
+        .count();
+    let mut accepted = Vec::new();
+    for record_index in 0usize.. {
+        let mut frame_votes: HashMap<Vec<u8>, (usize, RecordFrame)> = HashMap::new();
+        let mut end_votes = 0;
+        for observation in observations {
+            let ActiveReadObservation::Records(records) = observation else {
+                continue;
+            };
+            let Some(frame) = records.get(record_index) else {
+                end_votes += 1;
+                continue;
+            };
+            let encoded = frame.encode()?.to_vec();
+            frame_votes
+                .entry(encoded)
+                .and_modify(|(count, _)| *count += 1)
+                .or_insert_with(|| (1, frame.clone()));
+        }
+        if let Some((_, frame)) = frame_votes
+            .into_values()
+            .find(|(count, _)| *count >= quorum)
+        {
+            accepted.push(frame);
+            continue;
+        }
+        if !accepted.is_empty() || end_votes >= quorum {
+            return Ok(ActiveReadDecision::Frames(accepted));
+        }
+        if pending == 0 {
+            return if successful < quorum {
+                Ok(ActiveReadDecision::NoReadQuorum)
+            } else {
+                Ok(ActiveReadDecision::Frames(Vec::new()))
+            };
+        }
+        return Ok(ActiveReadDecision::Pending);
+    }
+    unreachable!("an active read decision always terminates at a finite prefix")
+}
+
 fn decoded_sealed_snapshot(
     snapshot: &ReplicaSnapshot,
     expected_records: u64,
@@ -2995,6 +3363,85 @@ fn replay_records(
         });
     }
     Ok(records)
+}
+
+fn check_readonly_floor(record: &ManifestRecord, next: WalSeqNo) -> Result<(), Error> {
+    if next.record_index < record.trunc {
+        return Err(Error::ReadOnlyLagged {
+            next,
+            truncation_floor: WalSeqNo::record(record.trunc),
+        });
+    }
+    Ok(())
+}
+
+fn readonly_segments(record: &ManifestRecord) -> Result<Vec<SegmentDescriptor>, Error> {
+    let mut segments = Vec::with_capacity(record.segments.len());
+    for (index, entry) in record.segments.iter().enumerate() {
+        let next_base = record
+            .segments
+            .get(index + 1)
+            .map_or(record.tail_base, |next| next.base);
+        let end_record_index = next_base.checked_sub(1).ok_or_else(|| {
+            Error::InvalidCatalog(format!(
+                "cannot derive an end for readonly segment {} at base {}",
+                entry.id, entry.base
+            ))
+        })?;
+        if end_record_index < entry.base {
+            return Err(Error::InvalidCatalog(format!(
+                "readonly segment {} at base {} extends past following base {next_base}",
+                entry.id, entry.base
+            )));
+        }
+        segments.push(SegmentDescriptor {
+            id: entry.id.clone(),
+            base_record_index: entry.base,
+            end_record_index,
+            crc32c: entry.crc32c,
+            copies: 0,
+            finalized_copies: 0,
+            seal_pending: record.seal_id.as_deref() == Some(entry.id.as_str()),
+        });
+    }
+    Ok(segments)
+}
+
+async fn refresh_readonly_manifest(
+    manifest: &mut Manifest,
+    poll_interval: Duration,
+) -> Result<ManifestRecord, Error> {
+    loop {
+        match manifest.refreshed_existing_record().await {
+            Ok(Some(record)) => return Ok(record),
+            Ok(None) => return Err(Error::Uninitialized),
+            Err(ProtocolError::ManifestUnavailable) => {
+                tokio::time::sleep(poll_interval).await;
+            }
+            Err(error) => return Err(error.into()),
+        }
+    }
+}
+
+fn spawn_readonly_manifest_poller(
+    mut manifest: Manifest,
+    poll_interval: Duration,
+) -> (
+    tokio::sync::watch::Receiver<Result<ManifestRecord, Error>>,
+    ReadOnlyManifestTask,
+) {
+    let (updates, receiver) = tokio::sync::watch::channel(Ok(manifest.record().clone()));
+    let task = tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(poll_interval).await;
+            let update = refresh_readonly_manifest(&mut manifest, poll_interval).await;
+            let terminal = update.is_err();
+            if updates.send(update).is_err() || terminal {
+                break;
+            }
+        }
+    });
+    (receiver, ReadOnlyManifestTask(task))
 }
 
 fn replicas_for(factories: &[Arc<dyn ReplicaFactory>], object: &str) -> Vec<Arc<dyn Replica>> {

--- a/rust/client/src/segment.rs
+++ b/rust/client/src/segment.rs
@@ -872,6 +872,10 @@ mod recovery {
                 .open_existing_manifest()
                 .await?
                 .ok_or(Error::Uninitialized)?;
+            // Manifest creation precedes the first claim that installs a tail.
+            if manifest.record().tail_id.is_none() {
+                return Err(Error::Uninitialized);
+            }
             check_readonly_floor(manifest.record(), checkpoint)?;
             Ok(ReadOnlyFollower {
                 from: checkpoint,
@@ -2575,22 +2579,15 @@ async fn read_active_quorum(state: &mut ActiveReadState) -> Result<Vec<RecordFra
 
         observations[result.replica_index] = match result.read {
             Ok(read) => {
-                // A replica's own generation must not change while the
-                // follower is reading one active segment. If it does, the
-                // object was replaced underneath the session and this byte
-                // offset no longer denotes the same position, so the bytes
-                // must not be mixed with what was already published.
-                match state.generations[result.replica_index] {
-                    Some(seen) if seen != read.generation => {
-                        return Err(Error::InvalidSegmentData(format!(
-                            "active segment {} on zone {} moved from generation {seen} to {}",
-                            state.id, result.replica_index, read.generation
-                        )));
-                    }
-                    Some(_) => {}
-                    None => state.generations[result.replica_index] = Some(read.generation),
+                // Repair can replace one copy without changing the majority's
+                // emitted prefix. Skip the changed copy for this poll and
+                // require majority byte agreement again on subsequent polls.
+                match state.generations[result.replica_index].replace(read.generation) {
+                    Some(seen) if seen != read.generation => ActiveReadObservation::Failed,
+                    _ => ActiveReadObservation::Records(
+                        RecordFrame::decode_complete_prefix(&read.bytes).0,
+                    ),
                 }
-                ActiveReadObservation::Records(RecordFrame::decode_complete_prefix(&read.bytes).0)
             }
             // A replica without a range-read implementation never becomes a
             // usable observation, so treating it as a transient failure would

--- a/rust/client/src/segment.rs
+++ b/rust/client/src/segment.rs
@@ -103,19 +103,16 @@ pub struct SegmentedVolume {
 pub struct ReadOnlyConfig {
     /// Delay before the next active-tail read when the previous one produced
     /// no records, either because the follower is caught up or because no
-    /// complete frame is yet visible on a replica quorum.
+    /// complete frame is yet visible on a replica quorum. A read that produced
+    /// records is followed immediately by the next read, so this bounds how
+    /// often an idle follower re-reads the tail and does not sit in the
+    /// delivery path while the writer is active.
     pub poll_interval: Duration,
     /// Delay between manifest re-reads. The manifest changes only when the
     /// writer rotates, seals, or truncates, so this is normally much larger
     /// than `poll_interval`; polling it at the active-tail rate multiplies
     /// regional reads without observing anything new.
     pub manifest_poll_interval: Duration,
-    /// When set, a read that produced records is followed immediately by the
-    /// next read instead of by `poll_interval`. This keeps `poll_interval` out
-    /// of the commit-to-subscribe path while the writer is active, at the cost
-    /// of reading as fast as the replicas answer. Clear it to poll on a fixed
-    /// cadence regardless of whether records were delivered.
-    pub continuous_when_active: bool,
 }
 
 impl Default for ReadOnlyConfig {
@@ -123,7 +120,6 @@ impl Default for ReadOnlyConfig {
         Self {
             poll_interval: Duration::from_secs(1),
             manifest_poll_interval: Duration::from_secs(1),
-            continuous_when_active: true,
         }
     }
 }
@@ -1014,9 +1010,9 @@ mod recovery {
 
                     // A read that delivered records means the writer is active
                     // and more bytes may already be visible, so the next read
-                    // starts immediately. `poll_interval` then bounds only how
-                    // often an idle follower re-reads the tail.
-                    if !(delivered && config.continuous_when_active) {
+                    // starts immediately. `poll_interval` bounds only how often
+                    // an idle follower re-reads the tail.
+                    if !delivered {
                         tokio::time::sleep(poll_interval).await;
                     }
                     let update = { manifest_updates.borrow_and_update().clone() };

--- a/rust/client/src/segment.rs
+++ b/rust/client/src/segment.rs
@@ -2554,27 +2554,39 @@ async fn read_sealed_segment(
         ));
     }
     let mut snapshots = Vec::new();
-    for replica in &replicas {
-        if let Ok(snapshot) = replica.snapshot().await {
-            if snapshot.crc32c == Some(expected_crc32c)
-                && crc32c::crc32c(&snapshot.bytes) == expected_crc32c
-            {
-                if let Some(records) = decoded_sealed_snapshot(
-                    &snapshot,
-                    expected_records,
-                    !accept_unfinalized_crc_match,
-                ) {
-                    return Ok(records);
+    // Failures that cannot clear by retrying, kept so a read that can never
+    // reach a quorum is reported instead of retried as a missing quorum.
+    let mut permanent = Vec::new();
+    for (zone, replica) in replicas.iter().enumerate() {
+        match replica.snapshot().await {
+            Ok(snapshot) => {
+                if snapshot.crc32c == Some(expected_crc32c)
+                    && crc32c::crc32c(&snapshot.bytes) == expected_crc32c
+                {
+                    if let Some(records) = decoded_sealed_snapshot(
+                        &snapshot,
+                        expected_records,
+                        !accept_unfinalized_crc_match,
+                    ) {
+                        return Ok(records);
+                    }
                 }
+                snapshots.push(snapshot);
             }
-            snapshots.push(snapshot);
+            Err(error) if permanent_read_code(error.code) => permanent.push((zone, error)),
+            Err(_) => {}
         }
     }
     snapshots
         .retain(|snapshot| decoded_sealed_snapshot(snapshot, expected_records, true).is_some());
     let quorum = majority(replicas.len());
     if snapshots.len() < quorum {
-        return Err(Error::NoReadQuorum);
+        return Err(quorum_impossible_error(
+            replicas.len(),
+            quorum,
+            permanent.iter().map(|(zone, error)| (*zone, error)),
+        )
+        .unwrap_or(Error::NoReadQuorum));
     }
     let records = canonical_prefix(&snapshots, quorum)?;
     if records.len() as u64 != expected_records {
@@ -2653,39 +2665,63 @@ async fn read_active_quorum(state: &mut ActiveReadState) -> Result<Vec<RecordFra
             ActiveReadDecision::Pending => {}
             ActiveReadDecision::Frames(frames) => return Ok(frames),
             ActiveReadDecision::NoReadQuorum => {
-                return Err(
-                    permanent_active_read_failure(&observations).unwrap_or(Error::NoReadQuorum)
-                );
+                return Err(permanent_active_read_failure(&observations, quorum)
+                    .unwrap_or(Error::NoReadQuorum));
             }
         }
     }
 }
 
-/// A missing read quorum caused by a failure that no amount of polling can
-/// clear. Authorization and request-shape errors are reported to the caller;
-/// everything else is treated as a replica that may answer on a later poll,
-/// including a copy that is absent, replaced, or still being written.
-fn permanent_active_read_failure(observations: &[ActiveReadObservation]) -> Option<Error> {
-    observations
-        .iter()
-        .enumerate()
-        .find_map(|(zone, observation)| match observation {
-            ActiveReadObservation::Failed(Some(error))
-                if matches!(
-                    error.code,
-                    TransportCode::PermissionDenied
-                        | TransportCode::Unauthenticated
-                        | TransportCode::InvalidArgument
-                ) =>
-            {
-                Some(Error::Transport {
-                    zone,
-                    code: error.code,
-                    message: error.message.clone(),
-                })
-            }
-            _ => None,
-        })
+/// Whether a read failure can never clear by polling the same replica again.
+/// Authorization and request-shape errors qualify. Everything else is a
+/// replica that may answer later, including a copy that is absent, replaced,
+/// or still being written.
+fn permanent_read_code(code: TransportCode) -> bool {
+    matches!(
+        code,
+        TransportCode::PermissionDenied
+            | TransportCode::Unauthenticated
+            | TransportCode::InvalidArgument
+    )
+}
+
+/// The error to report when permanent failures alone leave too few replicas
+/// to ever form a read quorum. One denied zone alongside a transient failure
+/// is not that: the remaining zones can still answer on a later poll, so the
+/// caller keeps retrying. Returns the first permanent failure by zone.
+fn quorum_impossible_error<'a>(
+    replica_count: usize,
+    quorum: usize,
+    permanent: impl Iterator<Item = (usize, &'a TransportError)>,
+) -> Option<Error> {
+    let permanent: Vec<_> = permanent.collect();
+    if replica_count.saturating_sub(permanent.len()) >= quorum {
+        return None;
+    }
+    permanent.first().map(|(zone, error)| Error::Transport {
+        zone: *zone,
+        code: error.code,
+        message: error.message.clone(),
+    })
+}
+
+fn permanent_active_read_failure(
+    observations: &[ActiveReadObservation],
+    quorum: usize,
+) -> Option<Error> {
+    quorum_impossible_error(
+        observations.len(),
+        quorum,
+        observations
+            .iter()
+            .enumerate()
+            .filter_map(|(zone, observation)| match observation {
+                ActiveReadObservation::Failed(Some(error)) if permanent_read_code(error.code) => {
+                    Some((zone, error))
+                }
+                _ => None,
+            }),
+    )
 }
 
 fn ensure_active_reads(state: &mut ActiveReadState) {

--- a/rust/client/src/segment.rs
+++ b/rust/client/src/segment.rs
@@ -172,6 +172,10 @@ struct ActiveReadState {
     replicas: Vec<Arc<dyn Replica>>,
     inflight: FuturesUnordered<BoxFuture<'static, ActiveReadResult>>,
     inflight_offsets: Vec<Option<i64>>,
+    /// Abort handle for each replica's outstanding read task. A read may
+    /// outlive the poll that started it, but not the active state that owns
+    /// it: dropping this state aborts the tasks instead of detaching them.
+    abort_handles: Vec<Option<tokio::task::AbortHandle>>,
     /// Object generation each replica last reported for this active segment.
     /// Generations are per-object, so they are comparable across polls of one
     /// replica but never across replicas.
@@ -186,8 +190,19 @@ struct ActiveReadResult {
 
 enum ActiveReadObservation {
     Pending,
-    Failed,
+    /// The read produced no usable bytes this poll. Carries the transport
+    /// error when there was one, so a failure that can never clear on its own
+    /// can be reported instead of retried as a missing quorum.
+    Failed(Option<TransportError>),
     Records(Vec<RecordFrame>),
+}
+
+impl Drop for ActiveReadState {
+    fn drop(&mut self) {
+        for handle in self.abort_handles.iter().flatten() {
+            handle.abort();
+        }
+    }
 }
 
 enum ActiveReadDecision {
@@ -911,7 +926,16 @@ mod recovery {
                             continue;
                         }
                         let object = format!("{prefix}/segments/{}", segment.id);
-                        let frames = match read_sealed_segment(&factories, &object, &segment).await {
+                        // Only the pending seal can be listed before its copies
+                        // are finalized; older entries were finalized or repaired.
+                        let frames = match read_sealed_segment(
+                            &factories,
+                            &object,
+                            &segment,
+                            segment.seal_pending,
+                        )
+                        .await
+                        {
                             Ok(frames) => frames,
                             Err(Error::NoReadQuorum) => {
                                 tokio::time::sleep(poll_interval).await;
@@ -954,6 +978,7 @@ mod recovery {
                             replicas,
                             inflight: FuturesUnordered::new(),
                             inflight_offsets: vec![None; replica_count],
+                            abort_handles: vec![None; replica_count],
                             generations: vec![None; replica_count],
                         });
                     }
@@ -1718,8 +1743,8 @@ mod recovery {
                 let records = read_sealed_segment(
                     &factories,
                     &format!("{prefix}/segments/{}", segment.id),
-                    &segment,
-                )
+                    &segment, false,
+)
                 .await?;
                 for record in replay_records(&segment, &records, from, end)? {
                     yield record;
@@ -2494,10 +2519,22 @@ pub(crate) fn segment_object(prefix: &str, id: &str) -> String {
     format!("{prefix}/segments/{id}")
 }
 
+/// Read one sealed segment's committed records.
+///
+/// `accept_unfinalized_crc_match` lets a copy that is not yet finalized serve
+/// the read when its full bytes match the CRC32C the manifest committed for
+/// this segment. The manifest lists a seal before the writer finalizes the
+/// object, and a readonly follower cannot enforce that finalization, so
+/// without this a follower that needs the pending seal waits on writer-side
+/// enforcement even though the committed bytes are already readable. The
+/// committed CRC32C identifies the exact bytes, so the match carries the same
+/// guarantee finalization does for content. Recovery and repair pass `false`
+/// and keep requiring finalized copies.
 async fn read_sealed_segment(
     factories: &[Arc<dyn ReplicaFactory>],
     object: &str,
     segment: &SegmentDescriptor,
+    accept_unfinalized_crc_match: bool,
 ) -> Result<Vec<RecordFrame>, Error> {
     let replicas = replicas_for(factories, object);
     let expected_end = segment.end_record_index;
@@ -2522,14 +2559,19 @@ async fn read_sealed_segment(
             if snapshot.crc32c == Some(expected_crc32c)
                 && crc32c::crc32c(&snapshot.bytes) == expected_crc32c
             {
-                if let Some(records) = decoded_sealed_snapshot(&snapshot, expected_records) {
+                if let Some(records) = decoded_sealed_snapshot(
+                    &snapshot,
+                    expected_records,
+                    !accept_unfinalized_crc_match,
+                ) {
                     return Ok(records);
                 }
             }
             snapshots.push(snapshot);
         }
     }
-    snapshots.retain(|snapshot| decoded_sealed_snapshot(snapshot, expected_records).is_some());
+    snapshots
+        .retain(|snapshot| decoded_sealed_snapshot(snapshot, expected_records, true).is_some());
     let quorum = majority(replicas.len());
     if snapshots.len() < quorum {
         return Err(Error::NoReadQuorum);
@@ -2583,7 +2625,7 @@ async fn read_active_quorum(state: &mut ActiveReadState) -> Result<Vec<RecordFra
                 // emitted prefix. Skip the changed copy for this poll and
                 // require majority byte agreement again on subsequent polls.
                 match state.generations[result.replica_index].replace(read.generation) {
-                    Some(seen) if seen != read.generation => ActiveReadObservation::Failed,
+                    Some(seen) if seen != read.generation => ActiveReadObservation::Failed(None),
                     _ => ActiveReadObservation::Records(
                         RecordFrame::decode_complete_prefix(&read.bytes).0,
                     ),
@@ -2605,14 +2647,45 @@ async fn read_active_quorum(state: &mut ActiveReadState) -> Result<Vec<RecordFra
                     ),
                 });
             }
-            Err(_) => ActiveReadObservation::Failed,
+            Err(error) => ActiveReadObservation::Failed(Some(error)),
         };
         match active_read_decision(&observations, quorum)? {
             ActiveReadDecision::Pending => {}
             ActiveReadDecision::Frames(frames) => return Ok(frames),
-            ActiveReadDecision::NoReadQuorum => return Err(Error::NoReadQuorum),
+            ActiveReadDecision::NoReadQuorum => {
+                return Err(
+                    permanent_active_read_failure(&observations).unwrap_or(Error::NoReadQuorum)
+                );
+            }
         }
     }
+}
+
+/// A missing read quorum caused by a failure that no amount of polling can
+/// clear. Authorization and request-shape errors are reported to the caller;
+/// everything else is treated as a replica that may answer on a later poll,
+/// including a copy that is absent, replaced, or still being written.
+fn permanent_active_read_failure(observations: &[ActiveReadObservation]) -> Option<Error> {
+    observations
+        .iter()
+        .enumerate()
+        .find_map(|(zone, observation)| match observation {
+            ActiveReadObservation::Failed(Some(error))
+                if matches!(
+                    error.code,
+                    TransportCode::PermissionDenied
+                        | TransportCode::Unauthenticated
+                        | TransportCode::InvalidArgument
+                ) =>
+            {
+                Some(Error::Transport {
+                    zone,
+                    code: error.code,
+                    message: error.message.clone(),
+                })
+            }
+            _ => None,
+        })
 }
 
 fn ensure_active_reads(state: &mut ActiveReadState) {
@@ -2629,6 +2702,7 @@ fn start_active_read(state: &mut ActiveReadState, replica_index: usize) {
     let replica = Arc::clone(&state.replicas[replica_index]);
     state.inflight_offsets[replica_index] = Some(byte_offset);
     let task = tokio::spawn(async move { replica.read_range(byte_offset).await });
+    state.abort_handles[replica_index] = Some(task.abort_handle());
     state.inflight.push(
         async move {
             let read = task.await.unwrap_or_else(|error| {
@@ -2703,8 +2777,9 @@ fn active_read_decision(
 fn decoded_sealed_snapshot(
     snapshot: &ReplicaSnapshot,
     expected_records: u64,
+    require_finalized: bool,
 ) -> Option<Vec<RecordFrame>> {
-    if !snapshot.finalized || !valid_format(&snapshot.metadata) {
+    if (require_finalized && !snapshot.finalized) || !valid_format(&snapshot.metadata) {
         return None;
     }
     let records = RecordFrame::decode_all(&snapshot.bytes).ok()?;
@@ -3323,7 +3398,7 @@ mod maintenance {
         object: &str,
         segment: &SegmentDescriptor,
     ) -> Result<Vec<u8>, Error> {
-        let records = read_sealed_segment(factories, object, segment).await?;
+        let records = read_sealed_segment(factories, object, segment, false).await?;
         let mut bytes = Vec::new();
         for record in records {
             bytes.extend_from_slice(&record.encode()?);

--- a/rust/client/src/transport.rs
+++ b/rust/client/src/transport.rs
@@ -56,6 +56,17 @@ pub struct ReplicaSnapshot {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+/// Byte range observed through the provider's bidirectional object-read path.
+pub struct ReplicaRangeRead {
+    /// Replica zone.
+    pub zone: usize,
+    /// Object generation returned with the read.
+    pub generation: i64,
+    /// Requested bytes currently visible at the open object's durable tail.
+    pub bytes: Vec<u8>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 /// State for one live zonal append stream, generation-bound once resumed.
 ///
 /// This is not a distributed ownership record. Logical writer identity comes
@@ -135,8 +146,9 @@ pub enum TransportCode {
     /// A precondition failed; on append/open this is a terminal writer fence,
     /// including both takeover revocation and finalized-object rejection.
     FailedPrecondition,
-    /// GCS redirected or aborted an operation. Rich zonal write redirects are
-    /// consumed by the gRPC transport before reaching protocol code.
+    /// GCS redirected or aborted an operation. Rich zonal bidirectional
+    /// redirects are consumed by the gRPC transport before reaching protocol
+    /// code.
     Aborted,
     /// Requested offset lies outside the provider's accepted range.
     OutOfRange,
@@ -226,6 +238,20 @@ pub trait Replica: Send + Sync {
     /// not derive `persisted_size` from provider metadata that hides appends.
     async fn snapshot(&self) -> Result<ReplicaSnapshot, TransportError>;
 
+    /// Read the currently visible suffix of an appendable object starting at
+    /// `offset` through the provider's bidirectional range-read API.
+    ///
+    /// The default keeps non-production test doubles source-compatible. A
+    /// readonly follower requires an implementation and treats this error as a
+    /// missing replica observation.
+    async fn read_range(&self, offset: i64) -> Result<ReplicaRangeRead, TransportError> {
+        Err(TransportError {
+            zone: 0,
+            code: TransportCode::Unimplemented,
+            message: format!("bidirectional range reads are unavailable at offset {offset}"),
+        })
+    }
+
     /// Read object metadata only, without the content read. Metadata reads are
     /// content-blind: they succeed even when the stored bytes are rotted, so
     /// repair can learn the generation of a copy whose `snapshot` fails with
@@ -268,9 +294,9 @@ pub trait Replica: Send + Sync {
 
     /// Re-learn the durable tail after a lane disturbance by resuming the
     /// append session (with its handle when available, else a guarded fresh
-    /// open). Never reads object bytes: the live service hides unfinalized
-    /// appendable content from reads, and `state_lookup` on the session is
-    /// the authoritative tail.
+    /// open). This remains the authoritative writer-lane tail even though
+    /// readonly followers can independently observe flushed bytes through
+    /// bidirectional reads.
     async fn resume_tail(&self, token: &mut AppendToken) -> Result<i64, TransportError>;
 
     /// Open a fresh, handle-free append stream guarded by the observed object.

--- a/rust/client/src/transport.rs
+++ b/rust/client/src/transport.rs
@@ -60,7 +60,11 @@ pub struct ReplicaSnapshot {
 pub struct ReplicaRangeRead {
     /// Replica zone.
     pub zone: usize,
-    /// Object generation returned with the read.
+    /// Generation of the object this read's session is bound to. Providers
+    /// report object metadata when a bidirectional read session opens rather
+    /// than on every range, so this is the generation the session was opened
+    /// against, not a fresh observation per range. It is comparable across
+    /// reads from one replica; generations of different zones are unrelated.
     pub generation: i64,
     /// Requested bytes currently visible at the open object's durable tail.
     pub bytes: Vec<u8>,
@@ -242,8 +246,9 @@ pub trait Replica: Send + Sync {
     /// `offset` through the provider's bidirectional range-read API.
     ///
     /// The default keeps non-production test doubles source-compatible. A
-    /// readonly follower requires an implementation and treats this error as a
-    /// missing replica observation.
+    /// readonly follower requires an implementation and fails with this error
+    /// rather than polling a replica that can never answer. The default cannot
+    /// know its own zone, so the caller attributes the failure.
     async fn read_range(&self, offset: i64) -> Result<ReplicaRangeRead, TransportError> {
         Err(TransportError {
             zone: 0,
@@ -466,6 +471,10 @@ impl Replica for TimedReplica {
 
     async fn stat(&self) -> Result<ReplicaSnapshot, TransportError> {
         timed_rpc!(self, stat, self.inner.stat())
+    }
+
+    async fn read_range(&self, offset: i64) -> Result<ReplicaRangeRead, TransportError> {
+        timed_rpc!(self, read_range, self.inner.read_range(offset))
     }
 
     async fn create_appendable(

--- a/rust/client/tests/grpc_integration.rs
+++ b/rust/client/tests/grpc_integration.rs
@@ -144,6 +144,7 @@ impl MetricsRecorder for Registrations {
                     "op",
                     "snapshot"
                         | "stat"
+                        | "read_range"
                         | "create_appendable"
                         | "create_append_session"
                         | "resume_tail"

--- a/rust/dst/src/sim_transport.rs
+++ b/rust/dst/src/sim_transport.rs
@@ -29,8 +29,8 @@ use chorus_fake_gcs::{FakeGcs, SimSessionOpen};
 use tonic::{Code, Request, Status};
 
 use chorus_client::{
-    AppendToken, LaneDurableChange, ListedObject, Replica, ReplicaFactory, ReplicaSnapshot,
-    TransportCode, TransportError,
+    AppendToken, LaneDurableChange, ListedObject, Replica, ReplicaFactory, ReplicaRangeRead,
+    ReplicaSnapshot, TransportCode, TransportError,
 };
 
 fn map_code(status: &Status) -> TransportCode {
@@ -332,6 +332,19 @@ impl Replica for InMemoryReplica {
             .await
             .map_err(|status| status_err(self.zone, &status))?;
         Ok(snapshot_from_object(self.zone, object, bytes))
+    }
+
+    async fn read_range(&self, offset: i64) -> Result<ReplicaRangeRead, TransportError> {
+        let (generation, bytes) = self
+            .fake
+            .sim_bidi_read_bytes(&self.bucket, &self.object, offset)
+            .await
+            .map_err(|status| status_err(self.zone, &status))?;
+        Ok(ReplicaRangeRead {
+            zone: self.zone,
+            generation,
+            bytes,
+        })
     }
 
     async fn create_appendable(

--- a/rust/fake-gcs/proto/storage_subset.proto
+++ b/rust/fake-gcs/proto/storage_subset.proto
@@ -93,6 +93,45 @@ message ReadObjectResponse {
   optional Object metadata = 4;
 }
 
+message BidiReadHandle {
+  bytes handle = 1;
+}
+
+message BidiReadObjectSpec {
+  string bucket = 1;
+  string object = 2;
+  int64 generation = 3;
+  optional int64 if_generation_match = 4;
+  optional int64 if_generation_not_match = 5;
+  optional int64 if_metageneration_match = 6;
+  optional int64 if_metageneration_not_match = 7;
+  optional BidiReadHandle read_handle = 13;
+  optional string routing_token = 14;
+}
+
+message ReadRange {
+  int64 read_offset = 1;
+  int64 read_length = 2;
+  int64 read_id = 3;
+}
+
+message BidiReadObjectRequest {
+  optional BidiReadObjectSpec read_object_spec = 1;
+  repeated ReadRange read_ranges = 8;
+}
+
+message ObjectRangeData {
+  optional ChecksummedData checksummed_data = 1;
+  optional ReadRange read_range = 2;
+  bool range_end = 3;
+}
+
+message BidiReadObjectResponse {
+  repeated ObjectRangeData object_data_ranges = 6;
+  optional Object metadata = 4;
+  optional BidiReadHandle read_handle = 7;
+}
+
 message UpdateObjectRequest {
   optional Object object = 1;
   optional int64 if_generation_match = 2;
@@ -171,38 +210,4 @@ message BidiWriteObjectResponse {
     Object resource = 2;
   }
   optional BidiWriteHandle write_handle = 3;
-}
-
-// Field numbers match google.storage.v2 exactly: the client encodes with the
-// real generated types, so the fake must decode the same wire format.
-message BidiReadObjectSpec {
-  string bucket = 1;
-  string object = 2;
-  int64 generation = 3;
-  optional int64 if_generation_match = 4;
-  optional int64 if_generation_not_match = 5;
-  optional int64 if_metageneration_match = 6;
-  optional int64 if_metageneration_not_match = 7;
-}
-
-message ReadRange {
-  int64 read_offset = 1;
-  int64 read_length = 2;
-  int64 read_id = 3;
-}
-
-message BidiReadObjectRequest {
-  BidiReadObjectSpec read_object_spec = 1;
-  repeated ReadRange read_ranges = 8;
-}
-
-message ObjectRangeData {
-  ChecksummedData checksummed_data = 1;
-  ReadRange read_range = 2;
-  bool range_end = 3;
-}
-
-message BidiReadObjectResponse {
-  Object metadata = 4;
-  repeated ObjectRangeData object_data_ranges = 6;
 }

--- a/rust/fake-gcs/src/lib.rs
+++ b/rust/fake-gcs/src/lib.rs
@@ -20,9 +20,10 @@ use proto::bidi_write_object_request::{Data, FirstMessage};
 use proto::bidi_write_object_response::WriteStatus;
 use proto::storage_server::{Storage, StorageServer};
 use proto::{
-    BidiReadObjectRequest, BidiReadObjectResponse, BidiWriteObjectRequest, BidiWriteObjectResponse,
-    DeleteObjectRequest, Empty, GetObjectRequest, ListObjectsRequest, ListObjectsResponse, Object,
-    ReadObjectRequest, ReadObjectResponse, Timestamp, UpdateObjectRequest,
+    BidiReadObjectRequest, BidiReadObjectResponse, BidiReadObjectSpec, BidiWriteObjectRequest,
+    BidiWriteObjectResponse, DeleteObjectRequest, Empty, GetObjectRequest, ListObjectsRequest,
+    ListObjectsResponse, Object, ObjectRangeData, ReadObjectRequest, ReadObjectResponse, ReadRange,
+    Timestamp, UpdateObjectRequest,
 };
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -30,7 +31,12 @@ pub enum Operation {
     Delete,
     Get,
     List,
+    /// One content range served, whether over `ReadObject` or as one range
+    /// message on a `BidiReadObject` stream.
     Read,
+    /// One `BidiReadObject` stream opened. A follower polling an active object
+    /// opens one stream per replica and then charges `Read` per poll.
+    BidiRead,
     Update,
     BidiWrite,
     BidiCreate,
@@ -56,6 +62,7 @@ impl Operation {
             Self::BidiAppendFlush => 9,
             Self::BidiFinalize => 10,
             Self::BidiGuardedReplace => 11,
+            Self::BidiRead => 12,
         }
     }
 }
@@ -690,6 +697,74 @@ impl FakeGcs {
         Ok(())
     }
 
+    async fn bidi_read_metadata(&self, spec: &BidiReadObjectSpec) -> Result<Object, Status> {
+        let state = self.inner.lock().await;
+        let object = state
+            .objects
+            .get(&object_key(&spec.bucket, &spec.object))
+            .ok_or_else(|| Status::not_found("object"))?;
+        check_bidi_read_preconditions(object, spec)?;
+        if crc32c::crc32c(&object.bytes) != object.integrity_crc32c {
+            return Err(Status::data_loss("stored object CRC32C mismatch"));
+        }
+        Ok(object.to_session_proto())
+    }
+
+    async fn bidi_read_range(
+        &self,
+        spec: &BidiReadObjectSpec,
+        range: ReadRange,
+        include_metadata: bool,
+    ) -> Result<BidiReadObjectResponse, Status> {
+        // Every range message is its own round trip, so it is charged as a
+        // content read. `Operation::BidiRead` covers opening the stream.
+        self.before(Operation::Read).await?;
+        if range.read_length < 0 {
+            return Err(Status::out_of_range("negative read length"));
+        }
+        let state = self.inner.lock().await;
+        let object = state
+            .objects
+            .get(&object_key(&spec.bucket, &spec.object))
+            .ok_or_else(|| Status::not_found("object"))?;
+        check_bidi_read_preconditions(object, spec)?;
+        if crc32c::crc32c(&object.bytes) != object.integrity_crc32c {
+            return Err(Status::data_loss("stored object CRC32C mismatch"));
+        }
+        let len = object.bytes.len();
+        let start = if range.read_offset < 0 {
+            len.saturating_sub(range.read_offset.unsigned_abs() as usize)
+        } else {
+            usize::try_from(range.read_offset).unwrap_or(usize::MAX)
+        };
+        if start > len {
+            return Err(Status::out_of_range("read offset"));
+        }
+        let limit = if range.read_length == 0 {
+            len - start
+        } else {
+            usize::try_from(range.read_length).unwrap_or(usize::MAX)
+        };
+        let end = len.min(start.saturating_add(limit));
+        let content = object.bytes[start..end].to_vec();
+        Ok(BidiReadObjectResponse {
+            object_data_ranges: vec![ObjectRangeData {
+                checksummed_data: Some(proto::ChecksummedData {
+                    crc32c: Some(crc32c::crc32c(&content)),
+                    content,
+                }),
+                read_range: Some(ReadRange {
+                    read_offset: start as i64,
+                    read_length: (end - start) as i64,
+                    read_id: range.read_id,
+                }),
+                range_end: true,
+            }],
+            metadata: include_metadata.then(|| object.to_session_proto()),
+            read_handle: None,
+        })
+    }
+
     /// Fault-inject and compute the operation latency WITHOUT sleeping.
     ///
     /// `before` is exactly this followed by [`Self::sleep_charged`]. The
@@ -1104,6 +1179,33 @@ impl FakeGcs {
         Ok(stored.bytes.clone())
     }
 
+    /// Read the currently visible suffix of an appendable object through the
+    /// in-process equivalent of `BidiReadObject`.
+    pub async fn sim_bidi_read_bytes(
+        &self,
+        bucket: &str,
+        object: &str,
+        offset: i64,
+    ) -> Result<(i64, Vec<u8>), Status> {
+        self.before(Operation::Read).await?;
+        if offset < 0 {
+            return Err(Status::invalid_argument("negative read offset"));
+        }
+        let state = self.inner.lock().await;
+        let stored = state
+            .objects
+            .get(&object_key(bucket, object))
+            .ok_or_else(|| Status::not_found("object"))?;
+        if crc32c::crc32c(&stored.bytes) != stored.integrity_crc32c {
+            return Err(Status::data_loss("stored object CRC32C mismatch"));
+        }
+        let start = usize::try_from(offset).unwrap_or(usize::MAX);
+        if start > stored.bytes.len() {
+            return Err(Status::out_of_range("read offset"));
+        }
+        Ok((stored.generation, stored.bytes[start..].to_vec()))
+    }
+
     async fn close_stream_after_response(&self, operation: Operation) -> Result<(), Status> {
         let mut state = self.inner.lock().await;
         let Some(code) = state
@@ -1225,8 +1327,8 @@ impl<T> Drop for TaskResponseStream<T> {
 #[tonic::async_trait]
 impl Storage for FakeGcs {
     type ReadObjectStream = ResponseStream<ReadObjectResponse>;
-    type BidiWriteObjectStream = ResponseStream<BidiWriteObjectResponse>;
     type BidiReadObjectStream = ResponseStream<BidiReadObjectResponse>;
+    type BidiWriteObjectStream = ResponseStream<BidiWriteObjectResponse>;
 
     async fn delete_object(
         &self,
@@ -1384,72 +1486,96 @@ impl Storage for FakeGcs {
     /// reads over this API because `ReadObject` stalls opening its stream
     /// against real appendable objects, so the fake has to implement it or the
     /// recovery tests exercise a path production no longer takes.
+    ///
+    /// The stream stays open across messages: the first message carries the
+    /// object spec, and each later message asks for another range on the same
+    /// object. Readonly followers poll an active object over one such stream
+    /// per zone.
     async fn bidi_read_object(
         &self,
         request: Request<tonic::Streaming<BidiReadObjectRequest>>,
     ) -> Result<Response<Self::BidiReadObjectStream>, Status> {
-        self.before(Operation::Read).await?;
-        let mut inbound = request.into_inner();
-        let first = inbound
+        self.before(Operation::BidiRead).await?;
+        let mut requests = request.into_inner();
+        let first = requests
             .message()
             .await?
-            .ok_or_else(|| Status::invalid_argument("empty bidi read stream"))?;
+            .ok_or_else(|| Status::invalid_argument("missing BidiReadObject request"))?;
         let spec = first
             .read_object_spec
-            .ok_or_else(|| Status::invalid_argument("first message must set read_object_spec"))?;
-        let state = self.inner.lock().await;
-        let object = state
-            .objects
-            .get(&object_key(&spec.bucket, &spec.object))
-            .ok_or_else(|| Status::not_found("object"))?;
-        check_name(object, &spec.bucket, &spec.object)?;
-        if crc32c::crc32c(&object.bytes) != object.integrity_crc32c {
-            return Err(Status::data_loss("stored object CRC32C mismatch"));
-        }
-        if spec.generation != 0 && spec.generation != object.generation {
-            return Err(Status::failed_precondition("generation mismatch"));
-        }
-        if spec
-            .if_generation_match
-            .is_some_and(|value| value != object.generation)
-        {
-            return Err(Status::failed_precondition("generation mismatch"));
-        }
-        if spec
-            .if_metageneration_match
-            .is_some_and(|value| value != object.metageneration)
-        {
-            return Err(Status::failed_precondition("metageneration mismatch"));
-        }
-        // A zero offset and length requests the whole object, which is the only
-        // shape chorus asks for.
-        let range = first.read_ranges.first().copied().unwrap_or_default();
-        let start = usize::try_from(range.read_offset.max(0)).unwrap_or(usize::MAX);
-        if start > object.bytes.len() {
-            return Err(Status::out_of_range("read offset"));
-        }
-        let limit = if range.read_length <= 0 {
-            object.bytes.len() - start
-        } else {
-            usize::try_from(range.read_length).unwrap_or(usize::MAX)
-        };
-        let end = object.bytes.len().min(start.saturating_add(limit));
-        let response = BidiReadObjectResponse {
-            object_data_ranges: vec![proto::ObjectRangeData {
-                checksummed_data: Some(proto::ChecksummedData {
-                    content: object.bytes[start..end].to_vec(),
-                    crc32c: Some(crc32c::crc32c(&object.bytes[start..end])),
-                }),
-                read_range: Some(proto::ReadRange {
-                    read_offset: range.read_offset,
-                    read_length: (end - start) as i64,
-                    read_id: range.read_id,
-                }),
-                range_end: true,
-            }],
-            metadata: Some(object.to_proto()),
-        };
-        Ok(Response::new(Box::pin(tokio_stream::iter([Ok(response)]))))
+            .clone()
+            .ok_or_else(|| Status::invalid_argument("first read request requires object spec"))?;
+        let (tx, rx) = tokio::sync::mpsc::channel(8);
+        let service = self.clone();
+        let task = tokio::spawn(async move {
+            let mut next = Some(first);
+            let mut include_metadata = true;
+            loop {
+                let request = match next.take() {
+                    Some(request) => request,
+                    None => match requests.message().await {
+                        Ok(Some(request)) => request,
+                        Ok(None) => break,
+                        Err(status) => {
+                            let _ = tx.send(Err(status)).await;
+                            break;
+                        }
+                    },
+                };
+                if request.read_object_spec.is_some() && !include_metadata {
+                    let _ = tx
+                        .send(Err(Status::invalid_argument(
+                            "object spec is only valid in the first read request",
+                        )))
+                        .await;
+                    break;
+                }
+                if request.read_ranges.is_empty() && include_metadata {
+                    match service.bidi_read_metadata(&spec).await {
+                        Ok(metadata) => {
+                            if tx
+                                .send(Ok(BidiReadObjectResponse {
+                                    object_data_ranges: Vec::new(),
+                                    metadata: Some(metadata),
+                                    read_handle: None,
+                                }))
+                                .await
+                                .is_err()
+                            {
+                                break;
+                            }
+                        }
+                        Err(status) => {
+                            let _ = tx.send(Err(status)).await;
+                            break;
+                        }
+                    }
+                    include_metadata = false;
+                    continue;
+                }
+                for range in request.read_ranges {
+                    match service
+                        .bidi_read_range(&spec, range, include_metadata)
+                        .await
+                    {
+                        Ok(response) => {
+                            include_metadata = false;
+                            if tx.send(Ok(response)).await.is_err() {
+                                return;
+                            }
+                        }
+                        Err(status) => {
+                            let _ = tx.send(Err(status)).await;
+                            return;
+                        }
+                    }
+                }
+            }
+        });
+        Ok(Response::new(Box::pin(TaskResponseStream {
+            inner: ReceiverStream::new(rx),
+            task,
+        })))
     }
 
     async fn update_object(
@@ -2027,6 +2153,32 @@ fn check_name(object: &StoredObject, bucket: &str, name: &str) -> Result<(), Sta
     }
 }
 
+fn check_bidi_read_preconditions(
+    object: &StoredObject,
+    spec: &BidiReadObjectSpec,
+) -> Result<(), Status> {
+    check_name(object, &spec.bucket, &spec.object)?;
+    if spec.generation != 0 && spec.generation != object.generation {
+        return Err(Status::failed_precondition("generation mismatch"));
+    }
+    if spec
+        .if_generation_match
+        .is_some_and(|value| value != object.generation)
+        || spec
+            .if_generation_not_match
+            .is_some_and(|value| value == object.generation)
+        || spec
+            .if_metageneration_match
+            .is_some_and(|value| value != object.metageneration)
+        || spec
+            .if_metageneration_not_match
+            .is_some_and(|value| value == object.metageneration)
+    {
+        return Err(Status::failed_precondition("read precondition mismatch"));
+    }
+    Ok(())
+}
+
 fn object_key(bucket: &str, object: &str) -> String {
     format!("{bucket}\0{object}")
 }
@@ -2060,8 +2212,9 @@ impl StoredObject {
             bucket: self.bucket.clone(),
             generation: self.generation,
             metageneration: self.metageneration,
-            // Live GCS does not expose flushed appendable bytes through
-            // GetObject.size until the object is finalized.
+            // Keep metadata tail-blind in the fake so protocol code cannot
+            // accidentally substitute GetObject.size for write-session
+            // persisted_size. Live visibility has varied over time.
             size: if self.finalized {
                 self.bytes.len() as i64
             } else {

--- a/rust/fake-gcs/src/lib.rs
+++ b/rust/fake-gcs/src/lib.rs
@@ -716,8 +716,10 @@ impl FakeGcs {
         range: ReadRange,
         include_metadata: bool,
     ) -> Result<BidiReadObjectResponse, Status> {
-        // Every range message is its own round trip, so it is charged as a
-        // content read. `Operation::BidiRead` covers opening the stream.
+        // Each range charges Read for counting, latency, and fault injection,
+        // preserving recovery's one Read per full-object read. The first gRPC
+        // range also incurs BidiRead at stream open; later ranges and the
+        // in-process path incur only Read.
         self.before(Operation::Read).await?;
         if range.read_length < 0 {
             return Err(Status::out_of_range("negative read length"));
@@ -1181,6 +1183,9 @@ impl FakeGcs {
 
     /// Read the currently visible suffix of an appendable object through the
     /// in-process equivalent of `BidiReadObject`.
+    /// Each read reports the current generation instead of retaining a session
+    /// generation. Followers discard a changed-generation observation, so both
+    /// this path and a gRPC session reopened after replacement are supported.
     pub async fn sim_bidi_read_bytes(
         &self,
         bucket: &str,
@@ -1495,16 +1500,25 @@ impl Storage for FakeGcs {
         &self,
         request: Request<tonic::Streaming<BidiReadObjectRequest>>,
     ) -> Result<Response<Self::BidiReadObjectStream>, Status> {
+        // Opening a gRPC stream charges BidiRead for counting, latency, and
+        // fault injection in addition to the first range's Read charge. Later
+        // ranges and the in-process path incur only the per-range Read charge.
         self.before(Operation::BidiRead).await?;
         let mut requests = request.into_inner();
         let first = requests
             .message()
             .await?
             .ok_or_else(|| Status::invalid_argument("missing BidiReadObject request"))?;
-        let spec = first
+        let mut spec = first
             .read_object_spec
             .clone()
             .ok_or_else(|| Status::invalid_argument("first read request requires object spec"))?;
+        if spec.generation == 0 {
+            // Bind every range to the opening generation. The fake stores only
+            // the current object, so replacement fails the existing generation
+            // precondition and requires the client to open a new session.
+            spec.generation = self.bidi_read_metadata(&spec).await?.generation;
+        }
         let (tx, rx) = tokio::sync::mpsc::channel(8);
         let service = self.clone();
         let task = tokio::spawn(async move {
@@ -2960,6 +2974,93 @@ mod tests {
         let error = rejected.message().await.unwrap_err();
         assert_eq!(error.code(), Code::FailedPrecondition);
         assert_eq!(error.message(), "The object has already been finalized.");
+    }
+
+    #[tokio::test]
+    async fn bidi_read_session_rejects_replacement_and_reopens_with_new_generation() {
+        let server = FakeGcs::default().start().await.unwrap();
+        let mut client = StorageClient::connect(server.endpoint.clone())
+            .await
+            .unwrap();
+        let bucket = "projects/_/buckets/zone-0";
+        let name = "replaced-during-read";
+        let mut create = create_request(bucket, name);
+        create.data = request(0, b"old", crc32c::crc32c(b"old")).data;
+        let mut writes = client
+            .bidi_write_object(tokio_stream::iter([create]))
+            .await
+            .unwrap()
+            .into_inner();
+        writes.message().await.unwrap().unwrap();
+
+        let first = BidiReadObjectRequest {
+            read_object_spec: Some(BidiReadObjectSpec {
+                bucket: bucket.into(),
+                object: name.into(),
+                ..Default::default()
+            }),
+            read_ranges: vec![ReadRange {
+                read_length: 3,
+                ..Default::default()
+            }],
+        };
+        let (tx, rx) = tokio::sync::mpsc::channel(4);
+        tx.send(first.clone()).await.unwrap();
+        let mut reads = client
+            .bidi_read_object(ReceiverStream::new(rx))
+            .await
+            .unwrap()
+            .into_inner();
+        let opened = reads.message().await.unwrap().unwrap();
+        let old_generation = opened.metadata.unwrap().generation;
+        assert_eq!(
+            opened.object_data_ranges[0]
+                .checksummed_data
+                .as_ref()
+                .unwrap()
+                .content,
+            b"old"
+        );
+
+        let mut replace = create_request(bucket, name);
+        let Some(FirstMessage::WriteObjectSpec(spec)) = replace.first_message.as_mut() else {
+            unreachable!();
+        };
+        spec.if_generation_match = Some(old_generation);
+        replace.data = request(0, b"new", crc32c::crc32c(b"new")).data;
+        let mut replacements = client
+            .bidi_write_object(tokio_stream::iter([replace]))
+            .await
+            .unwrap()
+            .into_inner();
+        replacements.message().await.unwrap().unwrap();
+        tx.send(BidiReadObjectRequest {
+            read_object_spec: None,
+            read_ranges: first.read_ranges.clone(),
+        })
+        .await
+        .unwrap();
+        let status = reads.message().await.unwrap_err();
+        assert_eq!(status.code(), Code::FailedPrecondition);
+        assert_eq!(status.message(), "generation mismatch");
+
+        let mut reopened = client
+            .bidi_read_object(tokio_stream::iter([first]))
+            .await
+            .unwrap()
+            .into_inner();
+        let response = reopened.message().await.unwrap().unwrap();
+        assert_ne!(response.metadata.unwrap().generation, old_generation);
+        assert_eq!(
+            response.object_data_ranges[0]
+                .checksummed_data
+                .as_ref()
+                .unwrap()
+                .content,
+            b"new"
+        );
+        assert_eq!(server.service.operation_count(Operation::BidiRead).await, 2);
+        assert_eq!(server.service.operation_count(Operation::Read).await, 3);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Add a readonly follower API for independent read-replica processes. The follower opens an existing WAL at a durable checkpoint, replays sealed history, and tails the active appendable segment without claiming a writer epoch, opening append streams, repairing data, or registering with the writer.

Active-tail reads use persistent `BidiReadObject` sessions: one stream per zone for the current active object, one range request per zone per poll, and publication as soon as the first strict majority returns identical complete frame bytes. Manifest refresh runs in parallel on its own interval so a regional manifest read neither gates active-tail delivery nor inherits the tail's request rate.

## Safety

A single replica is not enough for non-coordinating reads because it can expose bytes that never reached a future recovery quorum. The follower emits only complete frames whose encoded bytes match on a strict majority, preserving the same quorum-intersection safety argument used by recovery.

This PR also adds P model/proof coverage for the readonly role, including cursor/prefix consistency, majority support, snapshot bounds, lag handling, and the property that readonly followers never coordinate with the writer.

## Polling

`ReadOnlyConfig` has two controls:

- `poll_interval` applies only after a read that delivered no records. A read that delivered is followed immediately by the next read, so this bounds how often an idle follower re-reads the tail and never sits in the delivery path while the writer is active.
- `manifest_poll_interval` paces manifest re-reads independently. The manifest changes only on rotation, seal, or truncation, so it is normally much larger than `poll_interval`; it bounds how long a rotation goes unobserved.

The follower's original loop slept `poll_interval` after every read, which put the interval directly in the commit-to-subscribe path. The benchmark tables below keep that behavior as the "fixed cadence" column for comparison; it was measured through a `--fixed-poll-cadence` benchmark flag that has since been removed, since it lost in every cell.

## Third review pass

- A follower whose cursor needs the **pending seal** no longer waits on writer-side finalization: a not-yet-finalized copy whose full bytes match the manifest's committed CRC32C serves the read. Recovery and repair keep requiring finalized copies. The test parks finalization and confirms the follower still reads the seal; without the relaxation the same test times out.
- **Denied reads fail fast.** `PermissionDenied`, `Unauthenticated`, and `InvalidArgument` on the active tail are returned as `Error::Transport` instead of being retried forever as a missing quorum. `NotFound` and friends stay transient (absent, replaced, or still-open copies).
- **Abandoned read tasks are cancelled** when their active state is dropped, instead of detached until timeout.
- `ReadonlyFollowerSafety` accepts sealed replay of a record **recovery retained** but the writer never committed, and counts `eCanonicalPersisted` writebacks as support. The active-tail driver now replays the retained record through a second follower; removing the new clause fails that test at the expected assertion.

## Fourth review pass

- The fail-fast rule for denied reads is now **quorum-aware**: a permanent failure terminates the follower only when permanent failures alone leave fewer replicas than a read quorum. One denied zone next to a transient failure keeps polling, since the remaining zones can still answer. Test: one zone denied and a second zone failing transiently on the first read, so that poll misses its quorum with the denial present; the follower keeps polling and delivers. Under the previous rule that poll returned the denial.
- The same rule now applies to **sealed-history replay**, which previously dropped every `snapshot()` error and retried a denied read quorum forever. Recovery and repair share the helper and already propagate any error from it, so for them this only replaces an opaque `NoReadQuorum` with the precise transport error in the same failure. Test: all zones denied on a sealed segment, the follower returns `PermissionDenied` instead of polling.

## Post-fix live run

Re-run at `57ff253` on the same `n2-standard-8` / `us-central1` / zonal-Rapid setup after all four review passes, so the follower's fixes (generation handling, quorum-aware fail-fast, pending-seal reads, task cancellation, timed reads) are under the same load as the first table.

Low-load commit-to-subscribe, `pipeline_window=1`, 256 records, p50 / p99 ms:

| Poll interval | Fixed cadence | Continuous |
| --- | ---: | ---: |
| 10 ms | 9.4 / 53.7 | 2.8 / 51.5 |
| 100 ms | 59.2 / 130.6 | 3.1 / 101.8 |
| 250 ms | 127.7 / 261.5 | 2.9 / 54.3 |

Saturated, `pipeline_window=64` (262,400-byte window after #12), 2048 records, p50 ms / subscriber rec/s:

| Poll interval | Fixed cadence | Continuous |
| --- | ---: | ---: |
| 10 ms | 70.0 / 4407 | 58.0 / 5328 |
| 100 ms | 153.5 / 4719 | 16.1 / 7451 |
| 250 ms | 488.7 / 1730 | 12.3 / 8581 |

Three repeats at 100 ms continuous, p50: `pipeline_window=1` 5.8 / 3.5 / 4.1 ms; `pipeline_window=64` 40.2 / 25.9 / 40.7 ms (8,687–9,949 rec/s).

Low-load continuous is unchanged from the first run (2–3 ms at every interval) and fixed cadence still tracks half the poll interval. Both 10 ms saturated runs were slower than before for **both** cadences, and the writer's own rate in those two runs was 5,403–5,634 rec/s against 9,939–12,948 in the other saturated runs, so that is writer-side variance in the service or VM during those minutes, not follower behavior. The ordering is unchanged in every cell.

`rapid-probe` against `subspace-dev-rapid-zonal-1` at the same commit passed all twelve probes. T7 confirms the exact provider behavior the follower rests on: for an open appendable object with 16 flushed bytes, `BidiReadObject` returned 16 bytes while `ReadObject` returned 0 and `GetObject.size` reported 0. T9 measured sequential flush RTT p50 at 1.7 ms, which accounts for most of the 2–3 ms low-load delivery figure.

## Base

Rebased onto [#12](https://github.com/rockwotj/chorus/pull/12). The readonly benchmark's `--pipeline-window` stays a client-side record count, the same kind of knob `disk-wal-bench --pipeline-window` is; the engine's byte-bounded window is sized to admit that many encoded records, and the queue keeps its eight-window headroom. Both derived budgets appear in the report's `configuration` block. The benchmark tables below were measured before #12 under the equivalent record-count configuration.

## Live GCS benchmarks

Measured on an `n2-standard-8` in `us-central1-a` against three zonal Rapid buckets plus a regional manifest bucket in the same region, 4 KiB records. "Fixed cadence" is the pre-change behavior, measured through a benchmark flag that has since been removed; both columns were the same binary.

Low-load commit-to-subscribe, `pipeline_window=1`, 256 records:

| Poll interval | Fixed cadence p50/p99 | Continuous p50/p99 |
| --- | ---: | ---: |
| 10 ms | 10.8 / 40.9 ms | 2.3 / 50.4 ms |
| 100 ms | 55.1 / 116.5 ms | 3.3 / 55.7 ms |
| 250 ms | 135.8 / 268.0 ms | 2.7 / 46.9 ms |

Saturated, `pipeline_window=64`, 2048 records:

| Poll interval | Fixed p50 / subscriber | Continuous p50 / subscriber |
| --- | ---: | ---: |
| 10 ms | 55.6 ms / 10561 rec/s | 24.2 ms / 9860 rec/s |
| 100 ms | 168.2 ms / 3840 rec/s | 31.0 ms / 9031 rec/s |
| 250 ms | 296.4 ms / 2319 rec/s | 55.9 ms / 9948 rec/s |

Under fixed cadence, low-load p50 tracks roughly half the poll interval, which is the behavior the interval was previously trading against request cost. Under continuous cadence it is flat at 2–3 ms across all three intervals.

Three repeats at 100 ms, p50 per run:

| Config | Fixed | Continuous |
| --- | ---: | ---: |
| `pipeline_window=1` | 61.0 / 57.3 / 56.2 ms | 2.7 / 3.1 / 2.6 ms |
| `pipeline_window=64` | 152.2 / 244.1 / 219.5 ms | 55.3 / 15.7 / 49.5 ms |

Saturated continuous runs vary more run to run than the low-load ones; the ordering is consistent across every repeat.

These supersede the numbers this PR was opened with in June, which do not reproduce: that run reported roughly 403 rec/s saturated writer throughput against roughly 10–15k rec/s here, so it was limited by something since fixed on `main`. Treat only the table above as current.

## Review follow-ups in this branch

- Skip the poll sleep after a delivering read; add `manifest_poll_interval`.
- Surface a replica whose `read_range` is the trait default as a terminal error instead of polling forever without delivering or reporting.
- Check `ReplicaRangeRead::generation` per replica across polls, and document that providers report it when a session opens rather than per range. It was previously carried by both transports and read by nobody.
- Wrap the follower's own replicas in `TimedReplica`, which only ever wrapped the writer quorum path, and add `read_range` to the existing `chorus.wal.transport.rpc_seconds{op}` label set.
- Fix a lost wakeup in the benchmark's commit timeline that could hang the final record, and active-segment sizing that rejected every small configuration.
- Add the fake-GCS smoke test for the readonly benchmark.

Second pass:

- A replica whose active object changes generation no longer terminates the follower. Repair replaces lagging copies under new generations; the changed copy is skipped for that poll and majority byte agreement decides the rest.
- `open_readonly` on the pre-claim initial manifest (no `tail_id`) returns `Uninitialized` instead of opening and then failing the first poll with `InvalidCatalog`.
- The fake's `BidiReadObject` stream binds to the generation resolved at open. Previously each range looked up the latest object by name under the opening generation's metadata, which is what hid the guard bug from its own tests.
- `ReadonlyFollowerSafety` now records every active-tail emission and asserts on recovery completion that the recovered segment retains it with the same value. The active-tail driver persists on two zones, lets the follower emit, crashes the writer before commit, then recovers.

## Model

The follower refreshes the manifest on its own schedule, so a poll works from whatever snapshot that task last published. The model described the follower this replaced — "Each poll reads one linearizable manifest snapshot" — with drivers asserting what a single poll must observe, so it was verifying a stronger system than the one that ships. The follower now caches the snapshot and each poll either re-reads the register or reuses the cache, bounded so a snapshot cannot go unrefreshed forever. Both affected drivers poll until the refresh lands; the truncation race asserts the stronger property this exposes, that a poll which has not yet seen a raised floor publishes nothing and does not advance its cursor on any attempt.

The model also carries a retention obligation the original did not: a record the follower emitted from the active tail must survive a later recovery, even if the writer never committed it. Before this, `QuorumLinearizability` iterated only writer-committed records and the active-tail driver required a commit before opening the follower, so the quorum-intersection claim this PR rests on was asserted but not checked.

`DirectoryEnforcement`'s read check is scoped to coordinating reads. The invariant is that a recovering writer which adopted an entry on finalized-quorum evidence does not then download it. That handler predates the readonly role, when a recovering writer was the only machine issuing `eRead`, so "every read" and "recovery's reads" were the same statement; they stop being the same once a follower exists. `eRead` is model-only and absent from `TRACE_EVENTS.txt`, so no trace producer changes.

## Follow-up, not in this PR

[#7](https://github.com/rockwotj/chorus/pull/7) moved repair's health assessment to object metadata and deleted `restore_sealed_quorum`, but `HistoricalMaintenanceCoordinator` still assesses by content read, as its own comment records. Nothing verifies the metadata-only decision path, including the `Unknown` vs `Damaged` distinction that keeps an unreachable zone from triggering a rewrite from a guess. Independent of the readonly role; belongs in its own change.







