### PR TITLE
Mark P files as documentation for Linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Prefer considering this documentation rather than having the language identified
+# incorrectly and misleading users across the GitHub UI. To be removed when P
+# support is added to Linguist.
+# https://github.com/github-linguist/linguist/issues/6907
+*.p linguist-documentation
+*.pproj linguist-documentation


### PR DESCRIPTION
## Summary

Add a root `.gitattributes` marking `*.p` and `*.pproj` as `linguist-documentation` to avoid misleading GitHub language classification while P is unsupported. Include the explanatory comment and link to https://github.com/github-linguist/linguist/issues/6907 so the workaround can be removed when P support lands.

Only repository metadata changes; source files and build behavior are unchanged.

## Verification

- `git check-attr` confirms the attribute is set on all 11 tracked P source/project files.
- Both extension patterns match root-level and nested sample paths.
- Rust and Markdown control paths remain unaffected.
- `git diff --cached --check` passed.
- Runtime tests were not run for this metadata-only change.