### PR TITLE
Hash the rolling segment digest on the runtime, not spawn_blocking

### DIFF
--- a/rust/client/src/protocol.rs
+++ b/rust/client/src/protocol.rs
@@ -489,14 +489,10 @@ impl AdmittedPrefix {
                 let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel::<Arc<[Bytes]>>();
                 let task = tokio::spawn(async move {
                     while let Some(chunks) = receiver.recv().await {
-                        hasher = tokio::task::spawn_blocking(move || {
-                            for chunk in chunks.iter() {
-                                hasher.update(chunk);
-                            }
-                            hasher
-                        })
-                        .await
-                        .expect("ordered digest task failed");
+                        for chunk in chunks.iter() {
+                            hasher.update(chunk);
+                        }
+                        tokio::task::yield_now().await;
                     }
                     hasher
                 });


### PR DESCRIPTION
Fixes the nightly DST certification flake ([run 29493605882](https://github.com/rockwotj/chorus/actions/runs/29493605882)): seed 556 intermittently failed the run-twice determinism check.

## Root cause

The writer's ordered digest worker hopped each batch of appended chunks onto `tokio::task::spawn_blocking`. The blocking pool is real OS threads, so the `JoinHandle` completion re-enters the otherwise single-threaded turmoil runtime at a wall-clock-dependent point in virtual time. The seal fold awaits this digest before its manifest CAS, so host thread timing decided whether the fold's `ViewCommitted` landed before or after the harness audit at the same virtual instant (~12% of runs took the minority ordering).

Diagnosis notes: the two divergent traces contained identical events and identical fake-GCS operation sequences — only the position of one `ViewCommitted` flipped. All `select!`s are `biased`, tokio's rng is seeded under `tokio_unstable`, and every HashMap iteration in the simulated path is sorted or order-independent; the `spawn_blocking` hop was the sole remaining cross-thread escape from virtual time.

## Fix

Hash inline in the ordered digest task, yielding between batches. Batches are pipeline-window sized, so the inline SHA-256 costs microseconds.

## Verification

- Seed 556 produces a single digest across 100 runs (baseline: two variants, ~12/88 split over 60 runs).
- The surviving digest matches the previous majority variant, so existing certified traces are unaffected.
- `cargo test -p chorus-client` passes.