### PR TITLE
Break recovery's prepare step into measurable sub-phases

### DIFF
--- a/rust/client/src/metrics.rs
+++ b/rust/client/src/metrics.rs
@@ -293,6 +293,9 @@ pub(crate) struct Metrics {
     pub(crate) repair_failures: Counter,
     pub(crate) recoveries_run: Counter,
     pub(crate) recovery_segments_adopted: Counter,
+    pub(crate) recovery_candidate_takeover: Histogram,
+    pub(crate) recovery_segment_provision: Histogram,
+    pub(crate) recovery_seal_enforcement: Histogram,
     pub(crate) orphan_objects_deleted: Counter,
     pub(crate) orphan_sweeps_deferred: Counter,
     pub(crate) truncation_cycles: Counter,
@@ -428,6 +431,18 @@ impl Metrics {
                 "Repair passes aborted by an error"
             ),
             recoveries_run: counter!("chorus.wal.recovery.runs", "Recovery attempts started"),
+            recovery_candidate_takeover: histogram!(
+                "chorus.wal.recovery.candidate_takeover_seconds",
+                "Fencing takeover and tail observation for one appendable candidate"
+            ),
+            recovery_segment_provision: histogram!(
+                "chorus.wal.recovery.segment_provision_seconds",
+                "Creating one segment object and opening its append lanes"
+            ),
+            recovery_seal_enforcement: histogram!(
+                "chorus.wal.recovery.seal_enforcement_seconds",
+                "Enforcing a deferred seal on a recovered predecessor"
+            ),
             recovery_segments_adopted: counter!(
                 "chorus.wal.recovery.segments_adopted",
                 "Sealed segments adopted by recovery"

--- a/rust/client/src/segment.rs
+++ b/rust/client/src/segment.rs
@@ -106,6 +106,26 @@ pub struct RecoveryTimings {
     /// Duration of directory adoption, committed-seal enforcement, and the
     /// appendable-candidate takeover walk.
     pub prepare: Duration,
+    /// How that prepare duration divides between its two regions.
+    pub phases: PreparePhases,
+}
+
+/// The two regions that `prepare` is made of, which cost very different
+/// amounts depending on what the previous writer left behind. Together they
+/// account for nearly all of `prepare`; the remainder is manifest bookkeeping
+/// already covered by `chorus.wal.manifest.cas_latency_seconds`.
+///
+/// Per-operation attribution within a region comes from the recovery
+/// histograms — candidate takeover, segment provisioning, and seal
+/// enforcement — since a region runs a variable number of each.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct PreparePhases {
+    /// Recovering and re-quorumizing the already-sealed directory chain.
+    pub sealed_chain: Duration,
+    /// Walking the appendable candidates: taking over the tail, then the
+    /// pending segment, and provisioning replacements for whichever cannot be
+    /// reused.
+    pub candidate_walk: Duration,
 }
 
 /// Startup recovery stream and capability to resume from a fenced frontier.
@@ -207,6 +227,7 @@ pub(crate) struct DeadSegmentSweepReport {
 /// Everything `prepare_recovery` learns and decides: the enforced sealed
 /// chain, the replay boundary, and the identity the writer starts from.
 struct RecoveredWriterState {
+    phases: PreparePhases,
     sealed_segments: Vec<SegmentDescriptor>,
     base_record_index: u64,
     checkpoint_floor: u64,
@@ -238,7 +259,12 @@ impl RecoveredPredecessor {
         let Some(seal) = self.deferred_seal.take() else {
             return Ok(());
         };
-        seal.volume.enforce_seal(seal.tail.canonical()).await?;
+        let started = tokio::time::Instant::now();
+        let enforced = seal.volume.enforce_seal(seal.tail.canonical()).await;
+        metrics
+            .recovery_seal_enforcement
+            .record_duration(started.elapsed());
+        enforced?;
         metrics.segments_sealed.increment();
         Ok(())
     }
@@ -792,6 +818,7 @@ mod recovery {
                 timings: RecoveryTimings {
                     epoch_claim,
                     prepare,
+                    phases: writer_state.phases,
                 },
                 volume: self.clone(),
                 manifest,
@@ -927,6 +954,7 @@ mod recovery {
             // has already durably applied
             let checkpoint_floor = adopted.trunc.max(checkpoint.record_index);
             let mut sealed_segments = Vec::with_capacity(chain.len() + 1);
+            let sealed_chain_started = tokio::time::Instant::now();
             for (id, base, end, crc32c) in &chain {
                 // The most recent seal may still have enforcement in flight, so
                 // recover and enforce it against the committed digest. Older
@@ -969,6 +997,9 @@ mod recovery {
                 }
             }
 
+            let sealed_chain = sealed_chain_started.elapsed();
+
+            let candidate_walk_started = tokio::time::Instant::now();
             // Walk the only two admissible appendable candidates in manifest
             // order. Every size observation follows a takeover fence. The first
             // empty candidate is the write frontier; non-empty predecessors are
@@ -1295,6 +1326,7 @@ mod recovery {
                     }
                 }
             }
+            let candidate_walk = candidate_walk_started.elapsed();
             let (active_id, active_writer) =
                 active.expect("recovery always establishes an empty frontier");
             if checkpoint.record_index > next_record_index {
@@ -1307,6 +1339,10 @@ mod recovery {
                 .recovery_segments_adopted
                 .add(sealed_segments.len() as u64);
             Ok(RecoveredWriterState {
+                phases: PreparePhases {
+                    sealed_chain,
+                    candidate_walk,
+                },
                 sealed_segments,
                 base_record_index: next_record_index,
                 checkpoint_floor,
@@ -1325,6 +1361,8 @@ mod recovery {
             mut manifest: Manifest,
         ) -> Result<SegmentedWriter, Error> {
             let RecoveredWriterState {
+                // Diagnostics only; the writer has no use for them.
+                phases: _,
                 sealed_segments,
                 base_record_index,
                 checkpoint_floor,
@@ -1617,7 +1655,8 @@ mod recovery {
         }
 
         async fn provision_segment(&self, id: String) -> Result<(String, Writer), Error> {
-            provision_spare(
+            let started = tokio::time::Instant::now();
+            let provisioned = provision_spare(
                 self.factories.clone(),
                 self.prefix.clone(),
                 self.client_config.clone(),
@@ -1626,7 +1665,11 @@ mod recovery {
                 id,
                 Arc::clone(&self.metrics),
             )
-            .await
+            .await;
+            self.metrics
+                .recovery_segment_provision
+                .record_duration(started.elapsed());
+            provisioned
         }
 
         async fn recover_manifest_candidate(
@@ -1636,7 +1679,12 @@ mod recovery {
         ) -> Result<RecoveredManifestCandidate, Error> {
             let object = self.segment_object(&id);
             let volume = self.volume_for(&object)?;
-            match volume.recover_candidate(None).await? {
+            let started = tokio::time::Instant::now();
+            let candidate = volume.recover_candidate(None).await;
+            self.metrics
+                .recovery_candidate_takeover
+                .record_duration(started.elapsed());
+            match candidate? {
                 RecoveryCandidate::Absent => Ok(RecoveredManifestCandidate::Absent),
                 RecoveryCandidate::Empty { reusable_writer } => {
                     Ok(RecoveredManifestCandidate::Empty { reusable_writer })


### PR DESCRIPTION
## Why

`Recovery::timings` reports `prepare` as a single number. For a single-writer database that number is the whole failover — it is the window between winning an election and being able to serve.

Two production handovers measured `prepare` at **10.7s** and **5.8s**, while the outgoing writer held only a handful of outstanding records. So the cost is not proportional to data. A cold recovery over the same volume spends roughly **300ms** in the same phase; the difference is taking over from a *live* writer.

Nothing inside `prepare` was observable. `segment.rs` has ten `info!` calls and no `debug!`/`trace!`, so there was nothing to turn up. The existing metrics eliminated the obvious suspects without explaining the time:

| Signal | Reading |
| --- | --- |
| `chorus_wal_lane_timeouts` | **0** — so much for the 5s `DEFAULT_LANE_STALL_TIMEOUT` theory |
| `chorus_wal_seal_duration_seconds` | no observations |
| `chorus_wal_manifest_cas_latency_seconds` | a few hundred ms across 4 attempts |
| `chorus_wal_append_commit_latency_seconds` | all samples under 10ms |

## What

`RecoveryTimings` gains `PreparePhases`, splitting `prepare` into its two regions — recovering the already-sealed directory chain, and walking the appendable candidates. Three histograms attribute work *within* a region, since a region runs a variable number of each operation:

- `chorus.wal.recovery.candidate_takeover_seconds`
- `chorus.wal.recovery.segment_provision_seconds`
- `chorus.wal.recovery.seal_enforcement_seconds`

They record at the **helper definitions**, not the call sites. The walk makes ~25 such calls spread across its arms, several split across lines, and instrumenting per-branch would have all but guaranteed a missed or double-counted path.

Manifest CAS is deliberately not re-timed — `chorus.wal.manifest.cas_latency_seconds` already covers it and has already shown it small.

The default `LATENCY_SECONDS_BOUNDARIES` fit well here: buckets at 2.5/5/10/30s cleanly separate a one-stall recovery from a two-stall one.

### Breaking change

`RecoveryTimings` gains a field, so literal construction breaks.

## Testing

Verified against the fake-GCS integration harness with a capturing `MetricsRecorder` (scratch test, reverted before commit):

| | cold recovery | takeover of a non-empty tail |
| --- | --- | --- |
| `sealed_chain` | 166ns | 167ns |
| `candidate_walk` | 708ns | **4.09ms** |

The sealed chain is flat while the walk explodes, with no network involved — the same shape as the production gap, which is good evidence the split lands on the right seam rather than merely adding numbers. All three histograms recorded.

`cargo build`, `cargo clippy --all-targets -D warnings`, `cargo fmt --check`, and the full suite (135 tests) pass.

## What this does not do

It does not fix anything — it makes the next measurement decisive. Once an embedding application exports these, the next takeover should say whether the seconds are candidate takeover, segment provisioning, or seal enforcement.