### PR TITLE
Trim WAL instrumentation to core operational metrics

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -354,6 +354,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "chorus-client",
+ "chorus-fake-gcs",
  "clap",
  "futures",
  "hdrhistogram",

--- a/rust/bin/chorus-cli/Cargo.toml
+++ b/rust/bin/chorus-cli/Cargo.toml
@@ -21,3 +21,6 @@ chorus-client = { path = "../../client" }
 serde_json.workspace = true
 tokio.workspace = true
 tracing-subscriber.workspace = true
+
+[dev-dependencies]
+chorus-fake-gcs = { path = "../../fake-gcs" }

--- a/rust/bin/chorus-cli/README.md
+++ b/rust/bin/chorus-cli/README.md
@@ -96,8 +96,9 @@ cargo run --release -p chorus-cli --bin chorus -- \
 ```
 
 Set a positive `--arrival-rate` for open-loop records per second. The report
-includes throughput, latency percentiles, batching, write amplification,
-pipeline metrics, and drain accounting.
+includes throughput, latency percentiles (`p50`, `p99`, `p99_9`, and `max`),
+configuration, and drain accounting. Batching, write amplification, pipeline
+high-water marks, and lane event counters are no longer reported.
 
 `benchmark recovery` populates a separate WAL below `<prefix>/iNNN` for each
 iteration, cleanly shuts down its writer, then measures epoch claim, prepare,
@@ -117,6 +118,10 @@ cargo run --release -p chorus-cli --bin chorus -- \
   --iterations 5 \
   --payload-bytes 4096
 ```
+
+The report retains per-phase latency percentiles, observed sealed-segment counts,
+and replayed-record counts. It no longer reports manifest CAS attempts or seal
+operation counts.
 
 The base prefix must be unused because each iteration starts record numbering at
 zero. This measures a new Chorus recovery pass in the same process with reused

--- a/rust/bin/chorus-cli/src/benchmark/append.rs
+++ b/rust/bin/chorus-cli/src/benchmark/append.rs
@@ -292,19 +292,7 @@ pub(crate) async fn run(storage: ConnectedStorage, prefix: String, args: AppendA
     let record_iops = completed_appends as f64 / elapsed;
     let committed_payload_bytes = metrics.counter("chorus.wal.append.committed_bytes");
     let committed_records = metrics.counter("chorus.wal.append.committed_records");
-    let batches_sent = metrics.counter("chorus.wal.batch.sent");
-    let replica_bytes_attempted = metrics.counter("chorus.wal.replica.bytes_attempted");
     let payload_mib = committed_payload_bytes as f64 / (1024.0 * 1024.0);
-    let records_per_persist = if batches_sent == 0 {
-        0.0
-    } else {
-        committed_records as f64 / batches_sent as f64
-    };
-    let write_amplification = if committed_payload_bytes == 0 {
-        0.0
-    } else {
-        replica_bytes_attempted as f64 / committed_payload_bytes as f64
-    };
     let report = serde_json::json!({
         "mode": mode,
         "arrival_rate_target": args.arrival_rate,
@@ -313,8 +301,6 @@ pub(crate) async fn run(storage: ConnectedStorage, prefix: String, args: AppendA
         "completed_appends": completed_appends,
         "scheduled_appends": workload.scheduled_appends,
         "committed_records": committed_records,
-        "batches_sent": batches_sent,
-        "records_per_persist": records_per_persist,
         "drain_timed_out": workload.drain_timed_out,
         "undrained_appends": workload.undrained_appends,
         "outstanding_cap_waits": workload.outstanding_cap_waits,
@@ -322,14 +308,6 @@ pub(crate) async fn run(storage: ConnectedStorage, prefix: String, args: AppendA
         "record_iops": record_iops,
         "payload_mib_per_second": payload_mib / elapsed,
         "payload_mib": payload_mib,
-        "wal_record_bytes": metrics.counter("chorus.wal.append.encoded_bytes"),
-        "replica_bytes_attempted": replica_bytes_attempted,
-        "write_amplification": write_amplification,
-        "max_inflight_records": metrics.gauge("chorus.wal.pipeline.max_inflight_records"),
-        "max_inflight_bytes": metrics.gauge("chorus.wal.pipeline.max_inflight_bytes"),
-        "lane_capacity_drops": metrics.counter("chorus.wal.lane.capacity_drops"),
-        "lane_timeouts": metrics.counter("chorus.wal.lane.timeouts"),
-        "pipeline_refills": metrics.counter("chorus.wal.pipeline.refills"),
         "latency_us": {
             "p50": latency.value_at_quantile(0.50),
             "p99": latency.value_at_quantile(0.99),

--- a/rust/bin/chorus-cli/src/benchmark/mod.rs
+++ b/rust/bin/chorus-cli/src/benchmark/mod.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 use chorus_client::{CounterFn, GaugeFn, HistogramFn, MetricsRecorder, UpDownCounterFn};
@@ -10,7 +10,6 @@ pub(crate) mod recovery;
 #[derive(Default)]
 pub(crate) struct BenchMetrics {
     counters: Mutex<HashMap<String, Arc<AtomicU64>>>,
-    gauges: Mutex<HashMap<String, Arc<AtomicI64>>>,
 }
 
 impl BenchMetrics {
@@ -20,15 +19,6 @@ impl BenchMetrics {
             .unwrap()
             .get(name)
             .map(|counter| counter.load(Ordering::Relaxed))
-            .unwrap_or(0)
-    }
-
-    pub(crate) fn gauge(&self, name: &str) -> i64 {
-        self.gauges
-            .lock()
-            .unwrap()
-            .get(name)
-            .map(|gauge| gauge.load(Ordering::Relaxed))
             .unwrap_or(0)
     }
 }
@@ -41,15 +31,11 @@ impl CounterFn for BenchCounter {
     }
 }
 
-struct BenchGauge(Arc<AtomicI64>);
-
-impl GaugeFn for BenchGauge {
-    fn set(&self, value: i64) {
-        self.0.store(value, Ordering::Relaxed);
-    }
-}
-
 struct NoopMetric;
+
+impl GaugeFn for NoopMetric {
+    fn set(&self, _value: i64) {}
+}
 
 impl UpDownCounterFn for NoopMetric {
     fn increment(&self, _value: i64) {}
@@ -78,18 +64,11 @@ impl MetricsRecorder for BenchMetrics {
 
     fn register_gauge(
         &self,
-        name: &str,
+        _name: &str,
         _description: &str,
         _labels: &[(&str, &str)],
     ) -> Arc<dyn GaugeFn> {
-        let metric = self
-            .gauges
-            .lock()
-            .unwrap()
-            .entry(name.to_string())
-            .or_default()
-            .clone();
-        Arc::new(BenchGauge(metric))
+        Arc::new(NoopMetric)
     }
 
     fn register_up_down_counter(

--- a/rust/bin/chorus-cli/src/benchmark/recovery.rs
+++ b/rust/bin/chorus-cli/src/benchmark/recovery.rs
@@ -13,20 +13,16 @@
 //! by varying `--target-sealed-segments`. Output is JSON with per-phase latency
 //! percentiles across iterations.
 
-use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{bail, Context, Result};
 use bytes::Bytes;
-use chorus_client::{
-    ClientConfig, MetricsRecorder, SegmentedVolume, WalEngineConfig, WalHandle, WalSeqNo,
-};
+use chorus_client::{ClientConfig, SegmentedVolume, WalEngineConfig, WalHandle, WalSeqNo};
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use hdrhistogram::Histogram;
 use tokio::time::Instant;
 
-use super::BenchMetrics;
 use crate::ConnectedStorage;
 
 #[derive(clap::Args, Debug)]
@@ -171,23 +167,17 @@ pub(crate) async fn run(
     let replay_records = args.replay_records.unwrap_or(args.populate_records);
     let checkpoint = args.populate_records.saturating_sub(replay_records);
 
-    let metrics = Arc::new(BenchMetrics::default());
-    let metrics_recorder: Arc<dyn MetricsRecorder> = metrics.clone();
-
     let mut phases = PhaseHistograms::new()?;
     let mut sealed_counts: Vec<u64> = Vec::new();
     let mut replayed_records: Vec<u64> = Vec::new();
-    let mut cas_attempts: Vec<u64> = Vec::new();
-    let mut segments_sealed: Vec<u64> = Vec::new();
 
     for iteration in 0..args.iterations {
         let prefix = format!("{prefix}/i{iteration:03}");
-        let volume = SegmentedVolume::new_with_metrics_recorder(
+        let volume = SegmentedVolume::new(
             storage.factories.clone(),
             storage.manifest_factory.clone(),
             &prefix,
             ClientConfig::default(),
-            metrics_recorder.clone(),
         )?;
 
         // --- populate -------------------------------------------------------
@@ -211,8 +201,6 @@ pub(crate) async fn run(
             .context("shutdown populated writer")?;
 
         // --- measure one recovery pass -------------------------------------
-        let cas_before = metrics.counter("chorus.wal.manifest.cas_attempts");
-        let sealed_before = metrics.counter("chorus.wal.seal.segments");
 
         let total_started = Instant::now();
         let mut recovery = volume
@@ -252,8 +240,6 @@ pub(crate) async fn run(
         record_us(&mut phases.total, total)?;
         sealed_counts.push(sealed_count);
         replayed_records.push(replay_span);
-        cas_attempts.push(metrics.counter("chorus.wal.manifest.cas_attempts") - cas_before);
-        segments_sealed.push(metrics.counter("chorus.wal.seal.segments") - sealed_before);
     }
 
     let avg = |v: &[u64]| -> f64 {
@@ -273,8 +259,6 @@ pub(crate) async fn run(
         "replay_records_target": replay_records,
         "replayed_records_avg": avg(&replayed_records),
         "checkpoint": checkpoint,
-        "manifest_cas_attempts_avg": avg(&cas_attempts),
-        "segments_sealed_avg": avg(&segments_sealed),
         "phase_latency_us": {
             "epoch_claim": summarize(&phases.epoch_claim),
             "prepare": summarize(&phases.prepare),

--- a/rust/bin/chorus-cli/tests/benchmark.rs
+++ b/rust/bin/chorus-cli/tests/benchmark.rs
@@ -1,0 +1,137 @@
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+use chorus_fake_gcs::FakeGcs;
+use serde_json::Value;
+
+async fn benchmark(args: &[&str]) -> Value {
+    let mut servers = Vec::new();
+    for _ in 0..4 {
+        servers.push(FakeGcs::default().start().await.unwrap());
+    }
+    let endpoints = servers[..3]
+        .iter()
+        .map(|server| server.endpoint.as_str())
+        .collect::<Vec<_>>()
+        .join(",");
+    let mut child = Command::new(env!("CARGO_BIN_EXE_chorus"))
+        .args([
+            "--anonymous",
+            "--endpoints",
+            &endpoints,
+            "--buckets",
+            "projects/_/buckets/z0,projects/_/buckets/z1,projects/_/buckets/z2",
+            "--manifest-endpoint",
+            &servers[3].endpoint,
+            "--manifest-bucket",
+            "projects/_/buckets/regional",
+            "--prefix",
+            "benchmark-smoke",
+            "benchmark",
+        ])
+        .args(args)
+        .env("RUST_LOG", "error")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    let finished = tokio::time::timeout(Duration::from_secs(30), async {
+        while child.try_wait().unwrap().is_none() {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await;
+    if finished.is_err() {
+        child.kill().unwrap();
+    }
+    let output = child.wait_with_output().unwrap();
+    assert!(
+        finished.is_ok() && output.status.success(),
+        "benchmark failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).unwrap()
+}
+
+fn assert_latency(latency: &Value) {
+    for field in ["p50", "p99", "p99_9", "max"] {
+        assert!(
+            latency[field].as_u64().unwrap() > 0,
+            "missing latency sample: {field}"
+        );
+    }
+    assert!(latency["p50"].as_u64() <= latency["p99"].as_u64());
+    assert!(latency["p99"].as_u64() <= latency["p99_9"].as_u64());
+    assert!(latency["p99_9"].as_u64() <= latency["max"].as_u64());
+}
+
+#[tokio::test]
+async fn append_benchmarks_keep_latency_and_throughput_without_internal_counters() {
+    for arrival_rate in ["0", "100"] {
+        let report = benchmark(&[
+            "append",
+            "--duration-seconds",
+            "1",
+            "--arrival-rate",
+            arrival_rate,
+            "--payload-bytes",
+            "32",
+            "--outstanding-appends",
+            "8",
+        ])
+        .await;
+        assert_latency(&report["latency_us"]);
+        assert!(report["payload_mib_per_second"].as_f64().unwrap() > 0.0);
+        assert!(report["record_iops"].as_f64().unwrap() > 0.0);
+        assert!(report["committed_records"].as_u64().unwrap() > 0);
+        assert_eq!(report["drain_timed_out"], false);
+        assert!(
+            report["configuration"]["max_inflight_bytes"]
+                .as_u64()
+                .unwrap()
+                > 0
+        );
+        for removed in [
+            "batches_sent",
+            "records_per_persist",
+            "wal_record_bytes",
+            "replica_bytes_attempted",
+            "write_amplification",
+            "max_inflight_records",
+            "max_inflight_bytes",
+            "lane_capacity_drops",
+            "lane_timeouts",
+            "pipeline_refills",
+        ] {
+            assert!(
+                report.get(removed).is_none(),
+                "obsolete diagnostic: {removed}"
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn recovery_benchmark_keeps_phase_latencies_without_operation_counts() {
+    let report = benchmark(&[
+        "recovery",
+        "--populate-records",
+        "100",
+        "--target-sealed-segments",
+        "2",
+        "--iterations",
+        "2",
+        "--payload-bytes",
+        "32",
+        "--populate-window",
+        "8",
+    ])
+    .await;
+    for phase in ["epoch_claim", "prepare", "replay", "start", "total"] {
+        assert_latency(&report["phase_latency_us"][phase]);
+    }
+    assert_eq!(report["replayed_records_avg"], 100.0);
+    assert!(report["observed_sealed_segments_avg"].as_f64().unwrap() > 0.0);
+    assert!(report.get("manifest_cas_attempts_avg").is_none());
+    assert!(report.get("segments_sealed_avg").is_none());
+}

--- a/rust/client/Cargo.toml
+++ b/rust/client/Cargo.toml
@@ -16,7 +16,7 @@ exclude = ["src/grpc_internal_tests.rs", "src/grpc_internal_tests/**", "tests/**
 [features]
 default = []
 probe-support = []
-# Internal capacity introspection used by the deterministic simulation harness.
+# Internal capacity introspection and event counters for deterministic simulation.
 dst-support = []
 
 [dependencies]

--- a/rust/client/README.md
+++ b/rust/client/README.md
@@ -140,6 +140,31 @@ data remains in the zonal buckets.
 - A running `WalHandle` is the exclusive writer. Starting another writer
   requires recovery, which fences the previous writer incarnation.
 
+## Metrics
+
+The default build registers 12 metric names, all prefixed with `chorus.wal.`:
+
+| Kind | Names |
+| --- | --- |
+| Counter | `append.committed_records`, `append.committed_bytes`, `append.failures`, `transport.rpc_failures{code}` |
+| Gauge | `pipeline.queue_depth`, `maintenance.queue_depth`, `replica.durable_lag_bytes{zone}`, `manifest.directory_bytes` |
+| Histogram | `append.commit_latency_seconds`, `transport.rpc_seconds{op}`, `manifest.cas_latency_seconds`, `seal.duration_seconds` |
+
+Lifecycle events, repair outcomes, retries, and maintenance failures are logged.
+RPC timing covers quorum-path replica operations, not all storage calls; manifest
+CAS timing remains separate. An operation such as `snapshot` may contain multiple
+provider RPCs. Labelled metrics register one series per label value.
+
+The internal `dst-support` feature additionally registers `lane.timeouts`,
+`lane.capacity_drops`, `repair.passes`, and `seal.segments`. Simulations use these
+for fault scheduling and protocol coverage; they are not production metrics.
+Unit-test builds also enable these counters.
+
+CLI benchmarks retain append latency percentiles, throughput, and recovery phase
+timings. They no longer report batching, write amplification, in-flight high-water
+marks, lane event counts, or recovery CAS/seal operation counts. Configured limits
+and observed/replayed record and segment counts remain in benchmark output.
+
 ## More information
 
 - [Design overview](https://rockwotj.com/blog/chorus/)

--- a/rust/client/src/engine.rs
+++ b/rust/client/src/engine.rs
@@ -239,7 +239,6 @@ pub struct WalEngine;
 /// awaitable by the database's apply pipeline.
 pub struct WalHandle {
     sender: mpsc::Sender<Command>,
-    metrics: Arc<Metrics>,
     engine_task: tokio::task::JoinHandle<()>,
     provisioner_task: tokio::task::JoinHandle<()>,
     provisioner_shutdown: watch::Sender<bool>,
@@ -248,7 +247,6 @@ pub struct WalHandle {
     rotation_recheck: mpsc::Sender<()>,
     next_seqno: u64,
     max_record_bytes: usize,
-    max_inflight_bytes: usize,
     max_active_segment_bytes: usize,
     total_admitted_bytes: u128,
     active_capacity: watch::Receiver<ActiveSegmentCapacity>,
@@ -261,7 +259,6 @@ struct AdmittedAppend {
     seqno: WalSeqNo,
     record: RecordFrame,
     payload_bytes: usize,
-    encoded_bytes: usize,
     /// Cumulative encoded admission boundary after this record. The engine
     /// publishes the last boundary assigned to an old segment when it swaps,
     /// so the handle can charge every later queued record to the successor
@@ -340,14 +337,12 @@ impl EngineState {
     ) {
         self.stop_admission(receiver);
         fail_all(&mut self.queue, error, metrics);
-        metrics.operation_failures.increment();
     }
 
     fn poison(&mut self, receiver: &mut mpsc::Receiver<Command>, metrics: &Metrics) {
         self.stop_admission(receiver);
         fail_completion_batches(&mut self.completion_batches, Error::Poisoned, metrics);
         fail_all(&mut self.queue, Error::Poisoned, metrics);
-        metrics.operation_failures.increment();
     }
 }
 
@@ -461,7 +456,6 @@ impl WalEngine {
         ));
         Ok(WalHandle {
             sender,
-            metrics,
             engine_task,
             provisioner_task,
             provisioner_shutdown,
@@ -470,7 +464,6 @@ impl WalEngine {
             rotation_recheck,
             next_seqno,
             max_record_bytes,
-            max_inflight_bytes,
             max_active_segment_bytes,
             total_admitted_bytes: 0,
             active_capacity,
@@ -574,17 +567,12 @@ impl WalHandle {
             .acquire_owned()
             .await
             .map_err(|_| Error::Closed)?;
-        self.metrics.max_inflight_bytes.update_max(
-            self.max_inflight_bytes
-                .saturating_sub(self.inflight_bytes.available_permits()) as u64,
-        );
         let (completion, receiver) = oneshot::channel();
         self.sender
             .send(Command::Append(AdmittedAppend {
                 seqno,
                 record,
                 payload_bytes,
-                encoded_bytes,
                 admission_end_bytes,
                 admitted_at: tokio::time::Instant::now(),
                 _inflight_bytes: inflight_bytes,
@@ -596,8 +584,6 @@ impl WalHandle {
 
         self.total_admitted_bytes = admission_end_bytes;
         self.next_seqno += 1;
-        self.metrics.append_records.increment();
-        self.metrics.append_bytes.add(payload_bytes as u64);
         Ok(AppendCompletion { receiver })
     }
 
@@ -795,13 +781,8 @@ async fn run_engine(
     // `select!` wake source, so a swap waiting on a slow spare can never park
     // the engine. `spare_requested` keeps at most one attempt outstanding.
     let mut spare_requested = false;
-    let attempted_stats = Arc::clone(&metrics);
-    let on_attempted: crate::protocol::AttemptedBytes = Arc::new(move |bytes| {
-        attempted_stats.replica_bytes_attempted.add(bytes);
-    });
 
     'engine: loop {
-        metrics.rotation_state.set(rotation.metric_value());
         state.drain_available(&mut receiver);
         observe_queue_depth(&metrics, config.queue_capacity, &queue_slots);
 
@@ -958,7 +939,6 @@ async fn run_engine(
             if let Some(attempt) = attempt {
                 if provision_requests.try_send(attempt).is_ok() {
                     spare_requested = true;
-                    metrics.spare_provisioning_attempts.increment();
                 }
             }
         }
@@ -1030,27 +1010,16 @@ async fn run_engine(
                 appends.push(append);
             }
             let records = appends.iter().map(|append| append.record.clone()).collect();
-            let wal_record_bytes: u64 = appends
-                .iter()
-                .map(|append| append.encoded_bytes as u64)
-                .sum();
             let batch_admission_end = appends
                 .last()
                 .map(|append| append.admission_end_bytes)
                 .unwrap_or(state.last_dispatched_admission_bytes);
-            match writer
-                .enqueue_records_for_engine(records, Arc::clone(&on_attempted))
-                .await
-            {
+            match writer.enqueue_records_for_engine(records).await {
                 Ok(commits) => {
                     for append in &mut appends {
                         drop(append.queue_slot.take());
                     }
                     state.last_dispatched_admission_bytes = batch_admission_end;
-                    if outstanding > 0 {
-                        metrics.pipeline_refills.increment();
-                    }
-                    metrics.wal_record_bytes.add(wal_record_bytes);
                     let expected_first = appends
                         .first()
                         .map(|append| append.seqno.record_index)
@@ -1072,7 +1041,6 @@ async fn run_engine(
                             fail_append(append, error.clone(), &metrics);
                         }
                         fail_all(&mut state.queue, error, &metrics);
-                        metrics.operation_failures.increment();
                         break 'engine;
                     }
                     state.pending_records += appends.len();
@@ -1080,9 +1048,6 @@ async fn run_engine(
                         commits,
                         appends: appends.into(),
                     });
-                    metrics
-                        .max_inflight_records
-                        .update_max(state.pending_records as u64);
                     rotation.mark_due(writer.rotation_due(config.max_segment_bytes));
                 }
                 Err(error) => {
@@ -1091,7 +1056,6 @@ async fn run_engine(
                     for append in appends {
                         fail_append(append, error.clone(), &metrics);
                     }
-                    metrics.operation_failures.increment();
                     fail_all(&mut state.queue, error, &metrics);
                     break 'engine;
                 }
@@ -1103,7 +1067,6 @@ async fn run_engine(
             break;
         }
 
-        metrics.rotation_state.set(rotation.metric_value());
         // The single wait point: every event that can unblock the engine is a
         // branch here, so nothing the loop is waiting for can fail to wake it.
         //
@@ -1126,7 +1089,6 @@ async fn run_engine(
                     }
                     fail_completion_batches(&mut state.completion_batches, Error::Poisoned, &metrics);
                     fail_all(&mut state.queue, Error::Poisoned, &metrics);
-                    metrics.operation_failures.increment();
                     break 'engine;
                 }
             }
@@ -1155,7 +1117,6 @@ async fn run_engine(
                         rotation = Rotation::Disabled {
                             due: writer.rotation_due(config.max_segment_bytes),
                         };
-                        metrics.operation_failures.increment();
                     }
                     RotationEvent::RetryElapsed => {
                         if let Rotation::Draining { retry, .. } = &mut rotation {
@@ -1181,7 +1142,6 @@ async fn run_engine(
                                     %error,
                                     "failed to refresh rotation eligibility after truncation"
                                 );
-                                metrics.operation_failures.increment();
                             }
                         }
                     }
@@ -1226,7 +1186,6 @@ async fn run_engine(
                                     rotation = Rotation::Disabled {
                                         due: writer.rotation_due(config.max_segment_bytes),
                                     };
-                                    metrics.operation_failures.increment();
                                 }
                             }
                         } else {
@@ -1250,12 +1209,10 @@ async fn run_engine(
                                 "manifest directory is full; pending fold waits for truncation"
                             );
                         } else if matches!(error, Error::Poisoned | Error::Fenced(_)) {
-                            metrics.spare_provisioning_failures.increment();
                             tracing::warn!(%error, "background rotation work was fenced");
                             state.fail_queued(&mut receiver, error, &metrics);
                             break 'engine;
                         } else {
-                            metrics.spare_provisioning_failures.increment();
                             tracing::warn!(%error, "background rotation work failed; will retry");
                             if rotation.has_pending_fold() && writer.unregistered_spare_ready() {
                                 rotation.arm_fold_retry(&client_config);
@@ -1263,7 +1220,6 @@ async fn run_engine(
                         }
                     }
                     None => {
-                        metrics.spare_provisioning_failures.increment();
                         tracing::warn!("spare provisioner stopped");
                         state.fail_queued(&mut receiver, Error::Closed, &metrics);
                         break 'engine;
@@ -1291,7 +1247,6 @@ async fn run_engine(
         tracing::warn!("WAL engine stopped without graceful shutdown");
     }
     metrics.queue_depth.set(0);
-    metrics.rotation_state.set(0);
 }
 
 /// What the rotation wake arm of the engine's `select!` observed: the two
@@ -1339,16 +1294,6 @@ enum Rotation {
 }
 
 impl Rotation {
-    fn metric_value(&self) -> i64 {
-        match self {
-            Self::Idle => 0,
-            Self::Due => 1,
-            Self::Draining { .. } => 2,
-            Self::Sealing { .. } => 3,
-            Self::Disabled { .. } => 4,
-        }
-    }
-
     fn mark_due(&mut self, due: bool) {
         if !due {
             return;
@@ -1556,9 +1501,6 @@ fn complete_append(append: AdmittedAppend, metrics: &Metrics) {
     }));
     metrics.committed_records.increment();
     metrics.committed_bytes.add(append.payload_bytes as u64);
-    metrics
-        .committed_records_watermark
-        .set_u64(append.seqno.record_index + 1);
 }
 
 fn admit_command(command: Command, queue: &mut VecDeque<Command>, next_admission: &mut u64) {

--- a/rust/client/src/grpc_internal_tests.rs
+++ b/rust/client/src/grpc_internal_tests.rs
@@ -161,10 +161,6 @@ fn record(payload: &[u8]) -> RecordFrame {
     }
 }
 
-fn no_attempted_bytes() -> crate::protocol::AttemptedBytes {
-    Arc::new(|_| {})
-}
-
 fn volume(
     factories: Vec<Arc<dyn ReplicaFactory>>,
     manifest_factory: Arc<dyn ReplicaFactory>,
@@ -194,7 +190,7 @@ fn volume_with_metrics(
 
 async fn append_one(writer: &mut SegmentedWriter, payload: &[u8]) -> u64 {
     writer
-        .enqueue_records(vec![record(payload)], no_attempted_bytes())
+        .enqueue_records(vec![record(payload)])
         .await
         .unwrap()
         .remove(0)

--- a/rust/client/src/grpc_internal_tests/engine.rs
+++ b/rust/client/src/grpc_internal_tests/engine.rs
@@ -79,9 +79,6 @@ async fn caller_numbered_appends_admit_in_order_and_refill_the_pipeline() {
         assert_eq!(receipt.next_seqno(), WalSeqNo::record(seqno as u64 + 1));
     }
     assert_eq!(metrics.counter("chorus.wal.append.committed_records"), 64);
-    // No refill-count assertion: the engine drains completion bursts and
-    // refills in batches, so a small fast pipeline may never refill while
-    // records are still outstanding.
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -169,15 +166,10 @@ async fn latency_injected_pipeline_keeps_many_commits_in_flight_across_rotation(
             );
         }
         panic!(
-            "latency pipeline timed out: completed={completed}/{RECORDS} rate={records_per_second:.1}/s rotation_state={} rotations={} max_inflight={} provision_attempts={} provision_failures={} operation_failures={} manifest_cas={} manifest_conflicts={}",
-            metrics.gauge("chorus.wal.rotation.state"),
-            metrics.counter("chorus.wal.rotation.completed"),
-            metrics.gauge("chorus.wal.pipeline.max_inflight_records"),
-            metrics.counter("chorus.wal.rotation.spare_provisioning_attempts"),
-            metrics.counter("chorus.wal.rotation.spare_provisioning_failures"),
-            metrics.counter("chorus.wal.operation.failures"),
-            metrics.counter("chorus.wal.manifest.cas_attempts"),
-            metrics.counter("chorus.wal.manifest.cas_conflicts"),
+            "latency pipeline timed out: completed={completed}/{RECORDS} rate={records_per_second:.1}/s queue_depth={} seals={} append_failures={}",
+            metrics.gauge("chorus.wal.pipeline.queue_depth"),
+            metrics.counter("chorus.wal.seal.segments"),
+            metrics.counter("chorus.wal.append.failures"),
         );
     }
     let creates = servers[0]
@@ -186,12 +178,7 @@ async fn latency_injected_pipeline_keeps_many_commits_in_flight_across_rotation(
         .await;
     let folds = servers[3].service.operation_count(Operation::Update).await;
     eprintln!(
-        "latency pipeline: records={RECORDS} elapsed={elapsed:?} rate={records_per_second:.1}/s max_inflight={} creates_per_zone={creates} manifest_updates={folds}",
-        metrics.gauge("chorus.wal.pipeline.max_inflight_records"),
-    );
-    assert!(
-        metrics.gauge("chorus.wal.pipeline.max_inflight_records") >= 32,
-        "commit path did not fill a healthy pipeline"
+        "latency pipeline: records={RECORDS} elapsed={elapsed:?} rate={records_per_second:.1}/s creates_per_zone={creates} manifest_updates={folds}"
     );
     assert!(
         records_per_second >= OFFERED_RATE * 0.75,
@@ -199,13 +186,13 @@ async fn latency_injected_pipeline_keeps_many_commits_in_flight_across_rotation(
     );
     shutdown_engine(handle).await;
     assert!(
-        metrics.counter("chorus.wal.rotation.completed") >= 2,
+        metrics.counter("chorus.wal.seal.segments") >= 2,
         "loaded run did not complete multiple rotations"
     );
     assert_eq!(
-        metrics.counter("chorus.wal.operation.failures"),
+        metrics.counter("chorus.wal.append.failures"),
         0,
-        "loaded run encountered an internal operation failure"
+        "loaded run encountered an append failure"
     );
 }
 
@@ -242,9 +229,7 @@ async fn queue_depth_one_makes_progress_across_latency_injected_rotation() {
                 .await
                 .unwrap();
         }
-        while metrics.counter("chorus.wal.rotation.completed") < 2
-            || metrics.counter("chorus.wal.seal.segments") < 2
-        {
+        while metrics.counter("chorus.wal.seal.segments") < 2 {
             tokio::time::sleep(Duration::from_millis(1)).await;
         }
     })
@@ -252,27 +237,21 @@ async fn queue_depth_one_makes_progress_across_latency_injected_rotation() {
     if result.is_err() {
         let manifest_updates = servers[3].service.operation_count(Operation::Update).await;
         panic!(
-            "queue-depth-one append wedged under service latency: rotation_state={} rotations={} provisions={} failures={} manifest_updates={}",
-            metrics.gauge("chorus.wal.rotation.state"),
-            metrics.counter("chorus.wal.rotation.completed"),
-            metrics.counter("chorus.wal.rotation.spare_provisioning_attempts"),
-            metrics.counter("chorus.wal.rotation.spare_provisioning_failures"),
-            manifest_updates,
+            "queue-depth-one append wedged under service latency: seals={} queue_depth={} append_failures={} manifest_updates={manifest_updates}",
+            metrics.counter("chorus.wal.seal.segments"),
+            metrics.gauge("chorus.wal.pipeline.queue_depth"),
+            metrics.counter("chorus.wal.append.failures"),
         );
     }
     shutdown_engine(handle).await;
-    let rotations = metrics.counter("chorus.wal.rotation.completed");
+    let rotations = metrics.counter("chorus.wal.seal.segments");
     eprintln!(
-        "latency qd1: rotations={rotations} creates_per_zone={} manifest_updates={} operation_failures={} repair_failures={} seal_retries={} spare_failures={} append_failures={}",
+        "latency qd1: seals={rotations} creates_per_zone={} manifest_updates={} append_failures={}",
         servers[0]
             .service
             .operation_count(Operation::BidiCreate)
             .await,
         servers[3].service.operation_count(Operation::Update).await,
-        metrics.counter("chorus.wal.operation.failures"),
-        metrics.counter("chorus.wal.repair.failures"),
-        metrics.counter("chorus.wal.seal.enforcement_retries"),
-        metrics.counter("chorus.wal.rotation.spare_provisioning_failures"),
         metrics.counter("chorus.wal.append.failures"),
     );
     assert!(
@@ -280,9 +259,9 @@ async fn queue_depth_one_makes_progress_across_latency_injected_rotation() {
         "queue-depth-one run completed only {rotations} rotations"
     );
     assert_eq!(
-        metrics.counter("chorus.wal.operation.failures"),
+        metrics.counter("chorus.wal.append.failures"),
         0,
-        "queue-depth-one run encountered an internal operation failure"
+        "queue-depth-one run encountered an append failure"
     );
 }
 
@@ -542,7 +521,7 @@ async fn admission_requires_manifest_room_to_seal_the_active_segment() {
 #[tokio::test]
 async fn admission_waits_for_the_encoded_inflight_byte_budget() {
     let (servers, factories, manifest_factory) = factory_cluster().await;
-    let (volume, metrics) = volume_with_metrics(factories, manifest_factory, "byte-budget-wal");
+    let volume = volume(factories, manifest_factory, "byte-budget-wal");
     let mut handle = WalEngine::start(
         volume.recover_writer().await.unwrap(),
         WalEngineConfig {
@@ -579,7 +558,6 @@ async fn admission_waits_for_the_encoded_inflight_byte_budget() {
     };
     first.await.unwrap();
     second.await.unwrap();
-    assert_eq!(metrics.gauge("chorus.wal.pipeline.max_inflight_bytes"), 9);
     shutdown_engine(handle).await;
 }
 
@@ -606,7 +584,7 @@ async fn queue_capacity_bounds_channel_and_engine_queue_together() {
         .await
         .unwrap();
     tokio::time::timeout(Duration::from_secs(1), async {
-        while metrics.gauge("chorus.wal.pipeline.max_inflight_records") != 1 {
+        while metrics.labeled_gauge("chorus.wal.replica.durable_lag_bytes", &[("zone", "0")]) == 0 {
             tokio::task::yield_now().await;
         }
     })
@@ -690,49 +668,6 @@ async fn lagging_replica_is_dropped_at_its_retained_byte_budget() {
 }
 
 #[tokio::test]
-async fn attempted_byte_metrics_include_transport_retries() {
-    let (servers, factories, manifest_factory) = factory_cluster().await;
-    let (volume, metrics) =
-        volume_with_metrics(factories, manifest_factory.clone(), "attempted-bytes-wal");
-    let mut recovery = volume.recover(WalSeqNo::ZERO).await.unwrap();
-    while recovery.try_next().await.unwrap().is_some() {}
-    let mut handle = recovery
-        .start(WalEngineConfig {
-            max_segment_bytes: 1,
-            ..Default::default()
-        })
-        .await
-        .unwrap();
-    servers[0]
-        .service
-        .inject(Operation::BidiWrite, Code::Unavailable)
-        .await;
-    handle
-        .enqueue_append(WalSeqNo::ZERO, bytes::Bytes::from_static(b"retry"))
-        .await
-        .unwrap()
-        .await
-        .unwrap();
-
-    // The injected lane failure retries after a backoff on a zone the
-    // commit quorum never waited for; poll until the retried chunk's bytes
-    // are attempted. The wait is wall-clock-bounded like
-    // `wait_for_repair_passes`, not iteration-bounded.
-    tokio::time::timeout(Duration::from_secs(10), async {
-        while metrics.counter("chorus.wal.replica.bytes_attempted") < 9 * 4 {
-            tokio::task::yield_now().await;
-        }
-    })
-    .await
-    .expect("the zone 0 lane never attempted the retried chunk");
-    handle.truncate_before(WalSeqNo::ZERO).await.unwrap();
-    assert_eq!(metrics.counter("chorus.wal.append.encoded_bytes"), 9);
-    assert_eq!(metrics.counter("chorus.wal.replica.bytes_attempted"), 9 * 4);
-    assert!(metrics.counter("chorus.wal.lane.retries") >= 1);
-    shutdown_engine(handle).await;
-}
-
-#[tokio::test]
 async fn clean_rotation_avoids_followup_content_reads() {
     let (servers, factories, manifest_factory) = factory_cluster().await;
     let volume = volume(factories, manifest_factory, "rotation-rpc-wal");
@@ -806,7 +741,7 @@ async fn rotation_refuses_to_cross_an_uncommitted_tail_gap() {
     }
     servers[0].service.permit_held_flushes(1).await;
     let pending = writer
-        .enqueue_records(vec![record(b"r1")], no_attempted_bytes())
+        .enqueue_records(vec![record(b"r1")])
         .await
         .unwrap()
         .remove(0);
@@ -1302,7 +1237,7 @@ async fn rotation_targets_repair_at_a_copy_missing_finalization() {
 
     // A crashed zone makes the rotation seal finalize only a quorum: the
     // engine must schedule a targeted repair pass for the one degraded
-    // copy (which records a transient skip while the zone stays down).
+    // copy even while the zone stays down.
     servers[2].service.set_crashed(true).await;
     handle
         .enqueue_append(WalSeqNo::ZERO, bytes::Bytes::from_static(b"sealed"))
@@ -1317,7 +1252,6 @@ async fn rotation_targets_repair_at_a_copy_missing_finalization() {
     })
     .await
     .expect("the degraded rotation never scheduled its targeted repair pass");
-    assert!(metrics.counter("chorus.wal.repair.transient_skips") >= 1);
     assert_eq!(metrics.counter("chorus.wal.seal.segments"), 1);
 
     servers[2].service.set_crashed(false).await;
@@ -1330,7 +1264,7 @@ async fn transient_seal_enforcement_failure_retries_without_gating_rotation() {
     let metrics = Arc::new(TestMetricsRecorder::default());
     let metrics_recorder: Arc<dyn crate::MetricsRecorder> = metrics.clone();
     // The shared test config has zero backoff, which can exhaust all outer
-    // maintenance retries before this task observes the first retry counter.
+    // maintenance retries before this task observes the next storage attempt.
     // A small test-only delay leaves the retry in flight while quorum returns.
     let volume = SegmentedVolume::new_with_factories_and_metrics_recorder(
         factories,
@@ -1374,10 +1308,22 @@ async fn transient_seal_enforcement_failure_retries_without_gating_rotation() {
     .await
     .expect("background fold did not reach the manifest update");
     for zone in [0usize, 1] {
+        servers[zone].service.reset_operation_counts().await;
         servers[zone].service.set_crashed(true).await;
     }
 
-    wait_for_counter(&metrics, "chorus.wal.seal.enforcement_retries", 1).await;
+    // Each failed recovery exhausts max_retries + 1 identity reads. First
+    // Writer::seal exhausts its storage fallback, then maintenance exhausts
+    // its first enforcement attempt. The next read proves an outer retry
+    // actually started, without retaining a production retry counter.
+    let retry_read = 2 * (test_config().max_retries as u64 + 1) + 1;
+    tokio::time::timeout(Duration::from_secs(10), async {
+        while servers[0].service.operation_count(Operation::Get).await < retry_read {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("committed seal enforcement did not retry after losing quorum");
     for zone in [0usize, 1] {
         servers[zone].service.set_crashed(false).await;
     }
@@ -1426,31 +1372,14 @@ async fn recorder_receives_write_and_seal_metrics() {
     .await
     .expect("automatic rotation did not seal a segment");
 
-    assert_eq!(metrics.counter("chorus.wal.append.records"), 1);
-    assert_eq!(metrics.counter("chorus.wal.append.bytes"), 6);
     assert_eq!(metrics.counter("chorus.wal.append.committed_records"), 1);
-    assert_eq!(metrics.gauge("chorus.wal.append.committed_watermark"), 1);
-    assert_eq!(metrics.counter("chorus.wal.batch.sent"), 1);
-    assert!(
-        metrics.counter("chorus.wal.append.encoded_bytes")
-            > metrics.counter("chorus.wal.append.bytes")
-    );
-    assert_eq!(metrics.counter("chorus.wal.rotation.completed"), 1);
-    assert_eq!(metrics.counter("chorus.wal.seal.segments"), 1);
-    assert!(metrics.counter("chorus.wal.manifest.cas_attempts") >= 2);
-    assert_eq!(metrics.counter("chorus.wal.repair.passes"), 1);
-    assert_eq!(
-        metrics.up_down_counter("chorus.wal.catalog.open_segments"),
-        1
-    );
+    assert_eq!(metrics.counter("chorus.wal.append.committed_bytes"), 6);
+    assert_eq!(metrics.counter("chorus.wal.append.failures"), 0);
     assert_eq!(
         metrics.histogram_samples("chorus.wal.append.commit_latency_seconds"),
         1
     );
-    assert_eq!(
-        metrics.histogram_samples("chorus.wal.manifest.cas_latency_seconds"),
-        metrics.counter("chorus.wal.manifest.cas_attempts") as usize
-    );
+    assert!(metrics.histogram_samples("chorus.wal.manifest.cas_latency_seconds") >= 2);
     assert_eq!(
         metrics.histogram_samples("chorus.wal.seal.duration_seconds"),
         1

--- a/rust/client/src/grpc_internal_tests/maintenance.rs
+++ b/rust/client/src/grpc_internal_tests/maintenance.rs
@@ -3,7 +3,7 @@ use super::*;
 #[tokio::test]
 async fn maintenance_sweeps_dead_spares_without_failing_recovery() {
     let (servers, factories, manifest_factory) = factory_cluster().await;
-    let (volume, metrics) = volume_with_metrics(
+    let volume = volume(
         factories.clone(),
         manifest_factory.clone(),
         "spare-sweep-wal",
@@ -62,8 +62,21 @@ async fn maintenance_sweeps_dead_spares_without_failing_recovery() {
         })
         .await
         .expect("orphan deletion failure must not fail recovery");
-    wait_for_counter(&metrics, "chorus.wal.orphan.sweeps_deferred", 1).await;
-    wait_for_counter(&metrics, "chorus.wal.orphan.objects_deleted", 3).await;
+    tokio::time::timeout(Duration::from_secs(10), async {
+        for factory in &factories {
+            let replica = factory.replica(&segment_object("spare-sweep-wal", &dead_spare));
+            loop {
+                match replica.stat().await {
+                    Err(error) if error.code == TransportCode::NotFound => break,
+                    Ok(_) => tokio::task::yield_now().await,
+                    Err(error) => panic!("unexpected spare stat failure: {error}"),
+                }
+            }
+        }
+    })
+    .await
+    .expect("the dead spare was not swept after the injected delete failure");
+    assert_eq!(servers[0].service.observed_fault_count().await, 1);
 
     for factory in &factories {
         assert_eq!(

--- a/rust/client/src/grpc_internal_tests/recovery.rs
+++ b/rust/client/src/grpc_internal_tests/recovery.rs
@@ -8,7 +8,7 @@ async fn recovery_does_not_promote_a_tail_below_the_second_largest_size() {
     servers[1].service.set_crashed(true).await;
     servers[2].service.set_crashed(true).await;
     let pending = first
-        .enqueue_records(vec![record(b"maybe-committed")], no_attempted_bytes())
+        .enqueue_records(vec![record(b"maybe-committed")])
         .await
         .unwrap()
         .remove(0);
@@ -75,9 +75,7 @@ async fn takeover_seals_old_segment_and_deposes_old_writer() {
 
     let recovered = volume.recover_writer().await.unwrap();
     assert_eq!(recovered.active_segment_base(), 1);
-    let stale = first
-        .enqueue_records(vec![record(b"stale")], no_attempted_bytes())
-        .await;
+    let stale = first.enqueue_records(vec![record(b"stale")]).await;
     let error = match stale {
         Ok(mut pending) => pending.remove(0).wait().await.unwrap_err(),
         Err(error) => error,
@@ -127,7 +125,7 @@ async fn manifest_takeover_fences_background_pending_fold() {
     assert!(matches!(error, Error::Fenced(_)), "{error}");
 
     let stale_error = match stale
-        .enqueue_records(vec![record(b"stale-successor")], no_attempted_bytes())
+        .enqueue_records(vec![record(b"stale-successor")])
         .await
     {
         Ok(mut pending) => pending.remove(0).wait().await.unwrap_err(),
@@ -340,11 +338,6 @@ async fn maintenance_restores_a_historical_segment_recovery_left_damaged() {
     )
     .unwrap();
     wait_for_repair_passes(&metrics, 1).await;
-    assert_eq!(metrics.counter("chorus.wal.repair.objects_repaired"), 1);
-    assert_eq!(
-        metrics.counter("chorus.wal.repair.segments_without_source"),
-        0
-    );
 
     let repaired = missing.snapshot().await.unwrap();
     assert!(repaired.finalized);
@@ -521,6 +514,47 @@ async fn repair_lists_each_zone_once_regardless_of_retained_history() {
 }
 
 #[tokio::test]
+async fn repair_skips_failed_listings_without_blocking_other_zones() {
+    for code in [Code::Unavailable, Code::PermissionDenied] {
+        let (servers, factories, manifest_factory) = factory_cluster().await;
+        let prefix = "repair-failed-listing-wal";
+        let volume = volume(factories.clone(), manifest_factory, prefix);
+        let mut writer = volume.recover_writer().await.unwrap();
+        append_one(&mut writer, b"committed").await;
+        writer.rotate().await.unwrap();
+        let object = segment_object(prefix, &writer.catalog()[0].id);
+        for factory in &factories[1..] {
+            let replica = factory.replica(&object);
+            let generation = replica.stat().await.unwrap().generation;
+            replica.delete(generation).await.unwrap();
+        }
+        servers[1].service.reset_operation_counts().await;
+        servers[1].service.inject(Operation::List, code).await;
+
+        let report = writer.repair_sealed_segments().await.unwrap();
+        assert_eq!(report.objects_repaired, 1);
+        assert_eq!(report.objects_already_healthy, 1);
+        assert_eq!(report.transient_failures, 1);
+        assert_eq!(report.segments_without_source, 0);
+        assert_eq!(servers[1].service.operation_count(Operation::List).await, 1);
+        assert_eq!(servers[1].service.operation_count(Operation::Get).await, 0);
+        assert_eq!(servers[1].service.operation_count(Operation::Read).await, 0);
+        assert_eq!(
+            factories[1].replica(&object).stat().await.unwrap_err().code,
+            TransportCode::NotFound,
+        );
+        assert!(
+            factories[2]
+                .replica(&object)
+                .stat()
+                .await
+                .unwrap()
+                .finalized
+        );
+    }
+}
+
+#[tokio::test]
 async fn repair_reports_a_segment_with_no_verifiable_copy_and_keeps_going() {
     let (_servers, factories, manifest_factory) = factory_cluster().await;
     let volume = volume(
@@ -559,7 +593,7 @@ async fn repair_reports_a_segment_with_no_verifiable_copy_and_keeps_going() {
 /// The wait is wall-clock-bounded, not iteration-bounded: the pass makes
 /// real loopback RPCs, so a slow machine needs time, not yields.
 #[tokio::test]
-async fn engine_start_repairs_rejoined_zone_and_reports_metrics() {
+async fn engine_start_repairs_rejoined_zone() {
     let (servers, factories, manifest_factory) = factory_cluster().await;
     servers[2].service.set_crashed(true).await;
     let (volume, metrics) = volume_with_metrics(
@@ -593,8 +627,6 @@ async fn engine_start_repairs_rejoined_zone_and_reports_metrics() {
 
     wait_for_repair_passes(&metrics, 1).await;
     assert_eq!(metrics.counter("chorus.wal.repair.passes"), 1);
-    assert_eq!(metrics.counter("chorus.wal.repair.objects_repaired"), 1);
-    assert_eq!(metrics.counter("chorus.wal.repair.failures"), 0);
     let repaired = factories[2]
         .replica(&sealed_object)
         .snapshot()
@@ -627,7 +659,6 @@ async fn repair_pass_failure_does_not_fail_appends() {
         .unwrap();
     wait_for_repair_passes(&metrics, 1).await;
     assert_eq!(metrics.counter("chorus.wal.repair.passes"), 1);
-    assert_eq!(metrics.counter("chorus.wal.repair.failures"), 1);
     assert_eq!(metrics.counter("chorus.wal.append.committed_records"), 1);
     shutdown_engine(handle).await;
 }
@@ -805,10 +836,7 @@ async fn startup_replay_preserves_record_order_and_sequence_numbers() {
     let volume = volume(factories, manifest_factory.clone(), "replay-wal");
     let mut writer = volume.recover_writer().await.unwrap();
     let pending = writer
-        .enqueue_records(
-            vec![record(b"a"), record(b"b"), record(b"c")],
-            no_attempted_bytes(),
-        )
+        .enqueue_records(vec![record(b"a"), record(b"b"), record(b"c")])
         .await
         .unwrap();
     for pending in pending {

--- a/rust/client/src/grpc_internal_tests/topology.rs
+++ b/rust/client/src/grpc_internal_tests/topology.rs
@@ -120,7 +120,7 @@ async fn five_zone_writes_block_without_a_three_zone_quorum() {
         server.service.set_crashed(true).await;
     }
     let pending = writer
-        .enqueue_records(vec![record(b"no-quorum")], no_attempted_bytes())
+        .enqueue_records(vec![record(b"no-quorum")])
         .await
         .unwrap()
         .remove(0);

--- a/rust/client/src/grpc_internal_tests/writer.rs
+++ b/rust/client/src/grpc_internal_tests/writer.rs
@@ -189,10 +189,7 @@ async fn pipeline_returns_per_record_quorum_futures() {
         .inject_delay(Operation::BidiWrite, Duration::from_secs(1))
         .await;
     let pending = writer
-        .enqueue_records(
-            vec![record(b"a"), record(b"b"), record(b"c")],
-            no_attempted_bytes(),
-        )
+        .enqueue_records(vec![record(b"a"), record(b"b"), record(b"c")])
         .await
         .unwrap();
     let offsets = tokio::time::timeout(Duration::from_millis(250), async {

--- a/rust/client/src/maintenance.rs
+++ b/rust/client/src/maintenance.rs
@@ -297,7 +297,6 @@ async fn execute_command(
                         deleted_segments = report.deleted_segments,
                         "truncation completed"
                     );
-                    task.metrics.truncation_cycles.increment();
                 }
                 Err(error) => {
                     tracing::warn!(
@@ -306,7 +305,6 @@ async fn execute_command(
                         "truncation failed"
                     );
                     task.manifest = None;
-                    task.metrics.operation_failures.increment();
                 }
             }
             for response in responses {
@@ -535,6 +533,7 @@ impl MaintenanceState {
         match enforcement {
             Ok((segment, all_replicas_finalized)) => {
                 self.sealed.insert(base);
+                #[cfg(any(test, feature = "dst-support"))]
                 self.metrics.segments_sealed.increment();
                 self.metrics
                     .seal_duration
@@ -557,7 +556,6 @@ impl MaintenanceState {
                     %error,
                     "committed seal enforcement exhausted retries; rotation disabled until restart"
                 );
-                self.metrics.operation_failures.increment();
                 drop(enforced);
             }
         }
@@ -573,9 +571,6 @@ impl MaintenanceState {
     ) -> Result<SegmentDescriptor, Error> {
         let mut attempt = 0usize;
         loop {
-            if attempt > 0 {
-                self.metrics.seal_enforcement_retries.increment();
-            }
             match enforce_committed_seal(
                 &self.factories,
                 &self.prefix,
@@ -642,9 +637,6 @@ impl MaintenanceState {
             return;
         };
         let report = sweep_dead_segments(&self.factories, &self.prefix, &sweep).await;
-        self.metrics
-            .orphan_objects_deleted
-            .add(report.deleted_objects as u64);
         if report.deferred_operations == 0 {
             self.dead_segment_sweep = None;
             if report.orphan_segments > 0 || report.deleted_objects > 0 {
@@ -658,10 +650,8 @@ impl MaintenanceState {
             return;
         }
 
-        self.metrics.orphan_sweeps_deferred.increment();
         match report.failure {
             Some(error) => {
-                self.metrics.operation_failures.increment();
                 tracing::warn!(
                     claimed_epoch = sweep.claimed_epoch,
                     orphan_segments = report.orphan_segments,
@@ -688,12 +678,10 @@ impl MaintenanceState {
         let prefix = self.prefix.clone();
         if let Err(error) = self.ensure_manifest().await {
             tracing::warn!(%error, "tombstone cleanup manifest unavailable");
-            self.metrics.operation_failures.increment();
             return;
         }
         let Some(mut manifest) = self.manifest.take() else {
             tracing::warn!("tombstone cleanup lost its ensured manifest handle");
-            self.metrics.operation_failures.increment();
             return;
         };
         let before: HashSet<u64> = self
@@ -720,7 +708,6 @@ impl MaintenanceState {
                 // have left this handle's cache behind a concurrent truncator.
                 self.manifest = None;
                 tracing::warn!(%error, "committed-floor tombstone cleanup failed");
-                self.metrics.operation_failures.increment();
             }
         }
     }
@@ -732,29 +719,20 @@ impl MaintenanceState {
                 Err(error) => {
                     tracing::warn!(%error, "repair manifest refresh unavailable");
                     self.manifest = None;
-                    self.metrics.repair_failures.increment();
+                    #[cfg(any(test, feature = "dst-support"))]
                     self.metrics.repair_passes.increment();
                     return;
                 }
             },
             Err(error) => {
                 tracing::warn!(%error, "repair manifest unavailable");
-                self.metrics.repair_failures.increment();
+                #[cfg(any(test, feature = "dst-support"))]
                 self.metrics.repair_passes.increment();
                 return;
             }
         };
         match repair_sealed_pass(&self.factories, &self.prefix, &self.catalog, floor).await {
             Ok(report) => {
-                self.metrics
-                    .repair_objects_repaired
-                    .add(report.objects_repaired as u64);
-                self.metrics
-                    .repair_transient_skips
-                    .add(report.transient_failures as u64);
-                self.metrics
-                    .repair_segments_without_source
-                    .add(report.segments_without_source as u64);
                 if report.objects_repaired > 0 {
                     tracing::info!(
                         segments_examined = report.segments_examined,
@@ -788,12 +766,11 @@ impl MaintenanceState {
             }
             Err(error) => {
                 tracing::warn!(%error, floor, "repair pass failed");
-                self.metrics.repair_failures.increment();
-                self.metrics.operation_failures.increment();
             }
         }
         // counted on completion: deterministic tests and the DST poll this
         // as "a full pass has run"
+        #[cfg(any(test, feature = "dst-support"))]
         self.metrics.repair_passes.increment();
     }
 
@@ -808,7 +785,7 @@ impl MaintenanceState {
                         "targeted repair manifest refresh unavailable"
                     );
                     self.manifest = None;
-                    self.metrics.repair_failures.increment();
+                    #[cfg(any(test, feature = "dst-support"))]
                     self.metrics.repair_passes.increment();
                     return;
                 }
@@ -819,7 +796,7 @@ impl MaintenanceState {
                     segment_base = segment.base_record_index,
                     "targeted repair manifest unavailable"
                 );
-                self.metrics.repair_failures.increment();
+                #[cfg(any(test, feature = "dst-support"))]
                 self.metrics.repair_passes.increment();
                 return;
             }
@@ -833,21 +810,25 @@ impl MaintenanceState {
         .await
         {
             Ok(report) => {
-                self.metrics
-                    .repair_objects_repaired
-                    .add(report.objects_repaired as u64);
-                self.metrics
-                    .repair_transient_skips
-                    .add(report.transient_failures as u64);
-                self.metrics
-                    .repair_segments_without_source
-                    .add(report.segments_without_source as u64);
                 if report.objects_repaired > 0 {
                     tracing::info!(
                         segment_base = segment.base_record_index,
                         objects_repaired = report.objects_repaired,
                         transient_failures = report.transient_failures,
                         "targeted post-rotation repair completed"
+                    );
+                }
+                if report.transient_failures > 0 {
+                    tracing::warn!(
+                        segment_base = segment.base_record_index,
+                        transient_failures = report.transient_failures,
+                        "targeted post-rotation repair left transient failures"
+                    );
+                }
+                if report.segments_without_source > 0 {
+                    tracing::error!(
+                        segment_base = segment.base_record_index,
+                        "targeted post-rotation repair found a committed sealed segment with no verifiable copy"
                     );
                 }
             }
@@ -857,10 +838,9 @@ impl MaintenanceState {
                     segment_base = segment.base_record_index,
                     "targeted post-rotation repair failed"
                 );
-                self.metrics.repair_failures.increment();
-                self.metrics.operation_failures.increment();
             }
         }
+        #[cfg(any(test, feature = "dst-support"))]
         self.metrics.repair_passes.increment();
     }
 

--- a/rust/client/src/manifest.rs
+++ b/rust/client/src/manifest.rs
@@ -684,18 +684,12 @@ impl Manifest {
                 CasTransform::Update { record, value } => (*record, value),
             };
             next.validate()?;
-            self.metrics.manifest_cas_attempts.increment();
             match self.timed_update(version, next.encode()).await {
                 Ok(updated) => {
                     self.install_cache(updated, next);
                     return Ok(value);
                 }
-                Err(
-                    error @ (ManifestStoreError::Conflict | ManifestStoreError::Unavailable(_)),
-                ) => {
-                    if matches!(error, ManifestStoreError::Conflict) {
-                        self.metrics.manifest_cas_conflicts.increment();
-                    }
+                Err(ManifestStoreError::Conflict | ManifestStoreError::Unavailable(_)) => {
                     self.refresh().await?;
                 }
                 Err(error) => return Err(error.into()),

--- a/rust/client/src/metrics.rs
+++ b/rust/client/src/metrics.rs
@@ -181,10 +181,6 @@ impl Gauge {
         self.0.set(value);
     }
 
-    pub(crate) fn set_u64(&self, value: u64) {
-        self.set(i64::try_from(value).unwrap_or(i64::MAX));
-    }
-
     pub(crate) fn set_usize(&self, value: usize) {
         self.set(i64::try_from(value).unwrap_or(i64::MAX));
     }
@@ -224,20 +220,6 @@ impl AggregateGauge {
     }
 }
 
-pub(crate) struct UpDownCounter(Arc<dyn UpDownCounterFn>);
-
-impl UpDownCounter {
-    fn register(recorder: &dyn MetricsRecorder, name: &str, description: &str) -> Self {
-        Self(recorder.register_up_down_counter(name, description, &[]))
-    }
-
-    pub(crate) fn add(&self, value: i64) {
-        self.0.increment(value);
-    }
-}
-
-/// Prometheus-style latency buckets in seconds, wide enough to span a fast
-/// zonal append acknowledgment and a slow regional seal alike.
 /// Every `TransportCode`, so a failure counter exists for each and a code that
 /// never fires is visibly zero rather than absent.
 const TRANSPORT_FAILURE_CODES: &[&str] = &[
@@ -258,6 +240,7 @@ const TRANSPORT_FAILURE_CODES: &[&str] = &[
     "Internal",
 ];
 
+/// Latency buckets spanning fast zonal acknowledgments and slow regional seals.
 const LATENCY_SECONDS_BOUNDARIES: &[f64] = &[
     0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0,
 ];
@@ -283,74 +266,27 @@ impl Histogram {
     }
 }
 
-pub(crate) struct HighWaterGauge {
-    high_water: AtomicI64,
-    gauge: Gauge,
-}
-
-impl HighWaterGauge {
-    fn register(recorder: &dyn MetricsRecorder, name: &str, description: &str) -> Self {
-        Self {
-            high_water: AtomicI64::new(0),
-            gauge: Gauge::register(recorder, name, description),
-        }
-    }
-
-    pub(crate) fn update_max(&self, value: u64) {
-        let value = i64::try_from(value).unwrap_or(i64::MAX);
-        if self.high_water.fetch_max(value, Ordering::Relaxed) < value {
-            self.gauge.set(value);
-            let current = self.high_water.load(Ordering::Relaxed);
-            if current > value {
-                self.gauge.set(current);
-            }
-        }
-    }
-}
-
 /// Handles for all metrics emitted by one WAL volume.
+///
+/// Four event counters are available only to deterministic simulations and
+/// unit tests: they synchronize fault injection and check protocol coverage,
+/// rather than describing production health.
 pub(crate) struct Metrics {
-    pub(crate) append_records: Counter,
-    pub(crate) append_bytes: Counter,
     pub(crate) append_failures: Counter,
     pub(crate) committed_records: Counter,
     pub(crate) committed_bytes: Counter,
-    pub(crate) batches_sent: Counter,
-    pub(crate) lane_retries: Counter,
+    #[cfg(any(test, feature = "dst-support"))]
     pub(crate) lane_timeouts: Counter,
-    pub(crate) rotations_completed: Counter,
-    pub(crate) spare_provisioning_attempts: Counter,
-    pub(crate) spare_provisioning_failures: Counter,
+    #[cfg(any(test, feature = "dst-support"))]
     pub(crate) segments_sealed: Counter,
-    pub(crate) seal_enforcement_retries: Counter,
-    pub(crate) manifest_cas_attempts: Counter,
-    pub(crate) manifest_cas_conflicts: Counter,
+    #[cfg(any(test, feature = "dst-support"))]
     pub(crate) repair_passes: Counter,
-    pub(crate) repair_objects_repaired: Counter,
-    pub(crate) repair_transient_skips: Counter,
-    pub(crate) repair_segments_without_source: Counter,
-    pub(crate) repair_failures: Counter,
-    pub(crate) recoveries_run: Counter,
-    pub(crate) recovery_segments_adopted: Counter,
-    /// Per-operation latency of individual provider RPCs, and the codes they
-    /// fail with. Phase timings say which part of recovery is slow; these say
-    /// which storage call is, which is the form a provider can act on.
+    /// Latency and failure codes of timed quorum-path replica operations.
     pub(crate) rpc: TransportRpcMetrics,
-    pub(crate) orphan_objects_deleted: Counter,
-    pub(crate) orphan_sweeps_deferred: Counter,
-    pub(crate) truncation_cycles: Counter,
-    pub(crate) operation_failures: Counter,
-    pub(crate) max_inflight_records: HighWaterGauge,
-    pub(crate) max_inflight_bytes: HighWaterGauge,
-    pub(crate) pipeline_refills: Counter,
+    #[cfg(any(test, feature = "dst-support"))]
     pub(crate) lane_capacity_drops: Counter,
-    pub(crate) wal_record_bytes: Counter,
-    pub(crate) replica_bytes_attempted: Counter,
-    pub(crate) open_segments: UpDownCounter,
-    pub(crate) committed_records_watermark: Gauge,
     pub(crate) queue_depth: Gauge,
     zone_durable_lag: Vec<AggregateGauge>,
-    pub(crate) rotation_state: Gauge,
     maintenance_queue_depth: AggregateGauge,
     pub(crate) manifest_directory_bytes: Gauge,
     pub(crate) append_commit_latency: Histogram,
@@ -367,13 +303,10 @@ pub(crate) struct TransportRpcMetrics {
     pub(crate) stat: Histogram,
     pub(crate) create_appendable: Histogram,
     pub(crate) create_append_session: Histogram,
-    pub(crate) create_register: Histogram,
-    pub(crate) update_register: Histogram,
     pub(crate) resume_tail: Histogram,
     pub(crate) takeover: Histogram,
     pub(crate) replace_appendable: Histogram,
     pub(crate) finalize: Histogram,
-    pub(crate) delete: Histogram,
     failures: Vec<(&'static str, Counter)>,
 }
 
@@ -383,7 +316,7 @@ impl TransportRpcMetrics {
             Histogram::register_with_labels(
                 recorder,
                 "chorus.wal.transport.rpc_seconds",
-                "Latency of one provider RPC",
+                "Latency of one quorum-path replica operation",
                 &[("op", op)],
             )
         };
@@ -406,13 +339,10 @@ impl TransportRpcMetrics {
             stat: rpc("stat"),
             create_appendable: rpc("create_appendable"),
             create_append_session: rpc("create_append_session"),
-            create_register: rpc("create_register"),
-            update_register: rpc("update_register"),
             resume_tail: rpc("resume_tail"),
             takeover: rpc("takeover"),
             replace_appendable: rpc("replace_appendable"),
             finalize: rpc("finalize"),
-            delete: rpc("delete"),
             failures,
         }
     }
@@ -436,11 +366,6 @@ impl Metrics {
                 Gauge::register(recorder, $name, $description)
             };
         }
-        macro_rules! high_water {
-            ($name:literal, $description:literal) => {
-                HighWaterGauge::register(recorder, $name, $description)
-            };
-        }
         macro_rules! histogram {
             ($name:literal, $description:literal) => {
                 Histogram::register(recorder, $name, $description)
@@ -460,14 +385,6 @@ impl Metrics {
             .collect();
 
         Self {
-            append_records: counter!(
-                "chorus.wal.append.records",
-                "Application records admitted for append"
-            ),
-            append_bytes: counter!(
-                "chorus.wal.append.bytes",
-                "Application payload bytes admitted for append"
-            ),
             append_failures: counter!(
                 "chorus.wal.append.failures",
                 "Admitted appends that completed with an error"
@@ -480,119 +397,25 @@ impl Metrics {
                 "chorus.wal.append.committed_bytes",
                 "Application payload bytes committed in contiguous sequence order"
             ),
-            batches_sent: counter!(
-                "chorus.wal.batch.sent",
-                "Logical record batches submitted to replication"
-            ),
-            lane_retries: counter!(
-                "chorus.wal.lane.retries",
-                "Replica lane recovery or resend attempts"
-            ),
+            #[cfg(any(test, feature = "dst-support"))]
             lane_timeouts: counter!(
                 "chorus.wal.lane.timeouts",
                 "Replica lanes shed after making no durable progress before their timeout"
             ),
-            rotations_completed: counter!(
-                "chorus.wal.rotation.completed",
-                "Active-segment rotations completed"
-            ),
-            spare_provisioning_attempts: counter!(
-                "chorus.wal.rotation.spare_provisioning_attempts",
-                "Background spare provisioning attempts"
-            ),
-            spare_provisioning_failures: counter!(
-                "chorus.wal.rotation.spare_provisioning_failures",
-                "Background spare provisioning failures"
-            ),
+            #[cfg(any(test, feature = "dst-support"))]
             segments_sealed: counter!(
                 "chorus.wal.seal.segments",
                 "Segments whose committed seal was enforced"
             ),
-            seal_enforcement_retries: counter!(
-                "chorus.wal.seal.enforcement_retries",
-                "Committed-seal enforcement retry attempts started by maintenance"
-            ),
-            manifest_cas_attempts: counter!(
-                "chorus.wal.manifest.cas_attempts",
-                "Manifest compare-and-swap requests sent to storage"
-            ),
-            manifest_cas_conflicts: counter!(
-                "chorus.wal.manifest.cas_conflicts",
-                "Manifest compare-and-swap precondition conflicts"
-            ),
+            #[cfg(any(test, feature = "dst-support"))]
             repair_passes: counter!(
                 "chorus.wal.repair.passes",
                 "Sealed-segment repair passes completed or skipped after an error"
             ),
-            repair_objects_repaired: counter!(
-                "chorus.wal.repair.objects_repaired",
-                "Missing or divergent sealed objects repaired"
-            ),
-            repair_transient_skips: counter!(
-                "chorus.wal.repair.transient_skips",
-                "Repair targets skipped after transient failures"
-            ),
-            repair_segments_without_source: counter!(
-                "chorus.wal.repair.segments_without_source",
-                "Sealed segments left unrepaired because no reachable copy verified"
-            ),
-            repair_failures: counter!(
-                "chorus.wal.repair.failures",
-                "Repair passes aborted by an error"
-            ),
-            recoveries_run: counter!("chorus.wal.recovery.runs", "Recovery attempts started"),
-            recovery_segments_adopted: counter!(
-                "chorus.wal.recovery.segments_adopted",
-                "Sealed segments adopted by recovery"
-            ),
-            orphan_objects_deleted: counter!(
-                "chorus.wal.orphan.objects_deleted",
-                "Dead-incarnation segment-object copies deleted by maintenance"
-            ),
-            orphan_sweeps_deferred: counter!(
-                "chorus.wal.orphan.sweeps_deferred",
-                "Dead-incarnation sweeps deferred after transient or terminal storage failures"
-            ),
-            truncation_cycles: counter!(
-                "chorus.wal.truncation.cycles",
-                "Application-triggered truncation cycles completed"
-            ),
-            operation_failures: counter!(
-                "chorus.wal.operation.failures",
-                "Engine and maintenance operations completed with errors"
-            ),
-            max_inflight_records: high_water!(
-                "chorus.wal.pipeline.max_inflight_records",
-                "High-water mark of dispatched uncommitted records"
-            ),
-            max_inflight_bytes: high_water!(
-                "chorus.wal.pipeline.max_inflight_bytes",
-                "High-water mark of admitted unresolved encoded bytes"
-            ),
-            pipeline_refills: counter!(
-                "chorus.wal.pipeline.refills",
-                "Pipeline refills before all prior records completed"
-            ),
+            #[cfg(any(test, feature = "dst-support"))]
             lane_capacity_drops: counter!(
                 "chorus.wal.lane.capacity_drops",
                 "Replica lanes dropped after exceeding their retained-byte budget"
-            ),
-            wal_record_bytes: counter!(
-                "chorus.wal.append.encoded_bytes",
-                "Encoded durable record bytes generated before replication"
-            ),
-            replica_bytes_attempted: counter!(
-                "chorus.wal.replica.bytes_attempted",
-                "Encoded bytes handed to replica transports including retries"
-            ),
-            open_segments: UpDownCounter::register(
-                recorder,
-                "chorus.wal.catalog.open_segments",
-                "Active appendable segments owned by this client",
-            ),
-            committed_records_watermark: gauge!(
-                "chorus.wal.append.committed_watermark",
-                "Exclusive committed record boundary"
             ),
             queue_depth: gauge!(
                 "chorus.wal.pipeline.queue_depth",
@@ -600,10 +423,6 @@ impl Metrics {
             ),
             zone_durable_lag,
             rpc: TransportRpcMetrics::register(recorder),
-            rotation_state: gauge!(
-                "chorus.wal.rotation.state",
-                "Rotation gate state: 0 idle, 1 due, 2 draining, 3 sealing, 4 disabled"
-            ),
             maintenance_queue_depth: AggregateGauge::register(
                 recorder,
                 "chorus.wal.maintenance.queue_depth",
@@ -667,10 +486,6 @@ pub(crate) mod test_support {
 
         pub(crate) fn labeled_gauge(&self, name: &str, labels: &[(&str, &str)]) -> i64 {
             self.gauges.lock().unwrap()[&metric_key(name, labels)].load(Ordering::Relaxed)
-        }
-
-        pub(crate) fn up_down_counter(&self, name: &str) -> i64 {
-            self.up_down_counters.lock().unwrap()[name].load(Ordering::Relaxed)
         }
 
         pub(crate) fn histogram_samples(&self, name: &str) -> usize {

--- a/rust/client/src/protocol.rs
+++ b/rust/client/src/protocol.rs
@@ -43,8 +43,6 @@ fn select_recovery_size(sizes: &mut [i64], replica_count: usize) -> Option<i64> 
     (required_available_support > 0).then(|| sizes[sizes.len() - required_available_support])
 }
 
-pub(crate) type AttemptedBytes = Arc<dyn Fn(u64) + Send + Sync>;
-
 #[derive(Clone, Debug)]
 /// Retry policy for transport operations used by recovery and writes.
 ///
@@ -1426,7 +1424,6 @@ impl Writer {
     pub async fn enqueue_data_window(
         &mut self,
         records: Vec<RecordFrame>,
-        on_attempted: AttemptedBytes,
     ) -> Result<CommitRange, ProtocolError> {
         if records.is_empty() {
             return Ok(CommitRange {
@@ -1451,7 +1448,6 @@ impl Writer {
             self.commits.poison();
             return Err(ProtocolError::NoQuorum);
         }
-        self.metrics.batches_sent.increment();
         let batch_bytes = chunks.iter().map(Bytes::len).sum::<usize>();
         let mut reservations = Vec::with_capacity(self.lanes.len());
         let mut retired_lanes = Vec::new();
@@ -1464,6 +1460,7 @@ impl Writer {
                 lane.done.abort();
                 retired_lanes.push(lane.done);
                 self.commits.finish_lane(zone, None);
+                #[cfg(any(test, feature = "dst-support"))]
                 self.metrics.lane_capacity_drops.increment();
                 tracing::warn!(
                     zone,
@@ -1491,8 +1488,6 @@ impl Writer {
             start,
             chunks: Arc::clone(&chunks),
             boundaries,
-            on_attempted: Arc::clone(&on_attempted),
-            bytes: batch_bytes,
             pending_lanes: AtomicUsize::new(reservations.iter().flatten().count()),
             packed_groups: std::sync::Mutex::new(BTreeMap::new()),
         });
@@ -1847,8 +1842,6 @@ struct BatchDescriptor {
     start: i64,
     chunks: Arc<[Bytes]>,
     boundaries: Arc<[i64]>,
-    on_attempted: AttemptedBytes,
-    bytes: usize,
     pending_lanes: AtomicUsize,
     packed_groups: Mutex<BTreeMap<i64, Arc<OnceLock<Arc<PackedAppend>>>>>,
 }
@@ -1987,8 +1980,9 @@ enum LaneDeath {
 }
 
 impl LaneDeath {
-    fn stalled(metrics: &Metrics) -> Self {
-        metrics.lane_timeouts.increment();
+    fn stalled(_metrics: &Metrics) -> Self {
+        #[cfg(any(test, feature = "dst-support"))]
+        _metrics.lane_timeouts.increment();
         Self::Stalled
     }
 }
@@ -2002,7 +1996,6 @@ struct LaneRuntime {
     stall_timeout: Arc<LaneStallTimeout>,
     durable: i64,
     retained: VecDeque<RetainedBatch>,
-    attempted: Option<AttemptedBytes>,
     monitor_session: bool,
     last_progress: tokio::time::Instant,
 }
@@ -2026,7 +2019,6 @@ impl LaneRuntime {
             stall_timeout,
             durable,
             retained: VecDeque::new(),
-            attempted: None,
             // Keep observing an idle live stream so a trailing fence cannot
             // disappear merely because its persisted-size response drained
             // the retained suffix.
@@ -2074,12 +2066,7 @@ impl LaneRuntime {
     async fn stage(&mut self, batches: Vec<LaneBatch>) -> Result<bool, LaneDeath> {
         match tokio::time::timeout_at(
             self.stall_deadline(),
-            stage_group(
-                &self.replica,
-                batches,
-                &mut self.attempted,
-                &mut self.retained,
-            ),
+            stage_group(&self.replica, batches, &mut self.retained),
         )
         .await
         {
@@ -2240,7 +2227,6 @@ async fn run_lane(
 async fn stage_group(
     replica: &Arc<dyn Replica>,
     batches: Vec<LaneBatch>,
-    attempted: &mut Option<AttemptedBytes>,
     retained: &mut VecDeque<RetainedBatch>,
 ) -> bool {
     let group_start = batches
@@ -2250,8 +2236,6 @@ async fn stage_group(
         .start;
     let packed = packed_group(&batches);
     for batch in batches {
-        (batch.batch.on_attempted)(batch.batch.bytes as u64);
-        *attempted = Some(Arc::clone(&batch.batch.on_attempted));
         retained.push_back(batch.into_retained());
     }
     replica
@@ -2400,7 +2384,6 @@ impl LaneRuntime {
     async fn recover(&mut self) -> Result<(), LaneDeath> {
         let mut attempt = 0usize;
         loop {
-            self.metrics.lane_retries.increment();
             let deadline = self.stall_deadline();
             let resumed =
                 tokio::time::timeout_at(deadline, self.replica.resume_tail(&mut self.token)).await;
@@ -2458,9 +2441,6 @@ impl LaneRuntime {
                         attempt,
                         "resending append lane batch after recovery"
                     );
-                    if let Some(attempted) = &self.attempted {
-                        attempted(resend_bytes as u64);
-                    }
                     let sent = tokio::time::timeout_at(
                         self.stall_deadline(),
                         self.replica.lane_send_packed(self.durable, &packed),
@@ -2765,13 +2745,10 @@ mod tests {
             end += chunk.len() as i64;
             boundaries.push(end);
         }
-        let bytes = chunks.iter().map(Bytes::len).sum();
         Arc::new(BatchDescriptor {
             start,
             chunks: chunks.into(),
             boundaries: boundaries.into(),
-            on_attempted: Arc::new(|_| {}),
-            bytes,
             pending_lanes: AtomicUsize::new(pending_lanes),
             packed_groups: std::sync::Mutex::new(BTreeMap::new()),
         })
@@ -3255,26 +3232,28 @@ mod tests {
     fn matching_lane_groups_share_one_packed_wire_payload() {
         let first = batch_descriptor(0, vec![Bytes::from_static(b"first")], 2);
         let second = batch_descriptor(first.end(), vec![Bytes::from_static(b"second")], 2);
+        let first_bytes = first.chunks.iter().map(Bytes::len).sum();
+        let second_bytes = second.chunks.iter().map(Bytes::len).sum();
         let first_budget = LaneBudget::new();
         let second_budget = LaneBudget::new();
         let group_one = vec![
             LaneBatch::new(
                 Arc::clone(&first),
-                first_budget.try_reserve(first.bytes).unwrap(),
+                first_budget.try_reserve(first_bytes).unwrap(),
             ),
             LaneBatch::new(
                 Arc::clone(&second),
-                first_budget.try_reserve(second.bytes).unwrap(),
+                first_budget.try_reserve(second_bytes).unwrap(),
             ),
         ];
         let group_two = vec![
             LaneBatch::new(
                 Arc::clone(&first),
-                second_budget.try_reserve(first.bytes).unwrap(),
+                second_budget.try_reserve(first_bytes).unwrap(),
             ),
             LaneBatch::new(
                 Arc::clone(&second),
-                second_budget.try_reserve(second.bytes).unwrap(),
+                second_budget.try_reserve(second_bytes).unwrap(),
             ),
         ];
 
@@ -3686,10 +3665,9 @@ mod tests {
         );
         let encoded = record(b"first").encode().unwrap().len();
         writer.set_max_replica_lag_bytes(encoded * 2);
-        let attempted: AttemptedBytes = Arc::new(|_| {});
 
         let first = writer
-            .enqueue_data_window(vec![record(b"first")], attempted.clone())
+            .enqueue_data_window(vec![record(b"first")])
             .await
             .unwrap()
             .into_pending()
@@ -3697,7 +3675,7 @@ mod tests {
         assert_eq!(sends_rx.recv().await, Some(encoded as i64));
 
         let second = writer
-            .enqueue_data_window(vec![record(b"other")], attempted.clone())
+            .enqueue_data_window(vec![record(b"other")])
             .await
             .unwrap()
             .into_pending()
@@ -3708,7 +3686,7 @@ mod tests {
         assert_eq!(sends_rx.recv().await, Some((encoded * 2) as i64));
 
         let third = writer
-            .enqueue_data_window(vec![record(b"third")], attempted)
+            .enqueue_data_window(vec![record(b"third")])
             .await
             .unwrap()
             .into_pending()

--- a/rust/client/src/segment.rs
+++ b/rust/client/src/segment.rs
@@ -19,8 +19,8 @@ use crate::metrics::{Metrics, MetricsRecorder, NoopMetricsRecorder};
 #[cfg(test)]
 use crate::protocol::PendingCommit;
 use crate::protocol::{
-    canonical_prefix, majority, valid_format, AttemptedBytes, ClientConfig, CommitRange,
-    ProtocolError, QuorumVolume, RecoveredTail, RecoveryCandidate, Writer,
+    canonical_prefix, majority, valid_format, ClientConfig, CommitRange, ProtocolError,
+    QuorumVolume, RecoveredTail, RecoveryCandidate, Writer,
 };
 use crate::record::RecordFrame;
 use crate::transport::{
@@ -242,12 +242,13 @@ struct RecoveredSeal {
 }
 
 impl RecoveredPredecessor {
-    async fn enforce_seal(&mut self, metrics: &Metrics) -> Result<(), Error> {
+    async fn enforce_seal(&mut self, _metrics: &Metrics) -> Result<(), Error> {
         let Some(seal) = self.deferred_seal.take() else {
             return Ok(());
         };
         seal.volume.enforce_seal(seal.tail.canonical()).await?;
-        metrics.segments_sealed.increment();
+        #[cfg(any(test, feature = "dst-support"))]
+        _metrics.segments_sealed.increment();
         Ok(())
     }
 
@@ -727,7 +728,6 @@ mod recovery {
         /// call [`Recovery::start`] to conditionally create the manifest-selected
         /// active segment and begin admission.
         pub async fn recover(&self, checkpoint: WalSeqNo) -> Result<Recovery, Error> {
-            self.metrics.recoveries_run.increment();
             let mut manifest = self.open_manifest().await?;
             let claim_started = tokio::time::Instant::now();
             manifest.claim().await.map_err(Error::from)?;
@@ -746,7 +746,6 @@ mod recovery {
         /// database checkpoint. Database integrations should use [`Self::recover`]
         /// with their durable replay boundary.
         pub async fn recover_from_committed_floor(&self) -> Result<Recovery, Error> {
-            self.metrics.recoveries_run.increment();
             let mut manifest = self.open_manifest().await?;
             let claim_started = tokio::time::Instant::now();
             manifest.claim().await.map_err(Error::from)?;
@@ -839,7 +838,6 @@ mod recovery {
             &self,
             checkpoint: WalSeqNo,
         ) -> Result<SegmentedWriter, Error> {
-            self.metrics.recoveries_run.increment();
             let mut manifest = self.open_manifest().await?;
             manifest.claim().await.map_err(Error::from)?;
             tracing::info!(
@@ -1328,9 +1326,6 @@ mod recovery {
                     checkpoint.record_index, next_record_index
                 )));
             }
-            self.metrics
-                .recovery_segments_adopted
-                .add(sealed_segments.len() as u64);
             Ok(RecoveredWriterState {
                 sealed_segments,
                 base_record_index: next_record_index,
@@ -1397,10 +1392,6 @@ mod recovery {
             // owner's takeover and the fold CAS's quorum intersection carry the
             // safety argument for what remains.
             manifest.validate_owner().await.map_err(Error::from)?;
-            self.metrics.open_segments.add(1);
-            self.metrics
-                .committed_records_watermark
-                .set_u64(base_record_index);
             let spare_registered = pending_fold.is_none();
             Ok(SegmentedWriter {
                 factories: self.factories.clone(),
@@ -1616,6 +1607,7 @@ mod recovery {
                 expected_crc32c,
             )
             .await?;
+            #[cfg(any(test, feature = "dst-support"))]
             self.metrics.segments_sealed.increment();
             Ok(sealed)
         }
@@ -1717,12 +1709,6 @@ mod recovery {
 /// Active writer operation, spare adoption, and rotation transitions.
 mod writer {
     use super::*;
-
-    impl Drop for SegmentedWriter {
-        fn drop(&mut self) {
-            self.metrics.open_segments.add(-1);
-        }
-    }
 
     impl SegmentedWriter {
         pub(crate) fn metrics(&self) -> Arc<Metrics> {
@@ -1863,11 +1849,10 @@ mod writer {
         pub(crate) async fn enqueue_records(
             &mut self,
             records: Vec<RecordFrame>,
-            on_attempted: AttemptedBytes,
         ) -> Result<Vec<RecordPendingCommit>, Error> {
             let pending = self
                 .segment_writer
-                .enqueue_data_window(records, on_attempted)
+                .enqueue_data_window(records)
                 .await?
                 .into_pending();
             Ok(pending
@@ -1882,12 +1867,8 @@ mod writer {
         pub(crate) async fn enqueue_records_for_engine(
             &mut self,
             records: Vec<RecordFrame>,
-            on_attempted: AttemptedBytes,
         ) -> Result<RecordCommitRange, Error> {
-            let range = self
-                .segment_writer
-                .enqueue_data_window(records, on_attempted)
-                .await?;
+            let range = self.segment_writer.enqueue_data_window(records).await?;
             let first_offset = range.first_offset() as u64;
             let end_offset = range.end_offset() as u64;
             Ok(RecordCommitRange {
@@ -2083,7 +2064,6 @@ mod writer {
                     seal_pending: swap.writer.is_some(),
                 });
             }
-            self.metrics.rotations_completed.increment();
             Ok(())
         }
 
@@ -2127,6 +2107,7 @@ mod writer {
                 .into_segment()
                 .ok_or_else(|| Error::Internal("live rotation lost its old writer".into()))?;
             segment.writer.seal().await?;
+            #[cfg(any(test, feature = "dst-support"))]
             self.metrics.segments_sealed.increment();
             tracing::info!(
                 segment_base = segment.base_record_index,
@@ -2529,6 +2510,14 @@ mod maintenance {
             let zones = listings
                 .into_iter()
                 .map(|listing| {
+                    if let Err(error) = &listing {
+                        tracing::warn!(
+                            %error,
+                            zone = error.zone,
+                            prefix = %objects_prefix,
+                            "sealed segment listing failed; skipping zone for this repair pass"
+                        );
+                    }
                     listing.ok().map(|objects| {
                         objects
                             .into_iter()

--- a/rust/client/src/transport.rs
+++ b/rust/client/src/transport.rs
@@ -388,17 +388,16 @@ impl TransportCode {
     }
 }
 
-/// Wraps a replica so every provider RPC reports its latency and, on failure,
-/// the code the provider returned.
+/// Reports latency and failure codes for quorum-path replica operations.
 ///
 /// Phase timings locate the slow part of recovery; they cannot say which
-/// storage call is slow, which is the only form a storage provider can act on.
-/// Applied once where a `QuorumVolume` is built, so no call site changes and no
-/// operation can be forgotten.
+/// storage operation is slow. Applied where a `QuorumVolume` is built; raw
+/// factory calls used by manifest storage, repair, and replay are not wrapped.
+/// An operation such as `snapshot` may perform more than one provider RPC.
 ///
 /// The lane methods (`lane_send`, `lane_send_packed`, `lane_durable_change`,
 /// `append`) delegate untimed: they run per chunk on the append hot path,
-/// where their cost is already covered by `chorus.wal.append.commit_latency`.
+/// where their cost is covered by `chorus.wal.append.commit_latency_seconds`.
 pub(crate) struct TimedReplica {
     inner: Arc<dyn Replica>,
     metrics: Arc<crate::metrics::Metrics>,
@@ -469,7 +468,7 @@ impl Replica for TimedReplica {
         &self,
         metadata: HashMap<String, String>,
     ) -> Result<ReplicaSnapshot, TransportError> {
-        timed_rpc!(self, create_register, self.inner.create_register(metadata))
+        self.inner.create_register(metadata).await
     }
 
     async fn update_register(
@@ -477,11 +476,7 @@ impl Replica for TimedReplica {
         metageneration: i64,
         metadata: HashMap<String, String>,
     ) -> Result<ReplicaSnapshot, TransportError> {
-        timed_rpc!(
-            self,
-            update_register,
-            self.inner.update_register(metageneration, metadata)
-        )
+        self.inner.update_register(metageneration, metadata).await
     }
 
     async fn resume_tail(&self, token: &mut AppendToken) -> Result<i64, TransportError> {
@@ -531,7 +526,7 @@ impl Replica for TimedReplica {
     }
 
     async fn delete(&self, generation: i64) -> Result<(), TransportError> {
-        timed_rpc!(self, delete, self.inner.delete(generation))
+        self.inner.delete(generation).await
     }
 
     async fn finalize(

--- a/rust/client/tests/grpc_integration.rs
+++ b/rust/client/tests/grpc_integration.rs
@@ -1,11 +1,19 @@
+use std::collections::BTreeSet;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use bytes::Bytes;
-use chorus_client::{ClientConfig, GrpcReplicaFactory, SegmentedVolume, WalEngineConfig, WalSeqNo};
+use chorus_client::{
+    ClientConfig, CounterFn, GaugeFn, GrpcReplicaFactory, HistogramFn, MetricsRecorder,
+    NoopMetricsRecorder, SegmentedVolume, UpDownCounterFn, WalEngineConfig, WalSeqNo,
+};
 use chorus_fake_gcs::FakeGcs;
 use futures::TryStreamExt;
 
-async fn volume(prefix: &str) -> (Vec<chorus_fake_gcs::RunningFake>, SegmentedVolume) {
+async fn volume(
+    prefix: &str,
+    recorder: Arc<dyn MetricsRecorder>,
+) -> (Vec<chorus_fake_gcs::RunningFake>, SegmentedVolume) {
     let mut servers = Vec::new();
     let mut factories = Vec::new();
     for zone in 0..3 {
@@ -29,7 +37,7 @@ async fn volume(prefix: &str) -> (Vec<chorus_fake_gcs::RunningFake>, SegmentedVo
             .unwrap();
     servers.push(regional);
 
-    let volume = SegmentedVolume::new(
+    let volume = SegmentedVolume::new_with_metrics_recorder(
         factories,
         manifest_factory,
         prefix,
@@ -37,6 +45,7 @@ async fn volume(prefix: &str) -> (Vec<chorus_fake_gcs::RunningFake>, SegmentedVo
             max_retries: 3,
             retry_base: Duration::ZERO,
         },
+        recorder,
     )
     .unwrap();
     (servers, volume)
@@ -44,7 +53,7 @@ async fn volume(prefix: &str) -> (Vec<chorus_fake_gcs::RunningFake>, SegmentedVo
 
 #[tokio::test]
 async fn public_api_appends_and_replays_records() {
-    let (_servers, volume) = volume("public-api-wal").await;
+    let (_servers, volume) = volume("public-api-wal", Arc::new(NoopMetricsRecorder)).await;
     let mut recovery = volume.recover(WalSeqNo::ZERO).await.unwrap();
     assert_eq!(recovery.end, WalSeqNo::ZERO);
     assert!(recovery.try_next().await.unwrap().is_none());
@@ -81,4 +90,107 @@ async fn public_api_appends_and_replays_records() {
         vec![b"one".as_slice(), b"two", b"three"]
     );
     assert_eq!(records[2].next_seqno(), WalSeqNo::record(3));
+}
+
+#[derive(Default)]
+struct Registrations(Mutex<BTreeSet<(String, &'static str)>>);
+
+impl MetricsRecorder for Registrations {
+    fn register_counter(
+        &self,
+        name: &str,
+        description: &str,
+        labels: &[(&str, &str)],
+    ) -> Arc<dyn CounterFn> {
+        self.0.lock().unwrap().insert((name.into(), "counter"));
+        NoopMetricsRecorder.register_counter(name, description, labels)
+    }
+
+    fn register_gauge(
+        &self,
+        name: &str,
+        description: &str,
+        labels: &[(&str, &str)],
+    ) -> Arc<dyn GaugeFn> {
+        self.0.lock().unwrap().insert((name.into(), "gauge"));
+        NoopMetricsRecorder.register_gauge(name, description, labels)
+    }
+
+    fn register_up_down_counter(
+        &self,
+        name: &str,
+        description: &str,
+        labels: &[(&str, &str)],
+    ) -> Arc<dyn UpDownCounterFn> {
+        self.0
+            .lock()
+            .unwrap()
+            .insert((name.into(), "up_down_counter"));
+        NoopMetricsRecorder.register_up_down_counter(name, description, labels)
+    }
+
+    fn register_histogram(
+        &self,
+        name: &str,
+        description: &str,
+        labels: &[(&str, &str)],
+        boundaries: &[f64],
+    ) -> Arc<dyn HistogramFn> {
+        self.0.lock().unwrap().insert((name.into(), "histogram"));
+        if name == "chorus.wal.transport.rpc_seconds" {
+            assert!(matches!(
+                labels,
+                [(
+                    "op",
+                    "snapshot"
+                        | "stat"
+                        | "create_appendable"
+                        | "create_append_session"
+                        | "resume_tail"
+                        | "takeover"
+                        | "replace_appendable"
+                        | "finalize"
+                )]
+            ));
+        }
+        NoopMetricsRecorder.register_histogram(name, description, labels, boundaries)
+    }
+}
+
+// Integration tests compile the library without cfg(test), so this checks the
+// real production surface and separately verifies the DST feature boundary.
+#[tokio::test]
+async fn metric_surface_contains_only_core_and_enabled_dst_instruments() {
+    let recorder = Arc::new(Registrations::default());
+    let (_servers, _volume) = volume("metric-surface", recorder.clone()).await;
+    let core = [
+        ("append.committed_records", "counter"),
+        ("append.committed_bytes", "counter"),
+        ("append.failures", "counter"),
+        ("transport.rpc_failures", "counter"),
+        ("pipeline.queue_depth", "gauge"),
+        ("maintenance.queue_depth", "gauge"),
+        ("replica.durable_lag_bytes", "gauge"),
+        ("manifest.directory_bytes", "gauge"),
+        ("append.commit_latency_seconds", "histogram"),
+        ("transport.rpc_seconds", "histogram"),
+        ("manifest.cas_latency_seconds", "histogram"),
+        ("seal.duration_seconds", "histogram"),
+    ];
+    let dst = if cfg!(feature = "dst-support") {
+        &[
+            ("lane.timeouts", "counter"),
+            ("lane.capacity_drops", "counter"),
+            ("repair.passes", "counter"),
+            ("seal.segments", "counter"),
+        ][..]
+    } else {
+        &[][..]
+    };
+    let expected = core
+        .iter()
+        .chain(dst)
+        .map(|(name, kind)| (format!("chorus.wal.{name}"), *kind))
+        .collect();
+    assert_eq!(*recorder.0.lock().unwrap(), expected);
 }

--- a/rust/dst/README.md
+++ b/rust/dst/README.md
@@ -14,6 +14,12 @@ recovery, segment rotation, repair, truncation, and admission logic remain the
 same implementation used with the production transport; only the transport
 adapter and service are replaced.
 
+The client dependency enables `dst-support`, which also exposes four diagnostic
+counters: `chorus.wal.lane.timeouts`, `chorus.wal.lane.capacity_drops`,
+`chorus.wal.repair.passes`, and `chorus.wal.seal.segments`. The harness uses them
+to schedule faults and check protocol coverage. Default production builds do not
+register or update these counters.
+
 The harness runs in turmoil's single-threaded virtual-time runtime. Seeded
 schedules cover:
 


### PR DESCRIPTION
## Summary

Reduce the default WAL metric surface from 44 names to 12, using logs for
lifecycle events and maintenance outcomes instead of retaining low-value counters.

The remaining production metrics, all prefixed with `chorus.wal.`, are:

| Kind | Names |
| --- | --- |
| Counter | `append.committed_records`, `append.committed_bytes`, `append.failures`, `transport.rpc_failures{code}` |
| Gauge | `pipeline.queue_depth`, `maintenance.queue_depth`, `replica.durable_lag_bytes{zone}`, `manifest.directory_bytes` |
| Histogram | `append.commit_latency_seconds`, `transport.rpc_seconds{op}`, `manifest.cas_latency_seconds`, `seal.duration_seconds` |

- Gate `lane.timeouts`, `lane.capacity_drops`, `repair.passes`, and `seal.segments`
  behind `dst-support` or unit-test builds. These remain available for simulation
  synchronization and protocol coverage, not production monitoring.
- Remove attempted-byte callbacks and private accounting helpers from the append
  and retry paths. Preserve public recorder traits and all storage/protocol behavior.
- Retain failure logs, warn when a zonal repair listing is skipped, and log failed
  targeted-repair outcomes even when no object was repaired.
- Retain manifest CAS timing: quorum-path RPC timing does not cover manifest-store
  calls. Remove unused register/delete RPC labels and clarify the wrapper's scope.
- Remove the byte-accounting-only test; preserve behavioral tests using storage
  state and fake-server observations. Test the exact default/DST metric surface.

## Benchmark output changes

Latency percentiles (`p50`, `p99`, `p99_9`, `max`), throughput, recovery phase timings,
configuration, and drain accounting remain. Added real CLI smoke tests against fake
GCS for open-loop append, closed-loop append, and recovery.

Removed append JSON fields: `batches_sent`, `records_per_persist`, `wal_record_bytes`,
`replica_bytes_attempted`, `write_amplification`, `max_inflight_records`, top-level
`max_inflight_bytes`, `lane_capacity_drops`, `lane_timeouts`, and `pipeline_refills`.
The configured `configuration.max_inflight_bytes` remains.

Removed recovery JSON fields: `manifest_cas_attempts_avg` and `segments_sealed_avg`.
Observed sealed-segment and replayed-record counts remain.

Consumers of removed metrics and JSON fields must update. No wire format,
persistent format, quorum behavior, retry policy, or admission limits change.

## Verification

- `cargo fmt --all --check` and `git diff --check`
- `cargo test -p chorus-client --no-default-features`
- `cargo test -p chorus-cli`
- `cargo test --workspace --all-features`
- `cargo clippy -p chorus-client -p chorus-cli --all-targets --no-default-features -- -D warnings`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- Ten DST seeds at 128 steps, each replayed for determinism. All ten per-seed traces
  match merged baseline `0240c08` byte for byte; the structural checker accepts the
  final 3,449-event trace. PObserve certification was not run.

## Existing DST caveat

An additional run with `--seeds 10 --steps 128 --inject-latency` hits the held-refill
scheduling assertion at seed 0, round 12, phase 12:

```text
background fold landed before the held-refill trap observed its window
```

Reproduced the same failure on unmodified merged baseline `0240c08`, using the same
build configuration. That separate harness issue is unchanged by this PR.
