### PR TITLE
Take sealed-segment repair off the startup path

### DIFF
--- a/p/model/Drivers.p
+++ b/p/model/Drivers.p
@@ -190,9 +190,9 @@ machine SealedRepairDriver {
 }
 
 // An older sealed segment has one manifest-checksum-valid copy, one corrupt
-// reachable copy, and one unavailable copy. Startup must restore the corrupt
-// live zone before it declares the historical directory safe.
-machine HistoricalRecoveryRepairDriver {
+// reachable copy, and one unavailable copy. Background repair must restore the
+// corrupt live zone rather than leaving the entry on a single copy.
+machine HistoricalMaintenanceRepairDriver {
     start state Init {
         entry {
             var buckets: seq[ZonalBucket];
@@ -226,7 +226,7 @@ machine HistoricalRecoveryRepairDriver {
             assert stopped.committed && stopped.sealed;
 
             // Commit a later seal so directory[0] is historical rather than
-            // the current seal whose enforcement already runs synchronously.
+            // the current seal, which recovery still enforces synchronously.
             send manifest, eManifestRead, (caller=this,);
             receive { case eManifestReadResponse: (r: tManifestReadResponse) {
                 readResponse = r;
@@ -255,7 +255,7 @@ machine HistoricalRecoveryRepairDriver {
                 historical.id != next.sealId;
 
             // Synchronizing probes ensure the corruption and crash have been
-            // applied before the startup repair coordinator reads the zones.
+            // applied before the repair coordinator reads the zones.
             send buckets[1], eCorruptRecord, (offset=0,);
             send buckets[1], eRead, (
                 caller=this, segment=historical.base, gen=-1);
@@ -271,7 +271,7 @@ machine HistoricalRecoveryRepairDriver {
             } }
             assert objectResponse.status == STATUS_TRANSIENT;
 
-            new HistoricalRecoveryCoordinator((
+            new HistoricalMaintenanceCoordinator((
                 buckets=buckets,
                 directoryEntry=historical,
                 expectedChecksum=77,

--- a/p/model/Monitors.p
+++ b/p/model/Monitors.p
@@ -597,16 +597,19 @@ spec DirectoryEnforcement observes eSealQuorumEnforced, eDirectoryAdopted,
     }
 }
 
-// Recovery may trust one finalized historical copy only because the manifest
-// checksum identifies its exact bytes. It must copy those bytes to another
-// reachable zone and restore a quorum before admitting new work.
-spec HistoricalRecoveryQuorum observes eHistoricalRecoveryReady {
+// Repair may trust one finalized historical copy only because the manifest
+// checksum identifies its exact bytes. Whenever it acts on a directory entry it
+// must copy those bytes to another reachable zone and leave a restored quorum
+// behind. Recovery does not observe this: sealed history is repaired by
+// background maintenance, and a startup that waited on it would pay a cost
+// proportional to retained history.
+spec HistoricalMaintenanceQuorum observes eHistoricalMaintenanceRepaired {
     start state Observing {
-        on eHistoricalRecoveryReady do (payload: (
+        on eHistoricalMaintenanceRepaired do (payload: (
             segment: int, checksum: int, healthyZones: set[int]
         )) {
             assert sizeof(payload.healthyZones) >= 2,
-                "startup completed with historical data on fewer than two zones";
+                "repair finished with historical data on fewer than two zones";
         }
     }
 }

--- a/p/model/PipelinedWal.p
+++ b/p/model/PipelinedWal.p
@@ -956,11 +956,13 @@ machine SealedRepairCoordinator {
     }
 }
 
-// Startup repair for one historical manifest-directory entry. The production
+// Background repair for one historical manifest-directory entry. The production
 // directory carries a CRC32C; `expectedChecksum` is its equality-only model
-// surrogate. Recovery may source repair from one exact checksum match, but
-// readiness still requires a restored quorum.
-machine HistoricalRecoveryCoordinator {
+// surrogate. Repair may source from one exact checksum match, but it must leave
+// a restored quorum behind. Production decides which entries reach this point
+// from object metadata alone; the model reads content because it has no
+// metadata-checksum surrogate.
+machine HistoricalMaintenanceCoordinator {
     start state Run {
         entry (payload: (
             buckets: seq[ZonalBucket],
@@ -1023,7 +1025,7 @@ machine HistoricalRecoveryCoordinator {
                     }
                 }
             }
-            announce eHistoricalRecoveryReady, (
+            announce eHistoricalMaintenanceRepaired, (
                 segment=payload.directoryEntry.base,
                 checksum=payload.expectedChecksum,
                 healthyZones=healthy);

--- a/p/model/Tests.p
+++ b/p/model/Tests.p
@@ -43,13 +43,13 @@ test tcImmutableSealedRepair [main=SealedRepairDriver]:
     (union { WriterProcess }, { SealedRepairCoordinator }, { ZonalBucket },
         { ManifestRegister }, { SealedRepairDriver });
 
-test tcHistoricalRecoveryRepair [main=HistoricalRecoveryRepairDriver]:
+test tcHistoricalMaintenanceRepair [main=HistoricalMaintenanceRepairDriver]:
     assert QuorumLinearizability, SingleWriterPerSegment, SealAndPrefixSafety,
         ManifestSafety, PendingRegistrationSafety, DirectoryStructure,
-        DirectoryEnforcement, HistoricalRecoveryQuorum in
-    (union { WriterProcess }, { HistoricalRecoveryCoordinator },
+        DirectoryEnforcement, HistoricalMaintenanceQuorum in
+    (union { WriterProcess }, { HistoricalMaintenanceCoordinator },
         { ZonalBucket }, { ManifestRegister },
-        { HistoricalRecoveryRepairDriver });
+        { HistoricalMaintenanceRepairDriver });
 
 test tcGetSizeExcludesOpenTail [main=GetSizeDriver]:
     assert QuorumLinearizability, SingleWriterPerSegment,

--- a/p/model/Types.p
+++ b/p/model/Types.p
@@ -234,9 +234,9 @@ event eSealQuorumEnforced: (
 event eSealedCopyRepaired: (
     zone: int, segment: int, endOffset: int, recordCount: int
 );
-// Model-only startup-repair observation. `checksum` is the equality-only
+// Model-only background-repair observation. `checksum` is the equality-only
 // surrogate for the CRC32C committed in the production directory entry.
-event eHistoricalRecoveryReady: (
+event eHistoricalMaintenanceRepaired: (
     segment: int, checksum: int, healthyZones: set[int]
 );
 event eSegmentSealed: (segment: int, endOffset: int);

--- a/rust/client/src/grpc.rs
+++ b/rust/client/src/grpc.rs
@@ -1198,12 +1198,19 @@ impl ReplicaFactory for GrpcReplicaFactory {
                 .await
                 .map_err(|status| replica.status(status))?
                 .into_inner();
-            listed.extend(response.objects.into_iter().map(|object| ListedObject {
-                zone: self.zone,
-                name: object.name,
-                generation: object.generation,
-                finalized: object.finalize_time.is_some(),
-                metadata: object.metadata,
+            listed.extend(response.objects.into_iter().map(|object| {
+                ListedObject {
+                    zone: self.zone,
+                    name: object.name,
+                    generation: object.generation,
+                    size: object.size,
+                    finalized: object.finalize_time.is_some(),
+                    crc32c: object
+                        .checksums
+                        .as_ref()
+                        .and_then(|checksums| checksums.crc32c),
+                    metadata: object.metadata,
+                }
             }));
             if response.next_page_token.is_empty() {
                 return Ok(listed);

--- a/rust/client/src/grpc_internal_tests/recovery.rs
+++ b/rust/client/src/grpc_internal_tests/recovery.rs
@@ -260,12 +260,12 @@ async fn recovery_repairs_a_lagging_prior_segment_before_the_active_segment() {
 }
 
 #[tokio::test]
-async fn recovery_repairs_historical_segment_to_quorum_before_returning() {
-    let (servers, factories, manifest_factory) = factory_cluster().await;
+async fn recovery_adopts_a_historical_segment_without_reading_it() {
+    let (_servers, factories, manifest_factory) = factory_cluster().await;
     let volume = volume(
         factories.clone(),
         manifest_factory.clone(),
-        "startup-historical-repair-wal",
+        "startup-historical-adopt-wal",
     );
     let mut writer = volume.recover_writer().await.unwrap();
     append_one(&mut writer, b"historical").await;
@@ -279,29 +279,36 @@ async fn recovery_repairs_historical_segment_to_quorum_before_returning() {
         writer.catalog().last().map(|segment| segment.id.as_str()),
         "the test must damage an older directory entry, not the current seal"
     );
-    let object = segment_object("startup-historical-repair-wal", &historical.id);
-    let missing = factories[1].replica(&object);
-    let generation = missing.snapshot().await.unwrap().generation;
-    missing.delete(generation).await.unwrap();
-    servers[0].service.set_crashed(true).await;
+    // Every copy of the oldest entry disappears. The committed directory still
+    // names its range and CRC32C, so recovery has everything it needs to adopt
+    // the chain; a startup that consulted storage instead could not proceed.
+    let object = segment_object("startup-historical-adopt-wal", &historical.id);
+    for factory in &factories {
+        let replica = factory.replica(&object);
+        let generation = replica.snapshot().await.unwrap().generation;
+        replica.delete(generation).await.unwrap();
+    }
     drop(writer);
 
-    let recovered = volume.recover_writer().await.unwrap();
+    let recovered = volume
+        .recover_writer_from(WalSeqNo::record(2))
+        .await
+        .unwrap();
     assert_eq!(recovered.active_segment_base(), 2);
-
-    let repaired = missing.snapshot().await.unwrap();
-    assert!(repaired.finalized);
-    assert_eq!(repaired.crc32c, historical.crc32c);
-    assert_eq!(crc32c::crc32c(&repaired.bytes), historical.crc32c.unwrap());
+    assert_eq!(
+        recovered.catalog()[0].id,
+        historical.id,
+        "the unreadable entry stays in the chain for background repair"
+    );
 }
 
 #[tokio::test]
-async fn recovery_repairs_bit_rotted_historical_segment_before_returning() {
-    let (servers, factories, manifest_factory) = factory_cluster().await;
-    let volume = volume(
+async fn maintenance_restores_a_historical_segment_recovery_left_damaged() {
+    let (_servers, factories, manifest_factory) = factory_cluster().await;
+    let (volume, metrics) = volume_with_metrics(
         factories.clone(),
         manifest_factory.clone(),
-        "startup-historical-rot-repair-wal",
+        "startup-historical-repair-wal",
     );
     let mut writer = volume.recover_writer().await.unwrap();
     append_one(&mut writer, b"historical").await;
@@ -310,23 +317,74 @@ async fn recovery_repairs_bit_rotted_historical_segment_before_returning() {
     writer.rotate().await.unwrap();
 
     let historical = writer.catalog()[0].clone();
-    let object = segment_object("startup-historical-rot-repair-wal", &historical.id);
+    let object = segment_object("startup-historical-repair-wal", &historical.id);
+    let missing = factories[1].replica(&object);
+    let generation = missing.snapshot().await.unwrap().generation;
+    missing.delete(generation).await.unwrap();
+    drop(writer);
+
+    let recovered = volume.recover_writer().await.unwrap();
+    assert_eq!(recovered.active_segment_base(), 2);
+    assert_eq!(
+        missing.snapshot().await.unwrap_err().code,
+        TransportCode::NotFound,
+        "recovery must not spend startup time restoring sealed history"
+    );
+
+    let handle = WalEngine::start(
+        recovered,
+        WalEngineConfig {
+            repair_interval: None,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    wait_for_repair_passes(&metrics, 1).await;
+    assert_eq!(metrics.counter("chorus.wal.repair.objects_repaired"), 1);
+    assert_eq!(
+        metrics.counter("chorus.wal.repair.segments_without_source"),
+        0
+    );
+
+    let repaired = missing.snapshot().await.unwrap();
+    assert!(repaired.finalized);
+    assert_eq!(repaired.crc32c, historical.crc32c);
+    assert_eq!(crc32c::crc32c(&repaired.bytes), historical.crc32c.unwrap());
+    shutdown_engine(handle).await;
+}
+
+#[tokio::test]
+async fn replay_reads_past_a_rotted_historical_copy() {
+    let (servers, factories, manifest_factory) = factory_cluster().await;
+    let volume = volume(
+        factories.clone(),
+        manifest_factory.clone(),
+        "startup-historical-rot-wal",
+    );
+    let mut writer = volume.recover_writer().await.unwrap();
+    append_one(&mut writer, b"historical").await;
+    writer.rotate().await.unwrap();
+    append_one(&mut writer, b"current-seal").await;
+    writer.rotate().await.unwrap();
+
+    let historical = writer.catalog()[0].clone();
+    let object = segment_object("startup-historical-rot-wal", &historical.id);
+    // Rot leaves the recorded checksum intact and fails the content read, so no
+    // listing or stat can see it. The read path is what notices: it verifies
+    // every copy it consumes against the committed CRC32C and takes the next
+    // one.
     assert!(
         servers[1]
             .service
             .corrupt_byte_for("projects/_/buckets/zone-1", &object, 0)
             .await
     );
-    servers[0].service.set_crashed(true).await;
     drop(writer);
 
-    let recovered = volume.recover_writer().await.unwrap();
-    assert_eq!(recovered.active_segment_base(), 2);
-
-    let repaired = factories[1].replica(&object).snapshot().await.unwrap();
-    assert!(repaired.finalized);
-    assert_eq!(repaired.crc32c, historical.crc32c);
-    assert_eq!(crc32c::crc32c(&repaired.bytes), historical.crc32c.unwrap());
+    let (end, records) = recover_records(&volume, WalSeqNo::ZERO).await;
+    assert_eq!(end, WalSeqNo::record(2));
+    assert_eq!(records[0].payload, b"historical".as_slice());
+    assert_eq!(records[1].payload, b"current-seal".as_slice());
 }
 
 #[tokio::test]
@@ -362,7 +420,7 @@ async fn rejoined_zone_receives_only_immutable_sealed_segment_repair() {
 }
 
 #[tokio::test]
-async fn repair_uses_stat_crc32c_to_target_same_size_divergence() {
+async fn repair_uses_the_listing_crc32c_to_target_same_size_divergence() {
     let (servers, factories, manifest_factory) = factory_cluster().await;
     let volume = volume(
         factories.clone(),
@@ -403,6 +461,12 @@ async fn repair_uses_stat_crc32c_to_target_same_size_divergence() {
     assert_eq!(servers[0].service.operation_count(Operation::Read).await, 1);
     assert_eq!(servers[1].service.operation_count(Operation::Read).await, 0);
     assert!(servers[2].service.operation_count(Operation::Read).await >= 1);
+    // One listing per zone answers the health question for the whole chain, so
+    // an untouched copy costs no per-object metadata read at all.
+    for server in &servers[..3] {
+        assert_eq!(server.service.operation_count(Operation::List).await, 1);
+    }
+    assert_eq!(servers[1].service.operation_count(Operation::Get).await, 0);
 
     let repaired = factories[2]
         .replica(&sealed_object)
@@ -411,6 +475,84 @@ async fn repair_uses_stat_crc32c_to_target_same_size_divergence() {
         .unwrap();
     assert_eq!(repaired.bytes, canonical.bytes);
     assert_eq!(repaired.crc32c, segment.crc32c);
+}
+
+#[tokio::test]
+async fn repair_lists_each_zone_once_regardless_of_retained_history() {
+    let (servers, factories, manifest_factory) = factory_cluster().await;
+    let volume = volume(
+        factories.clone(),
+        manifest_factory.clone(),
+        "repair-listing-wal",
+    );
+    let mut writer = volume.recover_writer().await.unwrap();
+    for payload in [
+        b"first".as_slice(),
+        b"second".as_slice(),
+        b"third".as_slice(),
+    ] {
+        append_one(&mut writer, payload).await;
+        writer.rotate().await.unwrap();
+    }
+    // three sealed entries plus the open frontier the last rotation installed
+    assert_eq!(writer.catalog().len(), 4);
+    let damaged = writer.catalog()[1].clone();
+    let object = segment_object("repair-listing-wal", &damaged.id);
+    let missing = factories[2].replica(&object);
+    let generation = missing.snapshot().await.unwrap().generation;
+    missing.delete(generation).await.unwrap();
+
+    for server in &servers[..3] {
+        server.service.reset_operation_counts().await;
+    }
+    let report = writer.repair_sealed_segments().await.unwrap();
+    assert_eq!(report.segments_examined, 3);
+    assert_eq!(report.objects_repaired, 1);
+    assert_eq!(report.objects_already_healthy, 8);
+    assert_eq!(report.segments_without_source, 0);
+    for server in &servers[..3] {
+        assert_eq!(server.service.operation_count(Operation::List).await, 1);
+    }
+    // Only the one segment that needs a source is read at all, and a zone whose
+    // copies are all intact answers no per-object question whatsoever.
+    assert_eq!(servers[0].service.operation_count(Operation::Read).await, 1);
+    assert_eq!(servers[1].service.operation_count(Operation::Read).await, 0);
+    assert_eq!(servers[1].service.operation_count(Operation::Get).await, 0);
+}
+
+#[tokio::test]
+async fn repair_reports_a_segment_with_no_verifiable_copy_and_keeps_going() {
+    let (_servers, factories, manifest_factory) = factory_cluster().await;
+    let volume = volume(
+        factories.clone(),
+        manifest_factory.clone(),
+        "repair-lost-segment-wal",
+    );
+    let mut writer = volume.recover_writer().await.unwrap();
+    for payload in [b"lost".as_slice(), b"kept".as_slice()] {
+        append_one(&mut writer, payload).await;
+        writer.rotate().await.unwrap();
+    }
+    let lost = writer.catalog()[0].clone();
+    let kept = writer.catalog()[1].clone();
+    let lost_object = segment_object("repair-lost-segment-wal", &lost.id);
+    for factory in &factories {
+        let replica = factory.replica(&lost_object);
+        let generation = replica.snapshot().await.unwrap().generation;
+        replica.delete(generation).await.unwrap();
+    }
+    let kept_object = segment_object("repair-lost-segment-wal", &kept.id);
+    let missing = factories[2].replica(&kept_object);
+    let generation = missing.snapshot().await.unwrap().generation;
+    missing.delete(generation).await.unwrap();
+
+    // Nothing else inspects sealed history, so an unrecoverable entry must be
+    // counted rather than swallowed, and must not stop the entries after it
+    // from being restored.
+    let report = writer.repair_sealed_segments().await.unwrap();
+    assert_eq!(report.segments_without_source, 1);
+    assert_eq!(report.objects_repaired, 1);
+    assert!(missing.snapshot().await.unwrap().finalized);
 }
 
 /// Maintenance runs on its own task; poll until `minimum` passes complete.

--- a/rust/client/src/lib.rs
+++ b/rust/client/src/lib.rs
@@ -23,8 +23,11 @@
 //! delete whole sealed segments below that checkpoint. Startup and periodic
 //! maintenance retry already-authorized deletion tombstones before repairing
 //! missing immutable sealed copies; degraded rotations also schedule a targeted
-//! repair. Active segments are never repaired in place, and maintenance never
-//! advances the database's checkpoint floor autonomously. See the `database_wal`
+//! repair. Recovery itself never inspects sealed history: it adopts the
+//! committed directory and starts serving, and background maintenance owns
+//! restoring a finalized quorum for older segments. Active segments are never
+//! repaired in place, and maintenance never advances the database's checkpoint
+//! floor autonomously. See the `database_wal`
 //! example for the complete lifecycle.
 //! Every fallible public operation returns [`Error`].
 //!

--- a/rust/client/src/maintenance.rs
+++ b/rust/client/src/maintenance.rs
@@ -752,6 +752,9 @@ impl MaintenanceState {
                 self.metrics
                     .repair_transient_skips
                     .add(report.transient_failures as u64);
+                self.metrics
+                    .repair_segments_without_source
+                    .add(report.segments_without_source as u64);
                 if report.objects_repaired > 0 {
                     tracing::info!(
                         segments_examined = report.segments_examined,
@@ -769,6 +772,17 @@ impl MaintenanceState {
                         transient_failures = report.transient_failures,
                         floor,
                         "repair pass left transient failures"
+                    );
+                }
+                if report.segments_without_source > 0 {
+                    // Recovery no longer inspects sealed history, so this pass
+                    // is the only place committed history below a finalized
+                    // quorum can be noticed at all.
+                    tracing::error!(
+                        segments_examined = report.segments_examined,
+                        segments_without_source = report.segments_without_source,
+                        floor,
+                        "repair pass found committed sealed segments with no verifiable copy"
                     );
                 }
             }
@@ -825,6 +839,9 @@ impl MaintenanceState {
                 self.metrics
                     .repair_transient_skips
                     .add(report.transient_failures as u64);
+                self.metrics
+                    .repair_segments_without_source
+                    .add(report.segments_without_source as u64);
                 if report.objects_repaired > 0 {
                     tracing::info!(
                         segment_base = segment.base_record_index,

--- a/rust/client/src/metrics.rs
+++ b/rust/client/src/metrics.rs
@@ -290,6 +290,7 @@ pub(crate) struct Metrics {
     pub(crate) repair_passes: Counter,
     pub(crate) repair_objects_repaired: Counter,
     pub(crate) repair_transient_skips: Counter,
+    pub(crate) repair_segments_without_source: Counter,
     pub(crate) repair_failures: Counter,
     pub(crate) recoveries_run: Counter,
     pub(crate) recovery_segments_adopted: Counter,
@@ -422,6 +423,10 @@ impl Metrics {
             repair_transient_skips: counter!(
                 "chorus.wal.repair.transient_skips",
                 "Repair targets skipped after transient failures"
+            ),
+            repair_segments_without_source: counter!(
+                "chorus.wal.repair.segments_without_source",
+                "Sealed segments left unrepaired because no reachable copy verified"
             ),
             repair_failures: counter!(
                 "chorus.wal.repair.failures",

--- a/rust/client/src/segment.rs
+++ b/rust/client/src/segment.rs
@@ -23,7 +23,9 @@ use crate::protocol::{
     ProtocolError, QuorumVolume, RecoveredTail, RecoveryCandidate, Writer,
 };
 use crate::record::RecordFrame;
-use crate::transport::{Replica, ReplicaFactory, ReplicaSnapshot, TransportCode, TransportError};
+use crate::transport::{
+    ListedObject, Replica, ReplicaFactory, ReplicaSnapshot, TransportCode, TransportError,
+};
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 /// Quorum-derived state of one opaque segment-object id across replicas.
@@ -42,9 +44,11 @@ pub(crate) struct SegmentDescriptor {
     pub end_record_index: u64,
     /// Full-object CRC32C committed in the manifest directory.
     pub crc32c: u32,
-    /// Number of zones where listing observed the object.
+    /// Number of zones where the most recent metadata observation found the
+    /// object. Zero for an entry adopted straight from the committed manifest
+    /// directory, which recovery accepts without touching storage.
     pub copies: usize,
-    /// Number of observed copies finalized by GCS.
+    /// Number of observed copies finalized by GCS, under the same convention.
     pub finalized_copies: usize,
     /// The fold CAS committed this seal, but the maintenance task has not
     /// finalized the object yet. Repair skips it — there is no finalized
@@ -95,8 +99,8 @@ pub struct SegmentedVolume {
 
 /// Wall-clock cost of the recovery phases that finish before the replay stream
 /// is handed back. `epoch_claim` is the manifest CAS that fences prior writers;
-/// `prepare` covers directory adoption and repair, committed-seal enforcement,
-/// and the appendable-candidate takeover walk. Replay and [`Recovery::start`]
+/// `prepare` covers directory adoption, committed-seal enforcement, and the
+/// appendable-candidate takeover walk. Replay and [`Recovery::start`]
 /// are timed by the caller. This is diagnostic only and is never read on the
 /// correctness path.
 #[derive(Clone, Copy, Debug, Default)]
@@ -104,7 +108,8 @@ pub struct RecoveryTimings {
     /// Duration of the manifest claim CAS that fences prior writers.
     pub epoch_claim: Duration,
     /// Duration of directory adoption, committed-seal enforcement, and the
-    /// appendable-candidate takeover walk.
+    /// appendable-candidate takeover walk. Bounded by the write frontier: it
+    /// does not grow with the amount of sealed history the volume retains.
     pub prepare: Duration,
 }
 
@@ -112,6 +117,9 @@ pub struct RecoveryTimings {
 ///
 /// Recovery claims an epoch, adopts the directory, and walks the manifest's
 /// ordered `[tail, pending?]` candidates with takeover-before-size fencing.
+/// Adoption is a manifest-only step: the committed directory names each
+/// retained segment's range and CRC32C, so restoring a sealed segment's zonal
+/// copies belongs to background maintenance, not to startup.
 /// This stream then emits the fixed range `[from, end)`. Consume it through
 /// `None` before calling [`start`](Self::start), which resumes the takeover
 /// handle for the first empty frontier or conditionally creates the bootstrap
@@ -424,8 +432,14 @@ pub struct RepairReport {
     pub objects_repaired: usize,
     /// Zonal copies already matching the immutable sealed source.
     pub objects_already_healthy: usize,
-    /// Transiently unavailable targets left for a later pass.
+    /// Transiently unavailable targets left for a later pass, including copies
+    /// in a zone that did not answer its listing.
     pub transient_failures: usize,
+    /// Segments whose committed bytes could not be assembled from any reachable
+    /// copy, so their damaged copies stay damaged. Nothing else observes sealed
+    /// history, so a nonzero count is the only signal that committed history has
+    /// fallen below a finalized quorum.
+    pub segments_without_source: usize,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -749,10 +763,11 @@ mod recovery {
         /// Recover the committed chain and repair immutable sealed segment copies.
         ///
         /// This volume-level primitive is intended for diagnostic and maintenance
-        /// tools that need a detailed [`RepairReport`]. Applications should run the
-        /// WAL engine, which performs the same repair automatically in the
-        /// background. The operation claims the WAL writer epoch and creates the
-        /// next active segment, just like normal recovery startup.
+        /// tools that need a detailed [`RepairReport`] on demand. Applications
+        /// should run the WAL engine, which performs the same repair in the
+        /// background; recovery itself never inspects sealed history. The
+        /// operation claims the WAL writer epoch and creates the next active
+        /// segment, just like normal recovery startup.
         pub async fn repair_sealed_segments(&self) -> Result<RepairReport, Error> {
             let mut recovery = self.recover_from_committed_floor().await?;
             while let Some(record) = recovery.next().await {
@@ -928,14 +943,26 @@ mod recovery {
             let checkpoint_floor = adopted.trunc.max(checkpoint.record_index);
             let mut sealed_segments = Vec::with_capacity(chain.len() + 1);
             for (id, base, end, crc32c) in &chain {
-                // The most recent seal may still have enforcement in flight, so
-                // recover and enforce it against the committed digest. Older
-                // entries once reached a finalized quorum, but may since have
-                // lost replicas. Before startup continues, use the directory
-                // CRC32C to find any surviving canonical copy, repair reachable
-                // missing or divergent copies, and require a restored quorum.
-                // This closes the window where startup could admit new commits
-                // while old committed history survived on only one zone.
+                // Startup cost is bounded by the write frontier, never by
+                // retained history. The committed directory is the chain
+                // authority: it already names every retained entry's range and
+                // full-object CRC32C, so adopting one costs a vector push and
+                // no object access. Zonal copies of old history may since have
+                // been lost or diverged; proving otherwise means touching every
+                // retained object, which is the cost this path must not pay.
+                // Old entries therefore enter the catalog unverified, and the
+                // background repair pass owns restoring their finalized quorum
+                // from the same committed CRC32C.
+                //
+                // The most recent seal differs in kind, not degree. The engine
+                // gates its next rotation on a seal reaching a finalized
+                // quorum, so `seal_id` is the one entry whose enforcement can
+                // still be in flight when a writer dies: its bytes may exist
+                // only as unfinalized appendable content, which no reader can
+                // consume. Replay and every later rotation depend on that one
+                // committed decision, so recovery finishes it here.
+                // `finalized_segment_descriptor` settles the healthy case from
+                // `stat` metadata alone, and there is only ever one such entry.
                 if adopted.seal_id.as_deref() == Some(id.as_str()) {
                     let expected_digest = (adopted.seal_base == Some(*base))
                         .then(|| adopted.seal_digest.clone())
@@ -952,7 +979,7 @@ mod recovery {
                         .await?;
                     sealed_segments.push(sealed);
                 } else {
-                    let mut sealed = SegmentDescriptor {
+                    sealed_segments.push(SegmentDescriptor {
                         id: id.clone(),
                         base_record_index: *base,
                         end_record_index: *end,
@@ -960,12 +987,7 @@ mod recovery {
                         copies: 0,
                         finalized_copies: 0,
                         seal_pending: false,
-                    };
-                    let healthy =
-                        restore_sealed_quorum(&self.factories, &self.prefix, &sealed).await?;
-                    sealed.copies = healthy;
-                    sealed.finalized_copies = healthy;
-                    sealed_segments.push(sealed);
+                    });
                 }
             }
 
@@ -1003,9 +1025,9 @@ mod recovery {
                     } => {
                         let active_id = fresh_id();
                         let pending_id = fresh_id();
-                        let (_, active_writer) = self.provision_segment(active_id.clone()).await?;
-                        let (_, pending_writer) =
-                            self.provision_segment(pending_id.clone()).await?;
+                        let (active_writer, pending_writer) = self
+                            .provision_frontier(active_id.clone(), pending_id.clone())
+                            .await?;
                         manifest
                             .replace_empty_frontier(
                                 Some(&tail_id),
@@ -1040,9 +1062,9 @@ mod recovery {
                     RecoveredManifestCandidate::Absent => {
                         let active_id = fresh_id();
                         let pending_id = fresh_id();
-                        let (_, active_writer) = self.provision_segment(active_id.clone()).await?;
-                        let (_, pending_writer) =
-                            self.provision_segment(pending_id.clone()).await?;
+                        let (active_writer, pending_writer) = self
+                            .provision_frontier(active_id.clone(), pending_id.clone())
+                            .await?;
                         manifest
                             .replace_empty_frontier(
                                 Some(&tail_id),
@@ -1085,10 +1107,11 @@ mod recovery {
                             | RecoveredManifestCandidate::Absent => {
                                 let active_id = fresh_id();
                                 let replacement_pending_id = fresh_id();
-                                let (_, active_writer) =
-                                    self.provision_segment(active_id.clone()).await?;
-                                let (_, pending_writer) = self
-                                    .provision_segment(replacement_pending_id.clone())
+                                let (active_writer, pending_writer) = self
+                                    .provision_frontier(
+                                        active_id.clone(),
+                                        replacement_pending_id.clone(),
+                                    )
                                     .await?;
                                 manifest
                                     .replace_empty_frontier(
@@ -1153,10 +1176,11 @@ mod recovery {
                             predecessor.enforce_seal(&self.metrics).await?;
                             let active_id = fresh_id();
                             let replacement_pending_id = fresh_id();
-                            let (_, active_writer) =
-                                self.provision_segment(active_id.clone()).await?;
-                            let (_, pending_writer) = self
-                                .provision_segment(replacement_pending_id.clone())
+                            let (active_writer, pending_writer) = self
+                                .provision_frontier(
+                                    active_id.clone(),
+                                    replacement_pending_id.clone(),
+                                )
                                 .await?;
                             manifest
                                 .fold_pending(&PendingFold {
@@ -1189,10 +1213,11 @@ mod recovery {
                                     .expect("non-empty tail produced one predecessor");
                                 let active_id = fresh_id();
                                 let replacement_pending_id = fresh_id();
-                                let (_, active_writer) =
-                                    self.provision_segment(active_id.clone()).await?;
-                                let (_, pending_writer) = self
-                                    .provision_segment(replacement_pending_id.clone())
+                                let (active_writer, pending_writer) = self
+                                    .provision_frontier(
+                                        active_id.clone(),
+                                        replacement_pending_id.clone(),
+                                    )
                                     .await?;
                                 manifest
                                     .fold_pending(&PendingFold {
@@ -1614,6 +1639,22 @@ mod recovery {
 
         fn segment_object(&self, id: &str) -> String {
             format!("{}{id}", self.segments_prefix())
+        }
+
+        /// Create both frontier objects at once. Each create already fans out
+        /// across the zones, so issuing the pair together leaves recovery's
+        /// object provisioning one round trip deep instead of two.
+        async fn provision_frontier(
+            &self,
+            active_id: String,
+            pending_id: String,
+        ) -> Result<(Writer, Writer), Error> {
+            let ((_, active), (_, pending)) = futures::future::try_join(
+                self.provision_segment(active_id),
+                self.provision_segment(pending_id),
+            )
+            .await?;
+            Ok((active, pending))
         }
 
         async fn provision_segment(&self, id: String) -> Result<(String, Writer), Error> {
@@ -2450,10 +2491,90 @@ mod maintenance {
         })
     }
 
-    /// One repair pass over `segments` at the committed `floor`: stat-precheck
-    /// every copy, re-replicate from a healthy finalized source only when a copy
-    /// is missing, rotted, or divergent. Free of writer state so the background
-    /// maintenance task can run it concurrently with appends.
+    /// Metadata-only health picture of one WAL prefix's segment objects, built
+    /// from one strongly consistent listing per zone.
+    ///
+    /// A listing costs the same one round trip per zone whatever the retained
+    /// history, and it carries everything a health decision needs: presence,
+    /// finalization, the format marker, and the provider's durable CRC32C. That
+    /// is the same checksum a `stat` returns, so a listing decides every copy of
+    /// every segment without a per-object metadata read and without a content
+    /// read.
+    struct SealedCopyIndex {
+        /// One entry per zone, in factory order. `None` marks a zone whose
+        /// listing failed: its copies are unknown for this pass, so repair
+        /// leaves them alone rather than rewriting from a guess.
+        zones: Vec<Option<HashMap<String, ListedObject>>>,
+    }
+
+    /// Health of one zonal copy as the listing describes it.
+    enum CopyHealth {
+        /// Present, finalized, well-formed, and carrying the committed CRC32C.
+        Healthy,
+        /// Absent, unfinalized, or carrying a different CRC32C.
+        Damaged,
+        /// The zone did not answer its listing.
+        Unknown,
+    }
+
+    impl SealedCopyIndex {
+        async fn build(factories: &[Arc<dyn ReplicaFactory>], prefix: &str) -> Self {
+            let objects_prefix = format!("{prefix}/segments/");
+            let listings = join_all(
+                factories
+                    .iter()
+                    .map(|factory| factory.list(&objects_prefix)),
+            )
+            .await;
+            let zones = listings
+                .into_iter()
+                .map(|listing| {
+                    listing.ok().map(|objects| {
+                        objects
+                            .into_iter()
+                            .map(|object| (object.name.clone(), object))
+                            .collect()
+                    })
+                })
+                .collect();
+            Self { zones }
+        }
+
+        fn health(&self, zone: usize, object: &str, expected_crc32c: u32) -> CopyHealth {
+            let Some(Some(listed)) = self.zones.get(zone) else {
+                return CopyHealth::Unknown;
+            };
+            match listed.get(object) {
+                Some(found)
+                    if found.finalized
+                        && valid_format(&found.metadata)
+                        && found.crc32c == Some(expected_crc32c) =>
+                {
+                    CopyHealth::Healthy
+                }
+                _ => CopyHealth::Damaged,
+            }
+        }
+    }
+
+    /// One repair pass over `segments` at the committed `floor`: assess every
+    /// copy from the zonal listings, then read bytes and re-replicate only for a
+    /// segment that actually has a damaged or missing copy. Free of writer state
+    /// so the background maintenance task can run it concurrently with appends.
+    ///
+    /// The pass is the sole owner of sealed-history durability: recovery adopts
+    /// the committed directory without touching storage, so nothing else ever
+    /// notices that an old segment dropped below a finalized quorum. One damaged
+    /// segment therefore must not end the pass — the entries after it need the
+    /// same attention — so a segment with no readable source is counted and the
+    /// walk continues.
+    ///
+    /// A listing (like a `stat`) reports the checksum the provider recorded at
+    /// write time. It identifies a missing, unfinalized, or divergent copy, and
+    /// it cannot identify a copy whose stored bytes rotted underneath an intact
+    /// recorded checksum. Such a copy fails its content read instead, which is
+    /// where replay skips it and where [`repair_sealed_copy`] recognizes it as a
+    /// target.
     pub(crate) async fn repair_sealed_pass(
         factories: &[Arc<dyn ReplicaFactory>],
         prefix: &str,
@@ -2461,6 +2582,7 @@ mod maintenance {
         floor: u64,
     ) -> Result<RepairReport, Error> {
         let mut report = RepairReport::default();
+        let index = SealedCopyIndex::build(factories, prefix).await;
         for segment in segments {
             if segment.end_record_index < floor {
                 continue;
@@ -2476,21 +2598,13 @@ mod maintenance {
             let object = segment_object(prefix, &segment.id);
             let expected_crc32c = segment.crc32c;
 
-            // Health pre-check by stat only. The committed CRC32C independently
-            // identifies every healthy copy without a content read.
             let replicas = replicas_for(factories, &object);
-            let stats = join_all(replicas.iter().map(|replica| replica.stat())).await;
             let mut targets = Vec::new();
-            for (replica, stat) in replicas.iter().zip(stats) {
-                let healthy = stat.is_ok_and(|stat| {
-                    stat.finalized
-                        && valid_format(&stat.metadata)
-                        && stat.crc32c == Some(expected_crc32c)
-                });
-                if healthy {
-                    report.objects_already_healthy += 1;
-                } else {
-                    targets.push(Arc::clone(replica));
+            for (zone, replica) in replicas.iter().enumerate() {
+                match index.health(zone, &object, expected_crc32c) {
+                    CopyHealth::Healthy => report.objects_already_healthy += 1,
+                    CopyHealth::Unknown => report.transient_failures += 1,
+                    CopyHealth::Damaged => targets.push(Arc::clone(replica)),
                 }
             }
             if targets.is_empty() {
@@ -2498,9 +2612,23 @@ mod maintenance {
             }
 
             // `seal_pending` already filtered the only segment that legitimately
-            // has no finalized copy, so a missing read quorum here is real loss
-            // and aborts the pass loudly.
-            let bytes = read_one_sealed_source(factories, &object, segment).await?;
+            // has no finalized copy, so failing to assemble a verified source
+            // here is either real loss or an unreachable quorum. Both are
+            // reported rather than silently tolerated, and neither stops the
+            // remaining entries from being repaired.
+            let bytes = match read_one_sealed_source(factories, &object, segment).await {
+                Ok(bytes) => bytes,
+                Err(error) => {
+                    tracing::warn!(
+                        %error,
+                        segment_base = segment.base_record_index,
+                        segment_id = %segment.id,
+                        "sealed segment has no verifiable source to repair from"
+                    );
+                    report.segments_without_source += 1;
+                    continue;
+                }
+            };
             // a rewritten copy carries the constant creation metadata: the
             // format marker only, like every segment object
             let metadata = crate::protocol::protocol_metadata();
@@ -2521,80 +2649,6 @@ mod maintenance {
             }
         }
         Ok(report)
-    }
-
-    /// Restore one manifest-owned historical segment to a finalized quorum.
-    ///
-    /// Startup needs this stronger gate before it can admit new work, but it
-    /// need not wait for an unreachable minority once a quorum is healthy.
-    /// The manifest CRC32C identifies a surviving canonical source. Recovery
-    /// reads every reachable copy because a metadata stat can still report the
-    /// original provider checksum when the content read detects storage rot;
-    /// only finalized, well-formed bytes whose computed CRC matches count.
-    /// Each successful repair is finalized and checksum-verified before
-    /// counting.
-    pub(crate) async fn restore_sealed_quorum(
-        factories: &[Arc<dyn ReplicaFactory>],
-        prefix: &str,
-        segment: &SegmentDescriptor,
-    ) -> Result<usize, Error> {
-        let quorum = majority(factories.len());
-        let expected_crc32c = segment.crc32c;
-        let object = segment_object(prefix, &segment.id);
-        let replicas = replicas_for(factories, &object);
-        let expected_records = segment
-            .end_record_index
-            .checked_sub(segment.base_record_index)
-            .and_then(|span| span.checked_add(1))
-            .ok_or_else(|| {
-                Error::InvalidCatalog(format!(
-                    "sealed segment {} has no valid committed end",
-                    segment.base_record_index
-                ))
-            })?;
-        let snapshots = join_all(replicas.iter().map(|replica| replica.snapshot())).await;
-        let mut healthy = 0;
-        let mut repair_targets = Vec::new();
-        let mut canonical = None;
-        for (replica, snapshot) in replicas.iter().zip(snapshots) {
-            match snapshot {
-                Ok(snapshot)
-                    if snapshot.crc32c == Some(expected_crc32c)
-                        && crc32c::crc32c(&snapshot.bytes) == expected_crc32c
-                        && decoded_sealed_snapshot(&snapshot, expected_records).is_some() =>
-                {
-                    healthy += 1;
-                    canonical.get_or_insert(snapshot.bytes);
-                }
-                _ => repair_targets.push(Arc::clone(replica)),
-            }
-        }
-        if healthy >= quorum {
-            return Ok(healthy);
-        }
-
-        let bytes = canonical.ok_or(Error::NoReadQuorum)?;
-        let metadata = crate::protocol::protocol_metadata();
-        for replica in repair_targets {
-            match repair_sealed_copy(
-                &replica,
-                Bytes::from(bytes.clone()),
-                metadata.clone(),
-                expected_crc32c,
-            )
-            .await
-            {
-                Ok(_) => {
-                    healthy += 1;
-                    if healthy >= quorum {
-                        return Ok(healthy);
-                    }
-                }
-                Err(error) if error.code.transient() => {}
-                Err(error) => return Err(error.into()),
-            }
-        }
-        Err(Error::NoReadQuorum)
     }
 
     /// One floor-committed truncation pass, free of writer state so the
@@ -2930,8 +2984,8 @@ mod maintenance {
 }
 
 pub(crate) use maintenance::{
-    cleanup_tombstones_pass, enforce_committed_seal, repair_sealed_pass, restore_sealed_quorum,
-    sweep_dead_segments, truncate_pass,
+    cleanup_tombstones_pass, enforce_committed_seal, repair_sealed_pass, sweep_dead_segments,
+    truncate_pass,
 };
 
 fn replay_records(

--- a/rust/client/src/transport.rs
+++ b/rust/client/src/transport.rs
@@ -19,8 +19,16 @@ pub struct ListedObject {
     pub name: String,
     /// Immutable provider generation used for guarded deletion.
     pub generation: i64,
+    /// Object length reported by the listing. Only a finalized object has a
+    /// meaningful length here: providers hide flushed appendable bytes from
+    /// object metadata until finalization.
+    pub size: i64,
     /// Whether the provider reports the object as finalized.
     pub finalized: bool,
+    /// Provider-computed CRC32C of the complete object, when supplied. This is
+    /// the same durable checksum a `stat` returns, so a listing alone decides
+    /// whether a sealed copy matches the manifest's committed digest.
+    pub crc32c: Option<u32>,
     /// Custom metadata containing the object format marker.
     pub metadata: HashMap<String, String>,
 }

--- a/rust/dst/src/sim_transport.rs
+++ b/rust/dst/src/sim_transport.rs
@@ -171,7 +171,12 @@ impl ReplicaFactory for InMemoryReplicaFactory {
                     .unwrap_or(&object.name)
                     .to_string(),
                 generation: object.generation,
+                size: object.size,
                 finalized: object.finalize_time.is_some(),
+                crc32c: object
+                    .checksums
+                    .as_ref()
+                    .and_then(|checksums| checksums.crc32c),
                 metadata: object.metadata,
             })
             .collect())


### PR DESCRIPTION
## The problem

Recovery gated startup on the health of every retained sealed segment. For each
directory entry above the truncation floor that was not the current seal,
`prepare_recovery` called `restore_sealed_quorum`, which downloaded the full
object from all three zonal replicas concurrently and CRC'd them.

Startup cost was therefore `(segments above the floor) × (3 full-object
downloads + CRC)`, serialized across segments, and peak memory was unbounded in
segment size — roughly 768 MiB in flight for a single 256 MiB segment.

A job server embedding chorus-client measured, on a staging restart with nothing
to replay:

```
replayed          0
replayMs          0.001
snapshotLoadMs    116.87
transportMs       71.185
epochClaimMs      53.825
prepareMs      3305.383   <- this
writerStartMs   332.403
totalMs        3916.536
```

Before a 2.4 M record write burst the same server's prepare was 479–655 ms. The
table drained back to 4 jobs and prepare stayed slow, because the cost tracks
retained segment history, not live data. The pod was OOMKilled at a 2 GiB limit
and crash-looped until the limit was raised to 8 GiB.

## The invariant change

This is a deliberate durability tradeoff, not an oversight.

**Still guaranteed at startup, unchanged:**

- The epoch claim fences every prior writer before anything else happens.
- `checkpoint.record_index < adopted.trunc` still fails with `InvalidCatalog`.
- Chain contiguity is still validated: every directory entry's end is derived
  from the following entry's base (or the committed tail base), and an entry
  that extends past the following base is still rejected.
- The most recent seal (`adopted.seal_id`) is still recovered and enforced
  against the committed digest and CRC32C.
- Replay still verifies every byte it returns against the committed CRC32C and
  the committed record count.

**Moved to background maintenance:**

- Restoring a finalized quorum for *older* directory entries. Those entries are
  adopted from the committed manifest — which already names their range and
  full-object CRC32C — and enter the catalog unverified. They are not assumed
  healthy: the whole catalog is the repair pass's work list, so every adopted
  entry is assessed on the next pass.

**The exposure window** is one repair interval (`WalEngineConfig::repair_interval`,
default 300 s), plus the time the pass needs to rewrite what it finds. During
that window a process can admit new commits while an old, already-checkpointed
segment survives on fewer than a quorum of zones. It is old history by
construction: anything the database has not yet checkpointed is either replayed
(and byte-verified) at startup or lives in the frontier segments recovery still
fences and enforces synchronously.

### Why `seal_id` keeps its synchronous enforcement

Removing it would break the write frontier. The engine gates its next rotation on
each seal reaching a finalized quorum, so `seal_id` is the one entry whose
enforcement can still be in flight when a writer dies — its bytes may exist only
as unfinalized appendable content, which no reader can consume and no repair pass
can copy. Replay and every subsequent rotation depend on finishing that one
committed decision, so recovery finishes it.

It is also cheap: there is at most one such entry, and
`finalized_segment_descriptor` already settles the healthy case from `stat`
metadata alone.

## Assessing health from metadata

`repair_sealed_pass` now builds a `SealedCopyIndex` from one strongly consistent
`ListObjects` per zone and decides every copy of every segment from it —
presence, finalization, the format marker, and the provider's durable CRC32C.
Bytes are read only for a segment that actually has a damaged or missing copy.
This makes the pass one round trip per zone regardless of retained history,
instead of one `stat` per object.

`ListedObject` gains `size` and `crc32c`, populated from `Object.size` and
`Object.checksums.crc32c` in both the gRPC transport and the simulation
transport. The fake already served both fields through `StoredObject::to_proto`,
so no fake change was needed — and the new tests assert `Operation::Get == 0` on
untouched zones, so a listing that failed to carry the checksum would fail the
tests rather than quietly fall back.

A zone whose listing fails is `Unknown`, not `Damaged`: its copies are left alone
and counted as transient failures, so an unreachable zone never triggers a
rewrite from a guess.

`restore_sealed_quorum` is deleted — it was the last caller-side full-object
health check.

## One damaged segment no longer ends the pass

The repair pass is now the sole observer of sealed-history durability, so it must
not stop at the first unrecoverable entry. A segment whose committed bytes cannot
be assembled from any reachable copy is counted in
`RepairReport::segments_without_source`, logged, exported as
`chorus.wal.repair.segments_without_source`, and the walk continues. A nonzero
count on that metric is the signal that committed history has fallen below a
finalized quorum; **it is worth an alert.**

## Frontier objects are created in parallel

Every recovery path that mints a fresh active and pending segment provisioned
them one after the other. `provision_frontier` issues both creates together, so
recovery's object provisioning is one round trip deep instead of two.

## Known limitation

Metadata (a listing or a `stat`) reports the checksum the provider recorded at
write time. It identifies a missing, unfinalized, or divergent copy. It cannot
identify a copy whose stored bytes rotted underneath an intact recorded checksum
— that copy fails its content read instead. The old startup path incidentally
scrubbed for this, because it downloaded and CRC'd everything; nothing does now.

The safety consequences are contained: replay verifies every copy it consumes
against the committed CRC32C and takes the next one
(`replay_reads_past_a_rotted_historical_copy` pins this), and `repair_sealed_copy`
still recognizes a rotted target through its `DATA_LOSS` read. What is gone is the
periodic *detection* sweep. In real GCS this is a narrow gap — the service
verifies stored objects on read and repairs from its own redundancy rather than
returning corrupt bytes — but a rate-limited background scrub that deep-verifies
a bounded number of segments per pass would close it properly. I did not add one
here: it needs its own memory budget and pacing design, and inventing a second
mechanism was out of scope for this change.

## The P model

`HistoricalRecoveryCoordinator` and its `HistoricalRecoveryQuorum` spec asserted
"startup completed with historical data on fewer than two zones", which the
implementation no longer provides. They are renamed to
`HistoricalMaintenanceCoordinator` / `HistoricalMaintenanceQuorum` and rescoped:
the property is now that *repair*, whenever it acts on a directory entry, leaves
a restored quorum behind. `eHistoricalRecoveryReady` is model-only and absent
from `TRACE_EVENTS.txt`, so PObserve is unaffected.

The model's coordinator still assesses by content read, because the model has no
metadata-checksum surrogate. Modeling the metadata-only health check is follow-up
work and is called out in the coordinator's comment.

## Tests

- `recovery_adopts_a_historical_segment_without_reading_it` — every copy of the
  oldest entry is deleted; recovery still succeeds and keeps the entry in the
  chain. Under the old code this failed startup with `NoReadQuorum`.
- `maintenance_restores_a_historical_segment_recovery_left_damaged` — recovery
  leaves the missing copy missing, then the background pass restores it.
- `replay_reads_past_a_rotted_historical_copy` — the read path still returns
  correct records around a rotted copy that no metadata can see.
- `repair_lists_each_zone_once_regardless_of_retained_history` — three sealed
  segments, one damaged copy: exactly one `List` per zone, one `Read` total, and
  zero `Get` on the untouched zone.
- `repair_reports_a_segment_with_no_verifiable_copy_and_keeps_going` — a totally
  lost segment is counted, and the entry after it is still repaired.
- `repair_uses_the_listing_crc32c_to_target_same_size_divergence` — the existing
  same-size divergence test, extended with the listing assertions.

Replaced: `recovery_repairs_historical_segment_to_quorum_before_returning` and
`recovery_repairs_bit_rotted_historical_segment_before_returning`, which asserted
the behaviour this change removes.

## Gates

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- `cargo test --workspace --all-features` — 167 passed, 0 failed (baseline 164)
- `p compile -pp QuorumModel.pproj` — succeeded
- `orchestrate.py check-model --schedules 200` — 0 bugs
- DST `--seeds 200 --steps 600` — passed; trace structure gate accepted
