### PR TITLE
Enforce seal witnesses concurrently, and measure inside enforce_seal

### DIFF
--- a/rust/client/src/metrics.rs
+++ b/rust/client/src/metrics.rs
@@ -143,6 +143,15 @@ impl Counter {
         Self(recorder.register_counter(name, description, &[]))
     }
 
+    fn register_with_labels(
+        recorder: &dyn MetricsRecorder,
+        name: &str,
+        description: &str,
+        labels: &[(&str, &str)],
+    ) -> Self {
+        Self(recorder.register_counter(name, description, labels))
+    }
+
     pub(crate) fn increment(&self) {
         self.add(1);
     }
@@ -298,7 +307,7 @@ pub(crate) struct Metrics {
     pub(crate) recovery_seal_enforcement: Histogram,
     pub(crate) recovery_seal_witness_reads: Histogram,
     pub(crate) recovery_seal_witness: Histogram,
-    pub(crate) recovery_seal_witness_attempts: Counter,
+    zone_seal_witness_attempts: Vec<Counter>,
     pub(crate) orphan_objects_deleted: Counter,
     pub(crate) orphan_sweeps_deferred: Counter,
     pub(crate) truncation_cycles: Counter,
@@ -343,6 +352,18 @@ impl Metrics {
                 Histogram::register(recorder, $name, $description)
             };
         }
+
+        let zone_seal_witness_attempts = (0..replica_count)
+            .map(|zone| {
+                let zone = zone.to_string();
+                Counter::register_with_labels(
+                    recorder,
+                    "chorus.wal.recovery.seal_witness_attempts",
+                    "Retry passes spent enforcing this zone's copy, one per pass",
+                    &[("zone", zone.as_str())],
+                )
+            })
+            .collect();
 
         let zone_durable_lag = (0..replica_count)
             .map(|zone| {
@@ -454,10 +475,6 @@ impl Metrics {
                 "chorus.wal.recovery.seal_witness_seconds",
                 "Forcing one replica's copy to match the canonical prefix"
             ),
-            recovery_seal_witness_attempts: counter!(
-                "chorus.wal.recovery.seal_witness_attempts",
-                "Retry iterations spent enforcing witnesses, one per pass"
-            ),
             recovery_segments_adopted: counter!(
                 "chorus.wal.recovery.segments_adopted",
                 "Sealed segments adopted by recovery"
@@ -516,6 +533,7 @@ impl Metrics {
                 "Appends waiting across the admission channel and engine queue"
             ),
             zone_durable_lag,
+            zone_seal_witness_attempts,
             rotation_state: gauge!(
                 "chorus.wal.rotation.state",
                 "Rotation gate state: 0 idle, 1 due, 2 draining, 3 sealing, 4 disabled"
@@ -542,6 +560,15 @@ impl Metrics {
                 "chorus.wal.seal.duration_seconds",
                 "Seconds to finalize a swapped-out segment"
             ),
+        }
+    }
+
+    /// One retry pass enforcing `zone`'s copy. Labelled per zone so a single
+    /// spinning replica is distinguishable from every zone retrying evenly —
+    /// the two have different causes and different fixes.
+    pub(crate) fn record_seal_witness_attempt(&self, zone: usize) {
+        if let Some(counter) = self.zone_seal_witness_attempts.get(zone) {
+            counter.increment();
         }
     }
 

--- a/rust/client/src/metrics.rs
+++ b/rust/client/src/metrics.rs
@@ -296,6 +296,9 @@ pub(crate) struct Metrics {
     pub(crate) recovery_candidate_takeover: Histogram,
     pub(crate) recovery_segment_provision: Histogram,
     pub(crate) recovery_seal_enforcement: Histogram,
+    pub(crate) recovery_seal_witness_reads: Histogram,
+    pub(crate) recovery_seal_witness: Histogram,
+    pub(crate) recovery_seal_witness_attempts: Counter,
     pub(crate) orphan_objects_deleted: Counter,
     pub(crate) orphan_sweeps_deferred: Counter,
     pub(crate) truncation_cycles: Counter,
@@ -442,6 +445,18 @@ impl Metrics {
             recovery_seal_enforcement: histogram!(
                 "chorus.wal.recovery.seal_enforcement_seconds",
                 "Enforcing a deferred seal on a recovered predecessor"
+            ),
+            recovery_seal_witness_reads: histogram!(
+                "chorus.wal.recovery.seal_witness_reads_seconds",
+                "Reading every replica's copy before seal enforcement begins"
+            ),
+            recovery_seal_witness: histogram!(
+                "chorus.wal.recovery.seal_witness_seconds",
+                "Forcing one replica's copy to match the canonical prefix"
+            ),
+            recovery_seal_witness_attempts: counter!(
+                "chorus.wal.recovery.seal_witness_attempts",
+                "Retry iterations spent enforcing witnesses, one per pass"
             ),
             recovery_segments_adopted: counter!(
                 "chorus.wal.recovery.segments_adopted",

--- a/rust/client/src/protocol.rs
+++ b/rust/client/src/protocol.rs
@@ -1152,12 +1152,16 @@ impl QuorumVolume {
     /// are fixed by the committed decision.
     pub async fn enforce_seal(&self, canonical: &CanonicalPrefix) -> Result<(), ProtocolError> {
         let data = Bytes::from(canonical.bytes.clone());
+        let reads_started = tokio::time::Instant::now();
         let reads = join_all(
             self.replicas
                 .iter()
                 .map(|replica| snapshot_with_retry(replica, &self.config)),
         )
         .await;
+        self.metrics
+            .recovery_seal_witness_reads
+            .record_duration(reads_started.elapsed());
         let mut witnesses: Vec<ReplicaSnapshot> = Vec::new();
         let mut missing: Vec<usize> = Vec::new();
         for (zone, read) in reads.into_iter().enumerate() {
@@ -1199,7 +1203,26 @@ impl QuorumVolume {
                 + shared
         });
         let mut finalized = 0usize;
-        for snapshot in witnesses {
+        // The sort leaves the best copy last, and it stays last: a crash part
+        // way through must never find every good copy already replaced. The
+        // strictly worse copies have no such constraint, so they go together —
+        // sequential enforcement made recovery pay one full retry chain per
+        // zone, and those chains dominate a takeover from a live writer.
+        let best = witnesses.pop();
+        let others = join_all(
+            witnesses
+                .into_iter()
+                .map(|snapshot| self.enforce_witness(snapshot, &data)),
+        )
+        .await;
+        for outcome in others {
+            match outcome {
+                Ok(true) => finalized += 1,
+                Ok(false) => {}
+                Err(error) => return Err(error),
+            }
+        }
+        if let Some(snapshot) = best {
             match self.enforce_witness(snapshot, &data).await {
                 Ok(true) => finalized += 1,
                 Ok(false) => {}
@@ -1233,7 +1256,12 @@ impl QuorumVolume {
     ) -> Result<bool, ProtocolError> {
         let zone = snapshot.zone;
         let replica = Arc::clone(&self.replicas[zone]);
+        let _timer = WitnessTimer {
+            metrics: &self.metrics,
+            started: tokio::time::Instant::now(),
+        };
         for _ in 0..=self.config.max_retries {
+            self.metrics.recovery_seal_witness_attempts.increment();
             if snapshot.finalized {
                 if snapshot.bytes == data[..] {
                     return Ok(true);
@@ -1284,6 +1312,23 @@ impl QuorumVolume {
             }
         }
         Ok(false)
+    }
+}
+
+/// Records one witness's enforcement on every exit path. `enforce_witness`
+/// returns from a dozen places — early success, transient give-up, and several
+/// error arms — so a guard is the only way to time all of them without
+/// restructuring the retry loop.
+struct WitnessTimer<'a> {
+    metrics: &'a Metrics,
+    started: tokio::time::Instant,
+}
+
+impl Drop for WitnessTimer<'_> {
+    fn drop(&mut self) {
+        self.metrics
+            .recovery_seal_witness
+            .record_duration(self.started.elapsed());
     }
 }
 

--- a/rust/client/src/protocol.rs
+++ b/rust/client/src/protocol.rs
@@ -1159,9 +1159,6 @@ impl QuorumVolume {
                 .map(|replica| snapshot_with_retry(replica, &self.config)),
         )
         .await;
-        self.metrics
-            .recovery_seal_witness_reads
-            .record_duration(reads_started.elapsed());
         let mut witnesses: Vec<ReplicaSnapshot> = Vec::new();
         let mut missing: Vec<usize> = Vec::new();
         for (zone, read) in reads.into_iter().enumerate() {
@@ -1189,6 +1186,13 @@ impl QuorumVolume {
                 Err(error) => return Err(error.into()),
             }
         }
+        // Stopped here rather than after the fan-out above: classifying a
+        // DATA_LOSS reply issues its own sequential `stat` per zone, and
+        // leaving that outside every phase would drop it from the accounting
+        // exactly when copies are rotted.
+        self.metrics
+            .recovery_seal_witness_reads
+            .record_duration(reads_started.elapsed());
         // shortest matching prefix first: the best copy is rewritten last
         witnesses.sort_by_key(|snapshot| {
             let shared = snapshot
@@ -1229,14 +1233,23 @@ impl QuorumVolume {
                 Err(error) => return Err(error),
             }
         }
-        for zone in missing {
+        // Absent zones hold nothing, so none of them is the best copy and no
+        // ordering constrains them. They ran in series, which is the same
+        // per-zone retry chain that made witness enforcement slow, and it is
+        // the path taken when replicas are least healthy.
+        let repairs = join_all(missing.into_iter().map(|zone| {
             let replica = Arc::clone(&self.replicas[zone]);
-            let Ok(created) =
-                create_with_retry(&replica, self.metadata.clone(), &self.config).await
-            else {
-                continue;
-            };
-            match self.enforce_witness(created, &data).await {
+            let data = data.clone();
+            async move {
+                let created = create_with_retry(&replica, self.metadata.clone(), &self.config)
+                    .await
+                    .ok()?;
+                Some(self.enforce_witness(created, &data).await)
+            }
+        }))
+        .await;
+        for repair in repairs.into_iter().flatten() {
+            match repair {
                 Ok(true) => finalized += 1,
                 Ok(false) => {}
                 Err(error) => return Err(error),
@@ -1256,12 +1269,18 @@ impl QuorumVolume {
     ) -> Result<bool, ProtocolError> {
         let zone = snapshot.zone;
         let replica = Arc::clone(&self.replicas[zone]);
+        // Correct already: nothing is enforced, so nothing is timed. Recording
+        // it would fill the histogram with zero-length samples on an idempotent
+        // re-seal and bury the one zone that is genuinely slow.
+        if snapshot.finalized && snapshot.bytes == data[..] {
+            return Ok(true);
+        }
         let _timer = WitnessTimer {
             metrics: &self.metrics,
             started: tokio::time::Instant::now(),
         };
         for _ in 0..=self.config.max_retries {
-            self.metrics.recovery_seal_witness_attempts.increment();
+            self.metrics.record_seal_witness_attempt(zone);
             if snapshot.finalized {
                 if snapshot.bytes == data[..] {
                     return Ok(true);


### PR DESCRIPTION
## What the sub-phase timings found

The instrumentation from #3 attributed a takeover from a live writer precisely:

| Phase | Time | Share |
| --- | --- | --- |
| `seal_enforcement` | **5.116s** (1 call) | **93%** |
| `candidate_takeover` | 0.404s (2 calls) | 7% |
| `segment_provision` | 0.091s (1 call) | 2% |
| `sealed_chain` region | 0.000s | 0% |

One `enforce_seal` call is essentially the entire failover. A cold recovery over the same volume spends ~300ms in the whole prepare step.

Worth noting: `chorus.wal.seal.duration_seconds` recorded **zero observations** throughout, because it covers the rotation path rather than recovery's `enforce_seal`. Sealing looked innocent while being the whole cost.

## The change

The reads in `enforce_seal` already fan out with `join_all`. The enforcement did not:

```rust
for snapshot in witnesses {
    match self.enforce_witness(snapshot, &data).await   // one zone at a time
```

Each `enforce_witness` is a retry loop whose every step (`takeover_with_retry`, `finalize_with_retry`, `replace_with_retry`, `snapshot_with_retry`) is itself a retry chain with backoff, and a `FailedPrecondition` re-snapshots and goes round again. Taking over from a live writer is exactly what trips those preconditions, so a takeover paid one full chain per replica **in series**.

Now the strictly-worse copies are enforced concurrently and **the best copy is still enforced last**.

That ordering is load bearing, not incidental — the sort exists so that a crash part way through never finds every good copy already replaced. So it is preserved rather than traded for throughput: `pop()` takes exactly the best witness (the sort leaves it last), the remainder run under `join_all`, and the best is enforced only after they complete. Missing-zone repairs keep their original position after the witnesses.

## Why this alone is not the fix

With three replicas this turns three sequential chains into two. Worth having, but it does not explain why a *single* witness costs ~1.7s. Three new signals settle that on the next takeover:

| Metric | What it decides |
| --- | --- |
| `chorus.wal.recovery.seal_witness_reads_seconds` | whether the read fan-out is a rounding error (inferred, never measured) |
| `chorus.wal.recovery.seal_witness_seconds` | per-zone cost, one observation each |
| `chorus.wal.recovery.seal_witness_attempts` | retry passes — if this runs far ahead of the witness count, the cost is a **retry storm** and the fix is the backoff, not the concurrency |

The per-witness timer is a `Drop` guard because `enforce_witness` returns from a dozen places — early success, transient give-up, and several error arms.

## Considered and rejected: a metadata fast path

Skipping the body read and comparing `(persisted_size, crc32c)` from `stat()` is feasible — `ReplicaSnapshot` already carries both. But it targets the wrong thing:

- The reads are already parallel, and the payload is tiny.
- The witness **sort needs bytes**: it ranks by shared prefix length, and a CRC gives match/no-match without the gradation that keeps the best copy last.
- In a takeover from a live writer the copies are by definition not finalized and not matching, so a fast path cannot short-circuit the case that is actually slow.

`seal_witness_reads_seconds` will confirm or refute this directly.

## Testing

Against the fake-GCS harness: a takeover still replays every record, the read batch reports once, per-witness timings report three times (one per zone), and attempts report one pass per witness on the happy path.

`cargo build`, `cargo clippy --all-targets -D warnings`, `cargo fmt --check`, and the full suite (135 tests) pass.