### PR TITLE
Time every provider RPC, and count the codes they fail with

### DIFF
--- a/rust/client/src/metrics.rs
+++ b/rust/client/src/metrics.rs
@@ -143,6 +143,15 @@ impl Counter {
         Self(recorder.register_counter(name, description, &[]))
     }
 
+    fn register_with_labels(
+        recorder: &dyn MetricsRecorder,
+        name: &str,
+        description: &str,
+        labels: &[(&str, &str)],
+    ) -> Self {
+        Self(recorder.register_counter(name, description, labels))
+    }
+
     pub(crate) fn increment(&self) {
         self.add(1);
     }
@@ -229,6 +238,26 @@ impl UpDownCounter {
 
 /// Prometheus-style latency buckets in seconds, wide enough to span a fast
 /// zonal append acknowledgment and a slow regional seal alike.
+/// Every `TransportCode`, so a failure counter exists for each and a code that
+/// never fires is visibly zero rather than absent.
+const TRANSPORT_FAILURE_CODES: &[&str] = &[
+    "NotFound",
+    "AlreadyExists",
+    "InvalidArgument",
+    "FailedPrecondition",
+    "Aborted",
+    "OutOfRange",
+    "ResourceExhausted",
+    "Unimplemented",
+    "DataLoss",
+    "Ambiguous",
+    "Unauthenticated",
+    "PermissionDenied",
+    "Unavailable",
+    "DeadlineExceeded",
+    "Internal",
+];
+
 const LATENCY_SECONDS_BOUNDARIES: &[f64] = &[
     0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0,
 ];
@@ -238,6 +267,15 @@ pub(crate) struct Histogram(Arc<dyn HistogramFn>);
 impl Histogram {
     fn register(recorder: &dyn MetricsRecorder, name: &str, description: &str) -> Self {
         Self(recorder.register_histogram(name, description, &[], LATENCY_SECONDS_BOUNDARIES))
+    }
+
+    fn register_with_labels(
+        recorder: &dyn MetricsRecorder,
+        name: &str,
+        description: &str,
+        labels: &[(&str, &str)],
+    ) -> Self {
+        Self(recorder.register_histogram(name, description, labels, LATENCY_SECONDS_BOUNDARIES))
     }
 
     pub(crate) fn record_duration(&self, duration: std::time::Duration) {
@@ -293,6 +331,10 @@ pub(crate) struct Metrics {
     pub(crate) repair_failures: Counter,
     pub(crate) recoveries_run: Counter,
     pub(crate) recovery_segments_adopted: Counter,
+    /// Per-operation latency of individual provider RPCs, and the codes they
+    /// fail with. Phase timings say which part of recovery is slow; these say
+    /// which storage call is, which is the form a provider can act on.
+    pub(crate) rpc: TransportRpcMetrics,
     pub(crate) orphan_objects_deleted: Counter,
     pub(crate) orphan_sweeps_deferred: Counter,
     pub(crate) truncation_cycles: Counter,
@@ -313,6 +355,72 @@ pub(crate) struct Metrics {
     pub(crate) append_commit_latency: Histogram,
     pub(crate) manifest_cas_latency: Histogram,
     pub(crate) seal_duration: Histogram,
+}
+
+/// One histogram per provider operation, plus failures keyed by the code the
+/// provider returned. `ResourceExhausted` in particular is a per-object
+/// mutation-rate limit rather than a client fault, and is invisible in a
+/// latency figure alone.
+pub(crate) struct TransportRpcMetrics {
+    pub(crate) snapshot: Histogram,
+    pub(crate) stat: Histogram,
+    pub(crate) create_appendable: Histogram,
+    pub(crate) create_append_session: Histogram,
+    pub(crate) create_register: Histogram,
+    pub(crate) update_register: Histogram,
+    pub(crate) resume_tail: Histogram,
+    pub(crate) takeover: Histogram,
+    pub(crate) replace_appendable: Histogram,
+    pub(crate) finalize: Histogram,
+    pub(crate) delete: Histogram,
+    failures: Vec<(&'static str, Counter)>,
+}
+
+impl TransportRpcMetrics {
+    fn register(recorder: &dyn MetricsRecorder) -> Self {
+        let rpc = |op: &str| {
+            Histogram::register_with_labels(
+                recorder,
+                "chorus.wal.transport.rpc_seconds",
+                "Latency of one provider RPC",
+                &[("op", op)],
+            )
+        };
+        let failures = TRANSPORT_FAILURE_CODES
+            .iter()
+            .map(|code| {
+                (
+                    *code,
+                    Counter::register_with_labels(
+                        recorder,
+                        "chorus.wal.transport.rpc_failures",
+                        "Provider RPCs that returned an error, by provider code",
+                        &[("code", code)],
+                    ),
+                )
+            })
+            .collect();
+        Self {
+            snapshot: rpc("snapshot"),
+            stat: rpc("stat"),
+            create_appendable: rpc("create_appendable"),
+            create_append_session: rpc("create_append_session"),
+            create_register: rpc("create_register"),
+            update_register: rpc("update_register"),
+            resume_tail: rpc("resume_tail"),
+            takeover: rpc("takeover"),
+            replace_appendable: rpc("replace_appendable"),
+            finalize: rpc("finalize"),
+            delete: rpc("delete"),
+            failures,
+        }
+    }
+
+    pub(crate) fn record_failure(&self, code: &str) {
+        if let Some((_, counter)) = self.failures.iter().find(|(name, _)| *name == code) {
+            counter.increment();
+        }
+    }
 }
 
 impl Metrics {
@@ -486,6 +594,7 @@ impl Metrics {
                 "Appends waiting across the admission channel and engine queue"
             ),
             zone_durable_lag,
+            rpc: TransportRpcMetrics::register(recorder),
             rotation_state: gauge!(
                 "chorus.wal.rotation.state",
                 "Rotation gate state: 0 idle, 1 due, 2 draining, 3 sealing, 4 disabled"

--- a/rust/client/src/protocol.rs
+++ b/rust/client/src/protocol.rs
@@ -852,6 +852,18 @@ impl QuorumVolume {
         if !SUPPORTED_REPLICA_COUNTS.contains(&replicas.len()) {
             return Err(ProtocolError::ReplicaCount);
         }
+        // Wrapped here because it is the one place that holds both the
+        // replicas and the recorder, so every provider RPC on the quorum path
+        // is timed without a single call site knowing about it.
+        let replicas: Vec<Arc<dyn Replica>> = replicas
+            .into_iter()
+            .map(|replica| {
+                Arc::new(crate::transport::TimedReplica::new(
+                    replica,
+                    Arc::clone(&metrics),
+                )) as Arc<dyn Replica>
+            })
+            .collect();
         Ok(Self {
             replicas,
             config,

--- a/rust/client/src/transport.rs
+++ b/rust/client/src/transport.rs
@@ -356,6 +356,189 @@ pub trait Replica: Send + Sync {
     async fn shutdown(&self) {}
 }
 
+impl TransportCode {
+    /// Stable label for the failure counter. Matches the variant name so a
+    /// metric reads the same as the code in a log line.
+    pub(crate) fn as_metric_label(&self) -> &'static str {
+        match self {
+            TransportCode::NotFound => "NotFound",
+            TransportCode::AlreadyExists => "AlreadyExists",
+            TransportCode::InvalidArgument => "InvalidArgument",
+            TransportCode::FailedPrecondition => "FailedPrecondition",
+            TransportCode::Aborted => "Aborted",
+            TransportCode::OutOfRange => "OutOfRange",
+            TransportCode::ResourceExhausted => "ResourceExhausted",
+            TransportCode::Unimplemented => "Unimplemented",
+            TransportCode::DataLoss => "DataLoss",
+            TransportCode::Ambiguous => "Ambiguous",
+            TransportCode::Unauthenticated => "Unauthenticated",
+            TransportCode::PermissionDenied => "PermissionDenied",
+            TransportCode::Unavailable => "Unavailable",
+            TransportCode::DeadlineExceeded => "DeadlineExceeded",
+            TransportCode::Internal => "Internal",
+        }
+    }
+}
+
+/// Wraps a replica so every provider RPC reports its latency and, on failure,
+/// the code the provider returned.
+///
+/// Phase timings locate the slow part of recovery; they cannot say which
+/// storage call is slow, which is the only form a storage provider can act on.
+/// Applied once where a `QuorumVolume` is built, so no call site changes and no
+/// operation can be forgotten.
+///
+/// The lane methods (`lane_send`, `lane_send_packed`, `lane_durable_change`,
+/// `append`) delegate untimed: they run per chunk on the append hot path,
+/// where their cost is already covered by `chorus.wal.append.commit_latency`.
+pub(crate) struct TimedReplica {
+    inner: Arc<dyn Replica>,
+    metrics: Arc<crate::metrics::Metrics>,
+}
+
+impl TimedReplica {
+    pub(crate) fn new(inner: Arc<dyn Replica>, metrics: Arc<crate::metrics::Metrics>) -> Self {
+        Self { inner, metrics }
+    }
+
+    fn record<T>(
+        &self,
+        histogram: &crate::metrics::Histogram,
+        started: std::time::Instant,
+        outcome: Result<T, TransportError>,
+    ) -> Result<T, TransportError> {
+        histogram.record_duration(started.elapsed());
+        if let Err(error) = &outcome {
+            self.metrics
+                .rpc
+                .record_failure(error.code.as_metric_label());
+        }
+        outcome
+    }
+}
+
+macro_rules! timed_rpc {
+    ($self:ident, $op:ident, $call:expr) => {{
+        let started = std::time::Instant::now();
+        let outcome = $call.await;
+        $self.record(&$self.metrics.rpc.$op, started, outcome)
+    }};
+}
+
+#[async_trait]
+impl Replica for TimedReplica {
+    async fn snapshot(&self) -> Result<ReplicaSnapshot, TransportError> {
+        timed_rpc!(self, snapshot, self.inner.snapshot())
+    }
+
+    async fn stat(&self) -> Result<ReplicaSnapshot, TransportError> {
+        timed_rpc!(self, stat, self.inner.stat())
+    }
+
+    async fn create_appendable(
+        &self,
+        metadata: HashMap<String, String>,
+    ) -> Result<ReplicaSnapshot, TransportError> {
+        timed_rpc!(
+            self,
+            create_appendable,
+            self.inner.create_appendable(metadata)
+        )
+    }
+
+    async fn create_append_session(
+        &self,
+        metadata: HashMap<String, String>,
+    ) -> Result<AppendToken, TransportError> {
+        timed_rpc!(
+            self,
+            create_append_session,
+            self.inner.create_append_session(metadata)
+        )
+    }
+
+    async fn create_register(
+        &self,
+        metadata: HashMap<String, String>,
+    ) -> Result<ReplicaSnapshot, TransportError> {
+        timed_rpc!(self, create_register, self.inner.create_register(metadata))
+    }
+
+    async fn update_register(
+        &self,
+        metageneration: i64,
+        metadata: HashMap<String, String>,
+    ) -> Result<ReplicaSnapshot, TransportError> {
+        timed_rpc!(
+            self,
+            update_register,
+            self.inner.update_register(metageneration, metadata)
+        )
+    }
+
+    async fn resume_tail(&self, token: &mut AppendToken) -> Result<i64, TransportError> {
+        timed_rpc!(self, resume_tail, self.inner.resume_tail(token))
+    }
+
+    async fn takeover(&self, observed: &ReplicaSnapshot) -> Result<AppendToken, TransportError> {
+        timed_rpc!(self, takeover, self.inner.takeover(observed))
+    }
+
+    async fn replace_appendable(
+        &self,
+        observed: &ReplicaSnapshot,
+        data: Bytes,
+        metadata: HashMap<String, String>,
+    ) -> Result<AppendToken, TransportError> {
+        timed_rpc!(
+            self,
+            replace_appendable,
+            self.inner.replace_appendable(observed, data, metadata)
+        )
+    }
+
+    async fn append(
+        &self,
+        token: &AppendToken,
+        write_offset: i64,
+        data: Vec<u8>,
+    ) -> Result<i64, TransportError> {
+        self.inner.append(token, write_offset, data).await
+    }
+
+    async fn lane_send(&self, write_offset: i64, chunks: &[Bytes]) -> Result<(), TransportError> {
+        self.inner.lane_send(write_offset, chunks).await
+    }
+
+    async fn lane_send_packed(
+        &self,
+        write_offset: i64,
+        packed: &PackedAppend,
+    ) -> Result<(), TransportError> {
+        self.inner.lane_send_packed(write_offset, packed).await
+    }
+
+    async fn lane_durable_change(&self, seen: i64) -> Result<LaneDurableChange, TransportError> {
+        self.inner.lane_durable_change(seen).await
+    }
+
+    async fn delete(&self, generation: i64) -> Result<(), TransportError> {
+        timed_rpc!(self, delete, self.inner.delete(generation))
+    }
+
+    async fn finalize(
+        &self,
+        token: &mut AppendToken,
+        write_offset: i64,
+    ) -> Result<ReplicaSnapshot, TransportError> {
+        timed_rpc!(self, finalize, self.inner.finalize(token, write_offset))
+    }
+
+    async fn shutdown(&self) {
+        self.inner.shutdown().await
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::TransportCode;


### PR DESCRIPTION
Commit latency is the only view we have of the write path, and it cannot say where the time goes.

A staging drain of the job server held **~26ms mean commit latency** while the pipeline sat nearly idle:

| | ingest (low concurrency) | drain |
| --- | ---: | ---: |
| commit latency | 3.9 ms | **24.5 ms** |
| pipeline queue depth | 15.0 | **2.6** of a 32-record window |
| replica durable lag | 4.5 MB | **316 bytes** |
| lane retries / timeouts / capacity drops | 0 | **0** |

Nothing is backed up, no lane is struggling, and the record rate during the slow window (400–1,200/s) was *lower* than during the fast one. That isolates the cost to a single un-pipelined quorum round trip — and nothing we export says which RPC that round trip is waiting on.

`TimedReplica` wraps a replica and records each operation's latency under `chorus.wal.transport.rpc_seconds{op}`, plus failures under `chorus.wal.transport.rpc_failures{code}`. It is applied where a `QuorumVolume` is built — the one place holding both the replicas and the recorder — so no call site changes and no operation can be missed.

The failure codes matter as much as the latencies: a per-object mutation rate limit surfaces as a specific code on a specific op, which is a form a storage provider can act on, where an aggregate latency is not.

### Note on provenance

This restores an instrument that was dropped alongside the recovery phase metrics it originally shipped with (the reverted PR 3). Those phase histograms measured *recovery*, which we since established is not where the time goes — recovery was fixed by moving `snapshot()` off `ReadObject`. This one measures the steady-state *write* path, which is where the open question now sits.

The cherry-pick took only the transport half; the recovery histograms and seal-witness counters stay reverted. `Counter::register_with_labels` is added to mirror the one `Gauge` already had.

### Verification

- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo fmt --all --check` clean
- 164 tests pass

### Not for merge yet

Opening this to pin the job server against it for a staging measurement. Will report the numbers here before asking for merge.