### PR TITLE
Read objects over BidiReadObject

### DIFF
--- a/rust/client/src/grpc.rs
+++ b/rust/client/src/grpc.rs
@@ -6,10 +6,11 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use googleapis_tonic_google_storage_v2::google::storage::v2::{
     bidi_write_object_request, bidi_write_object_response, storage_client::StorageClient,
-    write_object_request, write_object_response, AppendObjectSpec, BidiWriteHandle,
-    BidiWriteObjectRedirectedError, BidiWriteObjectRequest, BidiWriteObjectResponse,
-    ChecksummedData, DeleteObjectRequest, GetObjectRequest, ListObjectsRequest, Object,
-    ReadObjectRequest, UpdateObjectRequest, WriteObjectRequest, WriteObjectSpec,
+    write_object_request, write_object_response, AppendObjectSpec, BidiReadObjectRequest,
+    BidiReadObjectSpec, BidiWriteHandle, BidiWriteObjectRedirectedError, BidiWriteObjectRequest,
+    BidiWriteObjectResponse, ChecksummedData, DeleteObjectRequest, GetObjectRequest,
+    ListObjectsRequest, Object, ReadRange, UpdateObjectRequest, WriteObjectRequest,
+    WriteObjectSpec,
 };
 use prost::Message as _;
 use tokio::sync::{mpsc, watch, Mutex as SessionMutex};
@@ -243,6 +244,68 @@ impl AppendSessionHandle {
 }
 
 impl GrpcReplica {
+    /// Read one generation in full over `BidiReadObject`.
+    ///
+    /// Preferred over `ReadObject`, which stalls a fixed ~5.1s opening its
+    /// stream against these appendable objects — measured across two zones and
+    /// three objects from 26KB to 198KB, while `GetObject` on the same objects
+    /// took 35ms and the drain under 2ms. Bidi returned the identical byte
+    /// count in 53ms. Same bytes, same generation guard, same per-chunk CRC
+    /// check; only the API differs.
+    ///
+    /// Errors carry the provider code, so the surrounding retry and quorum
+    /// logic classifies a bidi failure exactly as it classified a `ReadObject`
+    /// one — transient codes retry, `NotFound` and `DataLoss` keep their
+    /// meaning to recovery.
+    async fn bidi_read(&self, generation: i64) -> Result<Vec<u8>, TransportError> {
+        let spec = BidiReadObjectSpec {
+            bucket: self.bucket.clone(),
+            object: self.object.clone(),
+            generation,
+            if_generation_match: Some(generation),
+            ..Default::default()
+        };
+        let open = BidiReadObjectRequest {
+            read_object_spec: Some(spec),
+            // Offset and size zero requests the whole object.
+            read_ranges: vec![ReadRange {
+                read_offset: 0,
+                read_length: 0,
+                read_id: 1,
+            }],
+        };
+        let request = self.request(tokio_stream::once(open))?;
+        let mut stream = self
+            .client
+            .clone()
+            .bidi_read_object(request)
+            .await
+            .map_err(|status| self.status(status))?
+            .into_inner();
+        let mut bytes = Vec::new();
+        while let Some(response) = stream
+            .message()
+            .await
+            .map_err(|status| self.status(status))?
+        {
+            for range in response.object_data_ranges {
+                if let Some(data) = range.checksummed_data {
+                    if data
+                        .crc32c
+                        .is_some_and(|expected| expected != crc32c::crc32c(&data.content))
+                    {
+                        return Err(self.error(
+                            TransportCode::DataLoss,
+                            "BidiReadObject response CRC32C mismatch",
+                        ));
+                    }
+                    bytes.extend_from_slice(&data.content);
+                }
+            }
+        }
+        Ok(bytes)
+    }
+
     fn live_session(&self) -> Result<Arc<AppendSessionHandle>, TransportError> {
         self.session.current.load_full().ok_or_else(|| {
             self.error(
@@ -1195,40 +1258,10 @@ impl Replica for GrpcReplica {
             .map_err(|status| self.status(status))?
             .into_inner();
 
-        let read = ReadObjectRequest {
-            bucket: self.bucket.clone(),
-            object: self.object.clone(),
-            generation: object.generation,
-            if_generation_match: Some(object.generation),
-            ..Default::default()
-        };
-        let request = self.request(read)?;
-        let mut stream = self
-            .client
-            .clone()
-            .read_object(request)
-            .await
-            .map_err(|status| self.status(status))?
-            .into_inner();
-        let mut bytes = Vec::new();
-        while let Some(response) = stream
-            .message()
-            .await
-            .map_err(|status| self.status(status))?
-        {
-            if let Some(data) = response.checksummed_data {
-                if data
-                    .crc32c
-                    .is_some_and(|expected| expected != crc32c::crc32c(&data.content))
-                {
-                    return Err(self.error(
-                        TransportCode::DataLoss,
-                        "ReadObject response CRC32C mismatch",
-                    ));
-                }
-                bytes.extend_from_slice(&data.content);
-            }
-        }
+        // Content comes over BidiReadObject. ReadObject stalls a fixed ~5.1s
+        // opening its stream against these appendable objects, independent of
+        // zone, object and size, while bidi returned the same bytes in 53ms.
+        let bytes = self.bidi_read(object.generation).await?;
         Ok(self.snapshot_from_object(object, bytes))
     }
 

--- a/rust/client/src/metrics.rs
+++ b/rust/client/src/metrics.rs
@@ -293,9 +293,6 @@ pub(crate) struct Metrics {
     pub(crate) repair_failures: Counter,
     pub(crate) recoveries_run: Counter,
     pub(crate) recovery_segments_adopted: Counter,
-    pub(crate) recovery_candidate_takeover: Histogram,
-    pub(crate) recovery_segment_provision: Histogram,
-    pub(crate) recovery_seal_enforcement: Histogram,
     pub(crate) orphan_objects_deleted: Counter,
     pub(crate) orphan_sweeps_deferred: Counter,
     pub(crate) truncation_cycles: Counter,
@@ -431,18 +428,6 @@ impl Metrics {
                 "Repair passes aborted by an error"
             ),
             recoveries_run: counter!("chorus.wal.recovery.runs", "Recovery attempts started"),
-            recovery_candidate_takeover: histogram!(
-                "chorus.wal.recovery.candidate_takeover_seconds",
-                "Fencing takeover and tail observation for one appendable candidate"
-            ),
-            recovery_segment_provision: histogram!(
-                "chorus.wal.recovery.segment_provision_seconds",
-                "Creating one segment object and opening its append lanes"
-            ),
-            recovery_seal_enforcement: histogram!(
-                "chorus.wal.recovery.seal_enforcement_seconds",
-                "Enforcing a deferred seal on a recovered predecessor"
-            ),
             recovery_segments_adopted: counter!(
                 "chorus.wal.recovery.segments_adopted",
                 "Sealed segments adopted by recovery"

--- a/rust/client/src/segment.rs
+++ b/rust/client/src/segment.rs
@@ -106,26 +106,6 @@ pub struct RecoveryTimings {
     /// Duration of directory adoption, committed-seal enforcement, and the
     /// appendable-candidate takeover walk.
     pub prepare: Duration,
-    /// How that prepare duration divides between its two regions.
-    pub phases: PreparePhases,
-}
-
-/// The two regions that `prepare` is made of, which cost very different
-/// amounts depending on what the previous writer left behind. Together they
-/// account for nearly all of `prepare`; the remainder is manifest bookkeeping
-/// already covered by `chorus.wal.manifest.cas_latency_seconds`.
-///
-/// Per-operation attribution within a region comes from the recovery
-/// histograms — candidate takeover, segment provisioning, and seal
-/// enforcement — since a region runs a variable number of each.
-#[derive(Clone, Copy, Debug, Default)]
-pub struct PreparePhases {
-    /// Recovering and re-quorumizing the already-sealed directory chain.
-    pub sealed_chain: Duration,
-    /// Walking the appendable candidates: taking over the tail, then the
-    /// pending segment, and provisioning replacements for whichever cannot be
-    /// reused.
-    pub candidate_walk: Duration,
 }
 
 /// Startup recovery stream and capability to resume from a fenced frontier.
@@ -227,7 +207,6 @@ pub(crate) struct DeadSegmentSweepReport {
 /// Everything `prepare_recovery` learns and decides: the enforced sealed
 /// chain, the replay boundary, and the identity the writer starts from.
 struct RecoveredWriterState {
-    phases: PreparePhases,
     sealed_segments: Vec<SegmentDescriptor>,
     base_record_index: u64,
     checkpoint_floor: u64,
@@ -259,12 +238,7 @@ impl RecoveredPredecessor {
         let Some(seal) = self.deferred_seal.take() else {
             return Ok(());
         };
-        let started = tokio::time::Instant::now();
-        let enforced = seal.volume.enforce_seal(seal.tail.canonical()).await;
-        metrics
-            .recovery_seal_enforcement
-            .record_duration(started.elapsed());
-        enforced?;
+        seal.volume.enforce_seal(seal.tail.canonical()).await?;
         metrics.segments_sealed.increment();
         Ok(())
     }
@@ -818,7 +792,6 @@ mod recovery {
                 timings: RecoveryTimings {
                     epoch_claim,
                     prepare,
-                    phases: writer_state.phases,
                 },
                 volume: self.clone(),
                 manifest,
@@ -954,7 +927,6 @@ mod recovery {
             // has already durably applied
             let checkpoint_floor = adopted.trunc.max(checkpoint.record_index);
             let mut sealed_segments = Vec::with_capacity(chain.len() + 1);
-            let sealed_chain_started = tokio::time::Instant::now();
             for (id, base, end, crc32c) in &chain {
                 // The most recent seal may still have enforcement in flight, so
                 // recover and enforce it against the committed digest. Older
@@ -997,9 +969,6 @@ mod recovery {
                 }
             }
 
-            let sealed_chain = sealed_chain_started.elapsed();
-
-            let candidate_walk_started = tokio::time::Instant::now();
             // Walk the only two admissible appendable candidates in manifest
             // order. Every size observation follows a takeover fence. The first
             // empty candidate is the write frontier; non-empty predecessors are
@@ -1326,7 +1295,6 @@ mod recovery {
                     }
                 }
             }
-            let candidate_walk = candidate_walk_started.elapsed();
             let (active_id, active_writer) =
                 active.expect("recovery always establishes an empty frontier");
             if checkpoint.record_index > next_record_index {
@@ -1339,10 +1307,6 @@ mod recovery {
                 .recovery_segments_adopted
                 .add(sealed_segments.len() as u64);
             Ok(RecoveredWriterState {
-                phases: PreparePhases {
-                    sealed_chain,
-                    candidate_walk,
-                },
                 sealed_segments,
                 base_record_index: next_record_index,
                 checkpoint_floor,
@@ -1361,8 +1325,6 @@ mod recovery {
             mut manifest: Manifest,
         ) -> Result<SegmentedWriter, Error> {
             let RecoveredWriterState {
-                // Diagnostics only; the writer has no use for them.
-                phases: _,
                 sealed_segments,
                 base_record_index,
                 checkpoint_floor,
@@ -1655,8 +1617,7 @@ mod recovery {
         }
 
         async fn provision_segment(&self, id: String) -> Result<(String, Writer), Error> {
-            let started = tokio::time::Instant::now();
-            let provisioned = provision_spare(
+            provision_spare(
                 self.factories.clone(),
                 self.prefix.clone(),
                 self.client_config.clone(),
@@ -1665,11 +1626,7 @@ mod recovery {
                 id,
                 Arc::clone(&self.metrics),
             )
-            .await;
-            self.metrics
-                .recovery_segment_provision
-                .record_duration(started.elapsed());
-            provisioned
+            .await
         }
 
         async fn recover_manifest_candidate(
@@ -1679,12 +1636,7 @@ mod recovery {
         ) -> Result<RecoveredManifestCandidate, Error> {
             let object = self.segment_object(&id);
             let volume = self.volume_for(&object)?;
-            let started = tokio::time::Instant::now();
-            let candidate = volume.recover_candidate(None).await;
-            self.metrics
-                .recovery_candidate_takeover
-                .record_duration(started.elapsed());
-            match candidate? {
+            match volume.recover_candidate(None).await? {
                 RecoveryCandidate::Absent => Ok(RecoveredManifestCandidate::Absent),
                 RecoveryCandidate::Empty { reusable_writer } => {
                     Ok(RecoveredManifestCandidate::Empty { reusable_writer })

--- a/rust/fake-gcs/proto/storage_subset.proto
+++ b/rust/fake-gcs/proto/storage_subset.proto
@@ -7,6 +7,8 @@ service Storage {
   rpc GetObject(GetObjectRequest) returns (Object);
   rpc ListObjects(ListObjectsRequest) returns (ListObjectsResponse);
   rpc ReadObject(ReadObjectRequest) returns (stream ReadObjectResponse);
+  rpc BidiReadObject(stream BidiReadObjectRequest)
+      returns (stream BidiReadObjectResponse);
   rpc UpdateObject(UpdateObjectRequest) returns (Object);
   rpc WriteObject(stream WriteObjectRequest) returns (WriteObjectResponse);
   rpc BidiWriteObject(stream BidiWriteObjectRequest)
@@ -169,4 +171,38 @@ message BidiWriteObjectResponse {
     Object resource = 2;
   }
   optional BidiWriteHandle write_handle = 3;
+}
+
+// Field numbers match google.storage.v2 exactly: the client encodes with the
+// real generated types, so the fake must decode the same wire format.
+message BidiReadObjectSpec {
+  string bucket = 1;
+  string object = 2;
+  int64 generation = 3;
+  optional int64 if_generation_match = 4;
+  optional int64 if_generation_not_match = 5;
+  optional int64 if_metageneration_match = 6;
+  optional int64 if_metageneration_not_match = 7;
+}
+
+message ReadRange {
+  int64 read_offset = 1;
+  int64 read_length = 2;
+  int64 read_id = 3;
+}
+
+message BidiReadObjectRequest {
+  BidiReadObjectSpec read_object_spec = 1;
+  repeated ReadRange read_ranges = 8;
+}
+
+message ObjectRangeData {
+  ChecksummedData checksummed_data = 1;
+  ReadRange read_range = 2;
+  bool range_end = 3;
+}
+
+message BidiReadObjectResponse {
+  Object metadata = 4;
+  repeated ObjectRangeData object_data_ranges = 6;
 }

--- a/rust/fake-gcs/src/lib.rs
+++ b/rust/fake-gcs/src/lib.rs
@@ -20,9 +20,9 @@ use proto::bidi_write_object_request::{Data, FirstMessage};
 use proto::bidi_write_object_response::WriteStatus;
 use proto::storage_server::{Storage, StorageServer};
 use proto::{
-    BidiWriteObjectRequest, BidiWriteObjectResponse, DeleteObjectRequest, Empty, GetObjectRequest,
-    ListObjectsRequest, ListObjectsResponse, Object, ReadObjectRequest, ReadObjectResponse,
-    Timestamp, UpdateObjectRequest,
+    BidiReadObjectRequest, BidiReadObjectResponse, BidiWriteObjectRequest, BidiWriteObjectResponse,
+    DeleteObjectRequest, Empty, GetObjectRequest, ListObjectsRequest, ListObjectsResponse, Object,
+    ReadObjectRequest, ReadObjectResponse, Timestamp, UpdateObjectRequest,
 };
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -1226,6 +1226,7 @@ impl<T> Drop for TaskResponseStream<T> {
 impl Storage for FakeGcs {
     type ReadObjectStream = ResponseStream<ReadObjectResponse>;
     type BidiWriteObjectStream = ResponseStream<BidiWriteObjectResponse>;
+    type BidiReadObjectStream = ResponseStream<BidiReadObjectResponse>;
 
     async fn delete_object(
         &self,
@@ -1374,6 +1375,78 @@ impl Storage for FakeGcs {
                 content: object.bytes[start..end].to_vec(),
                 crc32c: Some(crc32c::crc32c(&object.bytes[start..end])),
             }),
+            metadata: Some(object.to_proto()),
+        };
+        Ok(Response::new(Box::pin(tokio_stream::iter([Ok(response)]))))
+    }
+
+    /// Serves the same bytes as `read_object` under the same guards. Chorus
+    /// reads over this API because `ReadObject` stalls opening its stream
+    /// against real appendable objects, so the fake has to implement it or the
+    /// recovery tests exercise a path production no longer takes.
+    async fn bidi_read_object(
+        &self,
+        request: Request<tonic::Streaming<BidiReadObjectRequest>>,
+    ) -> Result<Response<Self::BidiReadObjectStream>, Status> {
+        self.before(Operation::Read).await?;
+        let mut inbound = request.into_inner();
+        let first = inbound
+            .message()
+            .await?
+            .ok_or_else(|| Status::invalid_argument("empty bidi read stream"))?;
+        let spec = first
+            .read_object_spec
+            .ok_or_else(|| Status::invalid_argument("first message must set read_object_spec"))?;
+        let state = self.inner.lock().await;
+        let object = state
+            .objects
+            .get(&object_key(&spec.bucket, &spec.object))
+            .ok_or_else(|| Status::not_found("object"))?;
+        check_name(object, &spec.bucket, &spec.object)?;
+        if crc32c::crc32c(&object.bytes) != object.integrity_crc32c {
+            return Err(Status::data_loss("stored object CRC32C mismatch"));
+        }
+        if spec.generation != 0 && spec.generation != object.generation {
+            return Err(Status::failed_precondition("generation mismatch"));
+        }
+        if spec
+            .if_generation_match
+            .is_some_and(|value| value != object.generation)
+        {
+            return Err(Status::failed_precondition("generation mismatch"));
+        }
+        if spec
+            .if_metageneration_match
+            .is_some_and(|value| value != object.metageneration)
+        {
+            return Err(Status::failed_precondition("metageneration mismatch"));
+        }
+        // A zero offset and length requests the whole object, which is the only
+        // shape chorus asks for.
+        let range = first.read_ranges.first().copied().unwrap_or_default();
+        let start = usize::try_from(range.read_offset.max(0)).unwrap_or(usize::MAX);
+        if start > object.bytes.len() {
+            return Err(Status::out_of_range("read offset"));
+        }
+        let limit = if range.read_length <= 0 {
+            object.bytes.len() - start
+        } else {
+            usize::try_from(range.read_length).unwrap_or(usize::MAX)
+        };
+        let end = object.bytes.len().min(start.saturating_add(limit));
+        let response = BidiReadObjectResponse {
+            object_data_ranges: vec![proto::ObjectRangeData {
+                checksummed_data: Some(proto::ChecksummedData {
+                    content: object.bytes[start..end].to_vec(),
+                    crc32c: Some(crc32c::crc32c(&object.bytes[start..end])),
+                }),
+                read_range: Some(proto::ReadRange {
+                    read_offset: range.read_offset,
+                    read_length: (end - start) as i64,
+                    read_id: range.read_id,
+                }),
+                range_end: true,
+            }],
             metadata: Some(object.to_proto()),
         };
         Ok(Response::new(Box::pin(tokio_stream::iter([Ok(response)]))))


### PR DESCRIPTION
## Finding

Recovery spent **5.5–11.2s** promoting a standby, nearly all of it reading objects.

`ReadObject` blocks a **fixed 5071–5130ms opening its stream** against these appendable objects:

```
object …000b-00000000  197,990 bytes   GetObject 34.6ms  ReadObject open 5099.2ms  drain 0.60ms
object …000c-00000000   25,767 bytes   GetObject 37.0ms  ReadObject open 5129.6ms  drain 1.31ms
object …000d-00000000  105,432 bytes   GetObject 32.1ms  ReadObject open 5084.9ms  drain 0.27ms
```

Measured across two zones and three objects spanning 26KB to 198KB. `GetObject` on the same objects took 32–37ms, draining under 2ms, and **every RPC returned success** — no errors, no retries, no throttling. A cost that ignores object, size and zone is not transfer.

A `BidiReadObject` raced against one of those reads returned the **identical byte count in 53ms**.

## Change

Content comes over `BidiReadObject`, under the same generation guard and the same per-chunk CRC32C check.

**`ReadObject` is removed from the read path, not kept as a fallback.** A fallback would mean a recovery that silently costs five seconds a read and still reports success, plus a second path that never runs and therefore is never tested.

Errors carry the provider code, so the surrounding retry and quorum logic classifies a bidi failure exactly as it classified a `ReadObject` one — transient codes retry, `NotFound` and `DataLoss` keep their meaning to recovery. (As a fallback-feeder this returned `Result<_, String>` and threw that classification away.)

## The fake GCS server had no BidiReadObject

Worth calling out, because it means the previous test signal was worthless: `fake-gcs` never implemented `BidiReadObject`. Every read in the suite hit bidi, got `UNIMPLEMENTED`, and silently fell back — so **the bidi path had never been executed by a single test**, while 135 of them reported green. Removing the fallback failed eight recovery tests immediately, which is what that gap looked like.

So the subset proto and service gain `BidiReadObject`, serving the same bytes under the same guards, with field numbers matched to `google.storage.v2` since the client encodes with the real generated types.

## What this removes

Supersedes #3 and #4, and **reverts #3**.

- **#4** (parallelize seal enforcement) rested on a wrong attribution. `enforce_seal` measured 5.116s once, but on the next takeover it was 174ms with zero witness retry passes while `candidate_takeover` was 5.519s — both were waiting on the same slow read. Closed rather than merged.
- **#3** (recovery sub-phase timings) did its job: splitting prepare into its two regions localized the cost to the candidate walk, and from there to the read. With the cause fixed it is three more histograms on a client that already carries forty. Reverted.

Net: **no new metrics and no new logging.**

## Result

Staging, real leader delete under sustained enqueue load:

| | before | after |
| --- | --- | --- |
| `prepare` | 5,693 / 5,721 / 10,773 ms | **484.7 / 613.6 / 641.3 ms** |
| `total` | 6,179 / 6,169 / 11,400 ms | **945.9 / 1,072.7 / 1,132.9 ms** |

No warnings or errors of any severity since the switch.

## Testing

135 tests pass, now genuinely through bidi rather than through a fallback. `cargo clippy --workspace --all-targets -D warnings` and `cargo fmt --check` clean. Validated in staging across several failovers including pod deletes under load.

## Risks worth review

- The fake implements bidi from a hand-written subset proto, so a shape change in the real API will not be caught by these tests. Same class of risk the subset proto already carried, now extended to one more message.
- `ReadObject` is gone, so if `BidiReadObject` is unavailable in some deployment the read fails rather than degrading. That is deliberate — a silent five-second degrade is worse — but it is a behaviour change for anyone running against a backend without bidi support.

## Worth raising with the provider

The `ReadObject` behaviour looks service-side: fixed stall independent of object, size and zone; `GetObject` fast on the same object; `BidiReadObject` fast on the same generation; no error on any call.