### PR TITLE
Add opt-in SlateDB WAL adapter with retained-history GC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
       - name: Tests
         run: cargo test --workspace --all-features
+      - name: Client without optional integrations
+        run: cargo test -p chorus-client --no-default-features
       - name: DST production smoke
         run: >-
           cargo run --release -p chorus-dst --

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -29,6 +29,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "aliasable"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -103,6 +115,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -133,6 +163,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -210,6 +249,17 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "backon"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
+dependencies = [
+ "fastrand",
+ "gloo-timers",
+ "tokio",
 ]
 
 [[package]]
@@ -298,6 +348,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytemuck"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -381,7 +437,8 @@ dependencies = [
  "prost-types",
  "serde",
  "sha2 0.10.9",
- "thiserror",
+ "slatedb",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -438,9 +495,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
- "windows-link",
+ "wasm-bindgen",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -471,7 +530,7 @@ version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -512,6 +571,15 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -572,6 +640,25 @@ version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-skiplist"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df29de440c58ca2cc6e587ec3d22347551a32435fbde9d2bff64e78a9ffa151b"
+dependencies = [
+ "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
@@ -699,10 +786,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "duration-str"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f88959de2d447fd3eddcf1909d1f19fe084e27a056a6904203dc5d8b9e771c1e"
+dependencies = [
+ "rust_decimal",
+ "serde",
+ "thiserror 2.0.18",
+ "time",
+ "winnow 0.6.26",
+]
 
 [[package]]
 name = "dyn-clone"
@@ -733,10 +839,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "5.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
+dependencies = [
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "fail-parallel"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c29b33a0187823f1fa88b36980227dc96c7504ede2288e7d2a77d9d6d88b260c"
+dependencies = [
+ "log",
+ "once_cell",
+ "rand 0.9.4",
+ "tokio",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "figment"
+version = "0.10.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
+dependencies = [
+ "atomic",
+ "pear",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "toml",
+ "uncased",
+ "version_check",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -749,6 +903,16 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
+dependencies = [
+ "bitflags",
+ "rustc_version",
+]
 
 [[package]]
 name = "flate2"
@@ -771,6 +935,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -933,6 +1103,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "google-cloud-auth"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -953,7 +1135,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "url",
@@ -974,7 +1156,7 @@ dependencies = [
  "rand 0.10.1",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -1002,7 +1184,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
  "url",
 ]
@@ -1107,7 +1289,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -1115,6 +1297,11 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hdrhistogram"
@@ -1129,6 +1316,12 @@ dependencies = [
  "nom",
  "num-traits",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -1195,6 +1388,12 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "humantime"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
 
 [[package]]
 name = "hybrid-array"
@@ -1290,7 +1489,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -1441,6 +1640,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "inlinable_string"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
+
+[[package]]
 name = "io-uring"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1473,6 +1678,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1490,9 +1704,9 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror",
+ "thiserror 2.0.18",
  "walkdir",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1586,10 +1800,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+
+[[package]]
+name = "lru"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
+dependencies = [
+ "hashbrown 0.17.1",
+]
 
 [[package]]
 name = "lru-slab"
@@ -1667,6 +1899,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1674,6 +1918,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -1702,6 +1955,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "object_store"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d354792e39fa5f0009e47623cf8b15b099bf9a652fa55c6f817fe28ac84fea50"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "chrono",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "humantime",
+ "itertools 0.15.0",
+ "nix",
+ "parking_lot",
+ "percent-encoding",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "walkdir",
+ "wasm-bindgen-futures",
+ "web-time",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1718,6 +2018,82 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "ouroboros"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0f050db9c44b97a94723127e6be766ac5c340c48f2c4bb3ffa11713744be59"
+dependencies = [
+ "aliasable",
+ "ouroboros_macro",
+ "static_assertions",
+]
+
+[[package]]
+name = "ouroboros_macro"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c7028bdd3d43083f6d8d4d5187680d0d3560d54df4cc9d752005268b41e64d0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "pear"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdeeaa00ce488657faba8ebf44ab9361f9365a97bd39ffb8a60663f57ff4b467"
+dependencies = [
+ "inlinable_string",
+ "pear_codegen",
+ "yansi",
+]
+
+[[package]]
+name = "pear_codegen"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bab5b985dc082b345f812b7df84e1bef27e7207b39e448439ba8bd69c93f147"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -1806,6 +2182,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "version_check",
+ "yansi",
+]
+
+[[package]]
 name = "prost"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1821,8 +2210,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck",
- "itertools",
+ "heck 0.5.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -1843,7 +2232,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -1976,7 +2365,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -1998,7 +2387,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2132,6 +2521,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rapid-probe"
 version = "0.1.0"
 dependencies = [
@@ -2146,6 +2544,15 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -2285,6 +2692,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be2a24f50780bc85f09cc6ac299bdf1424302742d77221106859c9d8b102126a"
+dependencies = [
+ "arrayvec",
+ "num-traits",
 ]
 
 [[package]]
@@ -2452,6 +2869,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2530,6 +2953,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2571,6 +3003,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.14.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -2643,10 +3088,90 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slatedb"
+version = "0.15.0"
+source = "git+https://github.com/slatedb/slatedb?rev=31656fe30064ce0d7991a578085341e21438af5e#31656fe30064ce0d7991a578085341e21438af5e"
+dependencies = [
+ "async-channel",
+ "async-trait",
+ "atomic",
+ "backon",
+ "bitflags",
+ "bytes",
+ "chrono",
+ "crc32fast",
+ "crossbeam-skiplist",
+ "dotenvy",
+ "duration-str",
+ "fail-parallel",
+ "figment",
+ "flatbuffers",
+ "futures",
+ "log",
+ "lru",
+ "object_store",
+ "ouroboros",
+ "parking_lot",
+ "rand 0.9.4",
+ "serde",
+ "serde_json",
+ "siphasher",
+ "slatedb-common",
+ "slatedb-txn-obj",
+ "smallvec",
+ "sysinfo",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "ulid",
+ "url",
+ "uuid",
+ "walkdir",
+]
+
+[[package]]
+name = "slatedb-common"
+version = "0.15.0"
+source = "git+https://github.com/slatedb/slatedb?rev=31656fe30064ce0d7991a578085341e21438af5e#31656fe30064ce0d7991a578085341e21438af5e"
+dependencies = [
+ "chrono",
+ "log",
+ "object_store",
+ "rand 0.9.4",
+ "rand_xoshiro",
+ "serde",
+ "thread_local",
+ "tokio",
+]
+
+[[package]]
+name = "slatedb-txn-obj"
+version = "0.15.0"
+source = "git+https://github.com/slatedb/slatedb?rev=31656fe30064ce0d7991a578085341e21438af5e#31656fe30064ce0d7991a578085341e21438af5e"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "chrono",
+ "futures",
+ "log",
+ "object_store",
+ "parking_lot",
+ "slatedb-common",
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "smallvec"
@@ -2669,6 +3194,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -2725,6 +3256,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.35.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3ffa3e4ff2b324a57f7aeb3c349656c7b127c3c189520251a648102a92496e"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2745,11 +3290,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2886,9 +3451,52 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
+ "hashbrown 0.15.5",
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tonic"
@@ -3015,6 +3623,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3098,6 +3707,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "ulid"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
+dependencies = [
+ "rand 0.9.4",
+ "serde",
+ "web-time",
+]
+
+[[package]]
+name = "uncased"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3114,6 +3743,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -3151,7 +3786,9 @@ version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
+ "getrandom 0.4.2",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -3351,12 +3988,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.61.2",
+ "windows-future",
+ "windows-link 0.1.3",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -3367,9 +4061,20 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading",
 ]
 
 [[package]]
@@ -3396,9 +4101,34 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
+]
 
 [[package]]
 name = "windows-result"
@@ -3406,7 +4136,16 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -3415,7 +4154,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3433,7 +4172,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3450,6 +4189,15 @@ dependencies = [
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
  "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -3501,6 +4249,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "winnow"
+version = "0.6.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3522,7 +4288,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "wit-parser",
 ]
 
@@ -3533,7 +4299,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.117",
@@ -3608,6 +4374,12 @@ checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
 ]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/rust/client/Cargo.toml
+++ b/rust/client/Cargo.toml
@@ -18,6 +18,9 @@ default = []
 probe-support = []
 # Internal capacity introspection and event counters for deterministic simulation.
 dst-support = []
+# Experimental: pinned to the unreleased pluggable-WAL API. Replace the git
+# dependency with a stable release before merging/publishing this integration.
+slatedb = ["dep:slatedb"]
 
 [dependencies]
 arc-swap.workspace = true
@@ -32,6 +35,7 @@ prost.workspace = true
 prost-types.workspace = true
 serde.workspace = true
 sha2.workspace = true
+slatedb = { git = "https://github.com/slatedb/slatedb", rev = "31656fe30064ce0d7991a578085341e21438af5e", default-features = false, optional = true }
 thiserror.workspace = true
 tokio.workspace = true
 tokio-stream.workspace = true

--- a/rust/client/README.md
+++ b/rust/client/README.md
@@ -187,13 +187,17 @@ using the same initializer or a clone; separate-process/offline collection is
 not supported and returns an error rather than recovering/fencing the volume.
 
 Configure the GC builder's `GarbageCollectorOptions::wal_options` for interval,
-`min_age`, and `dry_run`. Age is conservative: a segment waits the full `min_age`
-after a collection pass first observes it as sealed and unreferenced. Restarting
-or subsequently observing it as referenced resets that grace period. No on-disk
-timestamp/schema change is needed. Dry runs do not advance the floor, delete
-objects, or start age timers; they log the proposed floor. Background maintenance
+`min_age`, and `dry_run`. Nonzero `min_age` uses GCS object modification time
+(`update_time`): every existing replica must be strictly older than the cutoff
+before GC authorizes a segment's deletion. A repaired/replaced copy gets its own
+age; unavailable listings, missing/invalid timestamps, or future timestamps defer
+new truncation. This requires all zones to answer age checks; `min_age = 0`
+disables the age gate and allows degraded-zone truncation. Object age survives
+restarts and is independent of when a segment becomes unreferenced. No on-disk
+schema change is needed. Dry runs do not advance the floor or delete objects;
+they log the proposed floor using the same age checks. Background maintenance
 may still retry deletions authorized by an earlier real collection. Long-lived
-checkpoints, a long grace period, or unavailable zones can still exhaust the
+checkpoints, a long minimum age, or unavailable zones can still exhaust the
 bounded manifest directory; size rotation/GC settings for the retention window.
 
 `WalReader` and `WalAdmin` remain unimplemented: separate live WAL readers and

--- a/rust/client/README.md
+++ b/rust/client/README.md
@@ -104,6 +104,121 @@ The database remains responsible for its checkpoint. Call
 `WalHandle::truncate_before` only after the database has durably incorporated
 all records below that boundary.
 
+## Experimental SlateDB adapter
+
+The opt-in `slatedb` feature provides
+`chorus_client::slatedb::ChorusWal`, implementing SlateDB's pluggable WAL writer,
+startup replay, and garbage-collection interfaces. It is disabled by default; the default build
+does not compile SlateDB or enable its object-store providers/caches.
+
+**Not ready to merge or publish:** this currently pins SlateDB main at
+[`31656fe3`](https://github.com/slatedb/slatedb/commit/31656fe30064ce0d7991a578085341e21438af5e).
+Replace the git dependency with the first suitable stable release and rerun
+the adapter tests before merging. Cargo still resolves optional dependencies
+when generating a lockfile, so even feature-off resolution may need GitHub.
+Applications must use the same SlateDB revision to share the trait types:
+
+```toml
+[dependencies]
+chorus-client = { path = "path/to/chorus/rust/client", features = ["slatedb"] }
+slatedb = { git = "https://github.com/slatedb/slatedb", rev = "31656fe30064ce0d7991a578085341e21438af5e", default-features = false }
+```
+
+Create a dedicated `SegmentedVolume` using the storage setup below, then pass
+it directly to SlateDB. Do **not** recover/start it separately:
+
+```rust,ignore
+use chorus_client::slatedb::ChorusWal;
+use slatedb::{Db, GarbageCollectorBuilder};
+use std::sync::Arc;
+
+let wal = ChorusWal::new(volume);
+let gc = GarbageCollectorBuilder::new("databases/orders", sst_object_store.clone())
+    .with_wal_gc(Arc::new(wal.clone()));
+let db = Db::builder("databases/orders", sst_object_store)
+    .with_wal_writer(Box::new(wal))
+    .with_gc_builder(gc)
+    .build()
+    .await?;
+
+let write = db.put(b"customer/7", b"alice").await?;
+write.await_durable().await?; // Waits for a Chorus quorum, not an SST flush.
+db.close().await?;
+```
+
+Use `ChorusWal::with_config(volume, config)` to customize `WalEngineConfig`.
+The complete **encoded batch** must fit `max_record_bytes` (default 1 MiB).
+Oversized batches fail, rather than being split and losing atomicity. Admission
+and completion failures close the adapter; ambiguous outcomes require reopening
+the database to resolve the recovered prefix, not retrying within that writer.
+
+Each SlateDB write batch is one Chorus record, preserving values, tombstones,
+merge operands, sequence numbers, and optional creation/expiry timestamps. A
+versioned binary envelope is independent of SlateDB's SST encoding. Record index
+`n` maps to WAL file ID `n + 1`; SlateDB's `replay_after_wal_id` consequently maps
+directly to Chorus's inclusive recovery checkpoint. Replay streams one batch at
+a time, and the engine starts after replay finishes, making GC available even
+before the first append. Append admission is
+pipelined and ordered quorum completions drive durability notifications. Flush
+is a barrier over preceding admissions; it does not force segment rotation.
+
+Fencing follows SlateDB's manifest-fence / Chorus-recovery / manifest-recheck
+protocol. Starting another database writer takes over the volume and invalidates
+the previous writer. Use the same dedicated volume on every open; do not share
+one volume between databases, mix other application records into it, or switch
+an existing database from its native WAL merely by changing this option. The
+upstream manifest does not yet persist/validate the custom backend identity.
+
+GC must be wired explicitly with `with_wal_gc` **and** `with_gc_builder`, using
+clones of the same `ChorusWal` instance and the same SlateDB database path/store.
+SlateDB supplies ranges referenced by the current manifest and retained
+checkpoints. Collection removes only whole sealed segments from the prefix
+before **every** referenced range, leaving holes between retained ranges alone.
+It preserves the current WAL boundary, the active tail, and pending seals.
+Replay position and retention authority are separate: an older checkpoint can
+keep history below the current writer's startup replay position.
+
+Collection uses the attached writer's existing maintenance queue, serializing
+deletion with repair without fencing or pausing the append engine. Committed
+truncation floors and generation-guarded deletion tombstones provide the usual
+Chorus retry/recovery safety, including when a zone is unavailable. Successful
+collection wakes the rotation capacity check. This collector requires an open Db
+using the same initializer or a clone; separate-process/offline collection is
+not supported and returns an error rather than recovering/fencing the volume.
+
+Configure the GC builder's `GarbageCollectorOptions::wal_options` for interval,
+`min_age`, and `dry_run`. Age is conservative: a segment waits the full `min_age`
+after a collection pass first observes it as sealed and unreferenced. Restarting
+or subsequently observing it as referenced resets that grace period. No on-disk
+timestamp/schema change is needed. Dry runs do not advance the floor, delete
+objects, or start age timers; they log the proposed floor. Background maintenance
+may still retry deletions authorized by an earlier real collection. Long-lived
+checkpoints, a long grace period, or unavailable zones can still exhaust the
+bounded manifest directory; size rotation/GC settings for the retention window.
+
+`WalReader` and `WalAdmin` remain unimplemented: separate live WAL readers and
+WAL-based clones are unsupported. Ordinary `Db::get`/`Db::scan` reads work.
+Do not use SlateDB's default WAL reader/clone/delete tools for this backend.
+Chorus CLI recovery/repair commands fence the active writer and must run offline.
+
+From the repository's `rust` directory:
+
+```sh
+cargo test -p chorus-client --features slatedb slatedb::
+cargo test -p chorus-client --features slatedb --test slatedb_integration
+cargo test -p chorus-client --no-default-features
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+```
+
+The adapter tests run actual SlateDB databases over the loopback fake-GCS
+transport, including atomic batch replay, L0 checkpoint resume, takeover,
+quorum-only durability, failure propagation, corrupt-record rejection, retained
+checkpoints, scheduled GC with live writes, age/dry-run gates, and deletion retries.
+External integration tests use only the exported API to check mixed writes,
+deletes, reads, and scans against a reference model across GC and fresh-client
+reopens, plus writer takeover while a zone is unavailable. These tests use fake
+GCS servers, not live-cloud resources.
+
 ## Storage setup
 
 A typical volume uses:

--- a/rust/client/src/engine.rs
+++ b/rust/client/src/engine.rs
@@ -112,7 +112,7 @@ impl Default for WalEngineConfig {
 }
 
 impl WalEngineConfig {
-    fn validate(&self) -> Result<(), Error> {
+    pub(crate) fn validate(&self) -> Result<(), Error> {
         if self.queue_capacity == 0 {
             return Err(Error::InvalidConfig("queue_capacity must be nonzero"));
         }
@@ -475,6 +475,13 @@ impl WalEngine {
 }
 
 impl WalHandle {
+    #[cfg(feature = "slatedb")]
+    pub(crate) fn gc_handle(&self) -> GcHandle {
+        GcHandle {
+            maintenance: self.maintenance.clone(),
+            rotation_recheck: self.rotation_recheck.clone(),
+        }
+    }
     /// Admit one caller-numbered opaque record without waiting for durability.
     ///
     /// Before waiting, this method verifies that `seqno` is exactly the next
@@ -745,6 +752,33 @@ impl WalHandle {
                 })
             }
         }
+    }
+}
+
+/// Collection-only capability. Cloning it never grants writer ownership.
+#[cfg(feature = "slatedb")]
+#[derive(Clone)]
+pub(crate) struct GcHandle {
+    maintenance: crate::maintenance::MaintenanceHandle,
+    rotation_recheck: mpsc::Sender<()>,
+}
+
+#[cfg(feature = "slatedb")]
+impl GcHandle {
+    pub(crate) async fn collect(
+        &self,
+        retain_from: u64,
+        min_age: Duration,
+        dry_run: bool,
+    ) -> Result<TruncationReport, Error> {
+        let report = self
+            .maintenance
+            .collect(retain_from, min_age, dry_run)
+            .await?;
+        if !dry_run {
+            let _ = self.rotation_recheck.try_send(());
+        }
+        Ok(report)
     }
 }
 

--- a/rust/client/src/grpc.rs
+++ b/rust/client/src/grpc.rs
@@ -1205,6 +1205,13 @@ impl ReplicaFactory for GrpcReplicaFactory {
                     generation: object.generation,
                     size: object.size,
                     finalized: object.finalize_time.is_some(),
+                    last_modified: object
+                        .update_time
+                        .filter(|time| {
+                            (-62_135_596_800..=253_402_300_799).contains(&time.seconds)
+                                && (0..1_000_000_000).contains(&time.nanos)
+                        })
+                        .and_then(|time| time.try_into().ok()),
                     crc32c: object
                         .checksums
                         .as_ref()

--- a/rust/client/src/lib.rs
+++ b/rust/client/src/lib.rs
@@ -77,6 +77,8 @@ mod metrics;
 mod protocol;
 mod record;
 mod segment;
+#[cfg(feature = "slatedb")]
+pub mod slatedb;
 mod transport;
 
 #[cfg(test)]

--- a/rust/client/src/maintenance.rs
+++ b/rust/client/src/maintenance.rs
@@ -199,10 +199,6 @@ struct MaintenanceState {
     /// and restart recovery enforces it.
     sealed: HashSet<u64>,
     checkpoint_floor: u64,
-    // Conservative age: time since this task first observed an eligible sealed
-    // segment. Restarting resets the grace period, never shortens it.
-    #[cfg(feature = "slatedb")]
-    gc_eligible_since: BTreeMap<String, Instant>,
     /// Retained until every zone was listed and every eligible object was
     /// deleted or already absent. The keep set may be stale; its strict
     /// below-claimed-epoch guard is the safety fence.
@@ -229,8 +225,6 @@ async fn run(
         deleted: HashSet::new(),
         sealed: HashSet::new(),
         checkpoint_floor: config.checkpoint_floor,
-        #[cfg(feature = "slatedb")]
-        gc_eligible_since: BTreeMap::new(),
         dead_segment_sweep: Some(config.dead_segment_sweep),
         manifest: None,
         metrics,
@@ -950,10 +944,36 @@ impl MaintenanceState {
             .refreshed_record()
             .await
             .map_err(Error::from)?;
-        let now = Instant::now();
-        let mut eligible = HashSet::new();
+        // Authorize only copies already older than min_age. All replicas must
+        // answer: a repaired copy can be younger than the quorum's originals.
+        // A zero age explicitly disables this gate (and permits degraded-zone
+        // truncation); normal tombstone cleanup still retries committed deletes.
+        let mut too_young = HashSet::new();
+        let mut ages_known = true;
+        if !min_age.is_zero() {
+            let now = std::time::SystemTime::now();
+            let prefix = format!("{}/segments/", self.prefix);
+            let listings = futures::future::join_all(
+                self.factories.iter().map(|factory| factory.list(&prefix)),
+            )
+            .await;
+            for listing in listings {
+                match listing {
+                    Ok(objects) => {
+                        for object in objects {
+                            if !older_than(object.last_modified, now, min_age) {
+                                too_young.insert(object.name);
+                            }
+                        }
+                    }
+                    Err(error) => {
+                        ages_known = false;
+                        tracing::warn!(%error, "SlateDB WAL GC cannot verify replica ages; deferring new truncation");
+                    }
+                }
+            }
+        }
         let mut floor = record.trunc;
-        let mut prefix_open = true;
         for (index, entry) in record.segments.iter().enumerate() {
             let end = record
                 .segments
@@ -966,31 +986,14 @@ impl MaintenanceState {
                 .catalog
                 .iter()
                 .any(|segment| segment.id == entry.id && !segment.seal_pending);
-            if end > retain_from || !sealed {
-                prefix_open = false;
-                continue;
+            if end > retain_from
+                || !sealed
+                || !ages_known
+                || too_young.contains(&crate::segment::segment_object(&self.prefix, &entry.id))
+            {
+                break;
             }
-            eligible.insert(entry.id.clone());
-            // A dry run neither advances the floor nor starts an age timer.
-            let since = if dry_run {
-                self.gc_eligible_since
-                    .get(&entry.id)
-                    .copied()
-                    .unwrap_or(now)
-            } else {
-                *self
-                    .gc_eligible_since
-                    .entry(entry.id.clone())
-                    .or_insert(now)
-            };
-            if prefix_open && now.duration_since(since) >= min_age {
-                floor = end;
-            } else {
-                prefix_open = false;
-            }
-        }
-        if !dry_run {
-            self.gc_eligible_since.retain(|id, _| eligible.contains(id));
+            floor = end;
         }
         if dry_run {
             tracing::info!(
@@ -1055,9 +1058,37 @@ async fn tick(interval: &mut Option<Interval>) {
     }
 }
 
+#[cfg(feature = "slatedb")]
+fn older_than(
+    last_modified: Option<std::time::SystemTime>,
+    now: std::time::SystemTime,
+    min_age: Duration,
+) -> bool {
+    last_modified
+        .and_then(|modified| now.duration_since(modified).ok())
+        .is_some_and(|age| age > min_age)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(feature = "slatedb")]
+    #[test]
+    fn gc_age_requires_known_time_strictly_older_than_cutoff() {
+        use std::time::{Duration, UNIX_EPOCH};
+        let age = Duration::from_secs(60);
+        let now = UNIX_EPOCH + Duration::from_secs(120);
+        assert!(super::older_than(
+            Some(now - age - Duration::from_nanos(1)),
+            now,
+            age
+        ));
+        assert!(!super::older_than(Some(now - age), now, age));
+        assert!(!super::older_than(Some(now), now, age));
+        assert!(!super::older_than(Some(now + age), now, age));
+        assert!(!super::older_than(None, now, age));
+    }
 
     fn segment(base: u64) -> SegmentDescriptor {
         SegmentDescriptor {

--- a/rust/client/src/maintenance.rs
+++ b/rust/client/src/maintenance.rs
@@ -51,6 +51,17 @@ pub(crate) enum MaintenanceCmd {
         floor: WalSeqNo,
         response: oneshot::Sender<Result<TruncationReport, Error>>,
     },
+    /// Retained-range GC, independent of this writer's startup replay point.
+    #[cfg(feature = "slatedb")]
+    Collect(GcRequest),
+}
+
+#[cfg(feature = "slatedb")]
+pub(crate) struct GcRequest {
+    pub retain_from: u64,
+    pub min_age: Duration,
+    pub dry_run: bool,
+    pub response: oneshot::Sender<Result<TruncationReport, Error>>,
 }
 
 /// Control handle owned by the [`crate::WalHandle`]; dropping it ends the
@@ -121,6 +132,24 @@ impl MaintenanceHandle {
     pub(crate) fn shutdown(&self) {
         let _ = self.shutdown.send(true);
     }
+
+    #[cfg(feature = "slatedb")]
+    pub(crate) async fn collect(
+        &self,
+        retain_from: u64,
+        min_age: Duration,
+        dry_run: bool,
+    ) -> Result<TruncationReport, Error> {
+        let (response, receiver) = oneshot::channel();
+        self.enqueue(MaintenanceCmd::Collect(GcRequest {
+            retain_from,
+            min_age,
+            dry_run,
+            response,
+        }))
+        .await?;
+        receiver.await.map_err(|_| Error::Closed)?
+    }
 }
 
 pub(crate) struct MaintenanceConfig {
@@ -170,6 +199,10 @@ struct MaintenanceState {
     /// and restart recovery enforces it.
     sealed: HashSet<u64>,
     checkpoint_floor: u64,
+    // Conservative age: time since this task first observed an eligible sealed
+    // segment. Restarting resets the grace period, never shortens it.
+    #[cfg(feature = "slatedb")]
+    gc_eligible_since: BTreeMap<String, Instant>,
     /// Retained until every zone was listed and every eligible object was
     /// deleted or already absent. The keep set may be stale; its strict
     /// below-claimed-epoch guard is the safety fence.
@@ -196,6 +229,8 @@ async fn run(
         deleted: HashSet::new(),
         sealed: HashSet::new(),
         checkpoint_floor: config.checkpoint_floor,
+        #[cfg(feature = "slatedb")]
+        gc_eligible_since: BTreeMap::new(),
         dead_segment_sweep: Some(config.dead_segment_sweep),
         manifest: None,
         metrics,
@@ -311,6 +346,17 @@ async fn execute_command(
                 let _ = response.send(result.clone());
             }
         }
+        #[cfg(feature = "slatedb")]
+        ReadyCommandKind::Collect(request) => {
+            task.adopt_catalog(catalog_rx);
+            let result = task
+                .collect_once(request.retain_from, request.min_age, request.dry_run)
+                .await;
+            if result.is_err() {
+                task.manifest = None;
+            }
+            let _ = request.response.send(result);
+        }
     }
 }
 
@@ -325,6 +371,8 @@ enum PendingGroup {
         segment: Box<SwappedSegment>,
         enforced: oneshot::Sender<()>,
     },
+    #[cfg(feature = "slatedb")]
+    Collect(GcRequest),
 }
 
 #[derive(Default)]
@@ -353,6 +401,8 @@ enum ReadyCommandKind {
         floor: WalSeqNo,
         responses: Vec<oneshot::Sender<Result<TruncationReport, Error>>>,
     },
+    #[cfg(feature = "slatedb")]
+    Collect(GcRequest),
 }
 
 impl PendingCommands {
@@ -368,6 +418,12 @@ impl PendingCommands {
             MaintenanceCmd::RepairSegment(segment) => self.push_repair(segment),
             MaintenanceCmd::Truncate { floor, response } => {
                 self.push_truncation(floor, response);
+            }
+            #[cfg(feature = "slatedb")]
+            MaintenanceCmd::Collect(request) => {
+                // Retention snapshots, dry runs, and age gates must not be
+                // coalesced with each other or ordinary truncation requests.
+                self.groups.push_back(PendingGroup::Collect(request));
             }
         }
     }
@@ -435,7 +491,17 @@ impl PendingCommands {
                             queued_requests: 1,
                         });
                     }
-                    Some(PendingGroup::Work(_)) | None => continue,
+                    _ => unreachable!("front group was a seal"),
+                },
+                #[cfg(feature = "slatedb")]
+                PendingGroup::Collect(_) => match self.groups.pop_front() {
+                    Some(PendingGroup::Collect(request)) => {
+                        return Some(ReadyCommand {
+                            kind: ReadyCommandKind::Collect(request),
+                            queued_requests: 1,
+                        })
+                    }
+                    _ => unreachable!("front group was a collection"),
                 },
             }
         }
@@ -871,6 +937,102 @@ impl MaintenanceState {
         Ok(report)
     }
 
+    #[cfg(feature = "slatedb")]
+    async fn collect_once(
+        &mut self,
+        retain_from: u64,
+        min_age: Duration,
+        dry_run: bool,
+    ) -> Result<TruncationReport, Error> {
+        let record = self
+            .ensure_manifest()
+            .await?
+            .refreshed_record()
+            .await
+            .map_err(Error::from)?;
+        let now = Instant::now();
+        let mut eligible = HashSet::new();
+        let mut floor = record.trunc;
+        let mut prefix_open = true;
+        for (index, entry) in record.segments.iter().enumerate() {
+            let end = record
+                .segments
+                .get(index + 1)
+                .map_or(record.tail_base, |next| next.base);
+            if end <= record.trunc {
+                continue;
+            } // Already-authorized deletion tombstone.
+            let sealed = self
+                .catalog
+                .iter()
+                .any(|segment| segment.id == entry.id && !segment.seal_pending);
+            if end > retain_from || !sealed {
+                prefix_open = false;
+                continue;
+            }
+            eligible.insert(entry.id.clone());
+            // A dry run neither advances the floor nor starts an age timer.
+            let since = if dry_run {
+                self.gc_eligible_since
+                    .get(&entry.id)
+                    .copied()
+                    .unwrap_or(now)
+            } else {
+                *self
+                    .gc_eligible_since
+                    .entry(entry.id.clone())
+                    .or_insert(now)
+            };
+            if prefix_open && now.duration_since(since) >= min_age {
+                floor = end;
+            } else {
+                prefix_open = false;
+            }
+        }
+        if !dry_run {
+            self.gc_eligible_since.retain(|id, _| eligible.contains(id));
+        }
+        if dry_run {
+            tracing::info!(
+                current_floor = record.trunc,
+                proposed_floor = floor,
+                retain_from,
+                "SlateDB WAL GC dry run"
+            );
+            return Ok(TruncationReport {
+                deleted_objects: 0,
+                deleted_segments: 0,
+            });
+        }
+        let before = self
+            .catalog
+            .iter()
+            .map(|segment| segment.base_record_index)
+            .collect();
+        let mut manifest = self
+            .manifest
+            .take()
+            .ok_or_else(|| Error::Internal("GC manifest disappeared".into()))?;
+        // Unlike truncate_before, this authority comes from ALL retained
+        // manifests, not the current writer's replay checkpoint. Never use
+        // checkpoint_floor here: it may be ahead of an older retained manifest.
+        let mut retention_floor = record.trunc;
+        let result = truncate_pass(
+            &self.factories,
+            &self.prefix,
+            &mut self.catalog,
+            &mut retention_floor,
+            &mut manifest,
+            WalSeqNo::record(floor),
+        )
+        .await;
+        self.manifest = Some(manifest);
+        if result.is_ok() {
+            self.remember_catalog_deletions(before);
+        }
+        result
+    }
+
     fn remember_catalog_deletions(&mut self, before: HashSet<u64>) {
         for gone in before {
             if !self
@@ -968,6 +1130,8 @@ mod tests {
                 ReadyCommandKind::SealSegment { .. } | ReadyCommandKind::Truncate { .. } => {
                     panic!("flood coalescer emitted an unexpected command");
                 }
+                #[cfg(feature = "slatedb")]
+                ReadyCommandKind::Collect(_) => panic!("no collections were queued"),
             }
         }
         assert_eq!(repaired, (0..8).step_by(2).collect::<Vec<_>>());

--- a/rust/client/src/slatedb.rs
+++ b/rust/client/src/slatedb.rs
@@ -1,0 +1,606 @@
+//! Experimental SlateDB writer integration, enabled by the `slatedb` feature.
+//!
+//! Pass [`ChorusWal`] to `Db::builder(...).with_wal_writer(Box::new(wal))`.
+//! Use one dedicated Chorus volume per SlateDB database, and supply the same
+//! volume on every open. Existing native SlateDB WALs cannot be migrated by
+//! simply changing the builder option.
+//!
+//! Each SlateDB batch is one versioned Chorus record. Chorus record index `n`
+//! maps to SlateDB WAL file ID `n + 1` (ID zero means no WAL). Thus SlateDB's
+//! exclusive `replay_after_wal_id` is exactly Chorus's inclusive replay index.
+//! Admission is pipelined; only ordered quorum completions publish durability.
+//!
+//! This implements writer initialization, bounded streaming recovery, writes,
+//! flush barriers, observation, close, and `WalGc`. Wire a clone of the same
+//! initializer into SlateDB's GC builder as shown below: collection runs through
+//! the live writer's maintenance task, preserving all supplied checkpoint ranges.
+//! Only whole sealed segments from the unreferenced prefix are reclaimed.
+//! `min_age` conservatively starts when GC first observes a segment as eligible;
+//! restart or a referenced observation resets that grace period. Dry runs do not
+//! change storage or start timers. An attached, open writer is required; offline
+//! or separate-process GC is not supported. `WalReader` and `WalAdmin` remain
+//! unimplemented, so live WAL readers and WAL-based clones are unsupported.
+//! Do not run Chorus recovery/maintenance tools concurrently with the database:
+//! those tools claim a new writer epoch and fence the database.
+//!
+//! The dependency is pinned to an unreleased SlateDB commit. Replace it with a
+//! stable release and revalidate the contract before merging or publishing.
+//!
+//! # Usage
+//!
+//! ```no_run
+//! use chorus_client::{SegmentedVolume, slatedb::ChorusWal};
+//! use slatedb::{Db, GarbageCollectorBuilder, object_store::ObjectStore};
+//! use std::sync::Arc;
+//!
+//! async fn open_database(
+//!     volume: SegmentedVolume,
+//!     sst_store: Arc<dyn ObjectStore>,
+//! ) -> Result<Db, slatedb::Error> {
+//!     let wal = ChorusWal::new(volume);
+//!     let gc = GarbageCollectorBuilder::new("orders", sst_store.clone())
+//!         .with_wal_gc(Arc::new(wal.clone()));
+//!     Db::builder("orders", sst_store)
+//!         .with_wal_writer(Box::new(wal))
+//!         .with_gc_builder(gc)
+//!         .build()
+//!         .await
+//! }
+//! ```
+
+mod codec;
+mod gc;
+#[cfg(test)]
+mod tests;
+
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use futures::TryStreamExt;
+use slatedb::wal::{
+    FlushResultFuture, WalError, WalEvent, WalIterator, WalObserver, WalRows, WalStatus,
+    WalStatusListener, WalWriter, WriterInit, WriterInitResult, WriterManifest,
+};
+use slatedb::RowEntry;
+use tokio::sync::{mpsc, oneshot, watch};
+use tokio::task::JoinHandle;
+
+use crate::{
+    AppendCompletion, Error, Recovery, SegmentedVolume, WalEngineConfig, WalHandle, WalSeqNo,
+};
+
+/// A SlateDB WAL initializer backed by a dedicated Chorus volume.
+///
+/// Construction does no I/O. SlateDB first fences its manifest, then calls this
+/// initializer to fence Chorus and resolve replay, then checks its manifest
+/// ownership again. Do not recover/start the volume separately before opening
+/// SlateDB: that would put the WAL fence outside this protocol.
+///
+/// Also implements `slatedb::wal::WalGc`. The writer and collector must receive
+/// clones of the same initializer so they share the process-local maintenance
+/// connection. Collection returns `WalError::Closed` before replay finishes or
+/// after the attached writer closes; it never opens/fences the volume itself.
+#[derive(Clone)]
+pub struct ChorusWal {
+    volume: SegmentedVolume,
+    config: WalEngineConfig,
+    gc: gc::Registry,
+}
+
+impl ChorusWal {
+    /// Use a dedicated volume and the default Chorus engine configuration.
+    pub fn new(volume: SegmentedVolume) -> Self {
+        Self::with_config(volume, WalEngineConfig::default())
+    }
+
+    /// Use explicit Chorus capacity, rotation, repair, and shutdown settings.
+    ///
+    /// `max_record_bytes` bounds an entire encoded SlateDB write batch, including
+    /// this adapter's framing. Exceeding it fails the write (and SlateDB may close
+    /// the database); batches are never split into non-atomic records.
+    pub fn with_config(volume: SegmentedVolume, config: WalEngineConfig) -> Self {
+        Self {
+            volume,
+            config,
+            gc: Arc::new(Mutex::new(None)),
+        }
+    }
+}
+
+#[async_trait]
+impl WriterInit for ChorusWal {
+    async fn fence_and_init(
+        &self,
+        manifest: &mut WriterManifest,
+    ) -> Result<WriterInitResult, WalError> {
+        self.config.validate().map_err(wal_error)?;
+        // Reject a stale initializer before it disrupts the current Chorus
+        // writer, and again after fencing. SlateDB also does the final check.
+        manifest.refresh().await?;
+        let recovery = self
+            .volume
+            .recover(WalSeqNo::record(manifest.replay_after_wal_id()))
+            .await
+            .map_err(wal_error)?;
+        manifest.refresh().await?;
+        writer_and_replay_with_gc(recovery, self.config.clone(), self.gc.clone())
+    }
+}
+
+#[cfg(test)]
+fn writer_and_replay(
+    recovery: Recovery,
+    config: WalEngineConfig,
+) -> Result<WriterInitResult, WalError> {
+    writer_and_replay_with_gc(recovery, config, Arc::new(Mutex::new(None)))
+}
+
+fn writer_and_replay_with_gc(
+    recovery: Recovery,
+    config: WalEngineConfig,
+    gc: gc::Registry,
+) -> Result<WriterInitResult, WalError> {
+    // Validate before constructing bounded channels (whose zero capacity panics).
+    config.validate().map_err(wal_error)?;
+    let next_index = recovery.end.record_index;
+    next_index
+        .checked_add(1)
+        .ok_or_else(|| internal_error("WAL ID space exhausted"))?;
+    let observer = Observer::new(next_index);
+    let (ready_tx, ready_rx) = oneshot::channel();
+    Ok(WriterInitResult {
+        replay_iterator: Box::new(Replay {
+            recovery: Some(recovery),
+            ready: Some(ready_tx),
+            observer: observer.clone(),
+            last_seq: None,
+            failure: None,
+            config: config.clone(),
+            gc,
+        }),
+        wal_writer: Box::new(Writer {
+            ready: Some(ready_rx),
+            handle: None,
+            pending: None,
+            completions: None,
+            runtime: None,
+            observer,
+            next_index,
+            last_admitted_seq: None,
+            config,
+        }),
+    })
+}
+
+struct Replay {
+    recovery: Option<Recovery>,
+    ready: Option<oneshot::Sender<StartedHandle>>,
+    observer: Observer,
+    last_seq: Option<u64>,
+    failure: Option<WalError>,
+    config: WalEngineConfig,
+    gc: gc::Registry,
+}
+
+// A successfully started engine must also be cancelled if replay's receiver is
+// dropped before the writer takes it (e.g. a failed Db build).
+struct StartedHandle {
+    handle: Option<WalHandle>,
+    runtime: tokio::runtime::Handle,
+}
+
+impl Drop for StartedHandle {
+    fn drop(&mut self) {
+        if let Some(handle) = self.handle.take() {
+            self.runtime.spawn(handle.abort());
+        }
+    }
+}
+
+#[async_trait]
+impl WalIterator for Replay {
+    async fn next(&mut self) -> Result<Option<WalRows>, WalError> {
+        if let Some(error) = &self.failure {
+            return Err(error.clone());
+        }
+        let Some(recovery) = self.recovery.as_mut() else {
+            return Ok(None);
+        };
+        let result = match recovery.try_next().await {
+            Ok(Some(record)) => codec::decode(record.payload).and_then(|rows| {
+                let seq = rows[0].seq;
+                if self.last_seq.is_some_and(|last| seq <= last) {
+                    return Err(data_error("SlateDB batch sequence regressed during replay"));
+                }
+                self.last_seq = Some(seq);
+                self.observer.state.lock().unwrap().status.last_flushed_seq = Some(seq);
+                Ok(Some(WalRows {
+                    rows,
+                    last_consumed_wal_file_id: record.seqno.record_index + 1,
+                }))
+            }),
+            Ok(None) => {
+                // The writer may start only after the complete fixed replay
+                // range has been consumed. Keep no second copy of replay data.
+                let recovery = self.recovery.take().unwrap();
+                match recovery.start(self.config.clone()).await.map_err(wal_error) {
+                    Ok(handle) => {
+                        let started = StartedHandle {
+                            handle: Some(handle),
+                            runtime: tokio::runtime::Handle::current(),
+                        };
+                        *self.gc.lock().unwrap() = Some(gc::Connection {
+                            handle: started.handle.as_ref().unwrap().gc_handle(),
+                            observer: self.observer.clone(),
+                        });
+                        if let Some(ready) = self.ready.take() {
+                            let _ = ready.send(started);
+                        }
+                        Ok(None)
+                    }
+                    Err(error) => Err(error),
+                }
+            }
+            Err(error) => Err(wal_error(error)),
+        };
+        if let Err(error) = &result {
+            self.failure = Some(error.clone());
+            self.observer.close(error.clone());
+        }
+        result
+    }
+}
+
+struct State {
+    status: WalStatus,
+    listeners: Vec<WalStatusListener>,
+}
+
+#[derive(Default)]
+struct Notifications {
+    publishing: bool,
+    pending: VecDeque<(WalEvent, Vec<WalStatusListener>)>,
+}
+
+#[derive(Clone)]
+struct Observer {
+    state: Arc<Mutex<State>>,
+    events: Arc<Mutex<Notifications>>,
+    changed: watch::Sender<()>,
+}
+
+impl Observer {
+    fn new(last_flushed_wal_id: u64) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(State {
+                status: WalStatus {
+                    closed_reason: None,
+                    estimated_bytes: 0,
+                    last_flushed_wal_id,
+                    last_flushed_seq: None,
+                    buffered_wal_entries_count: 0,
+                },
+                listeners: Vec::new(),
+            })),
+            events: Arc::new(Mutex::new(Notifications::default())),
+            changed: watch::channel(()).0,
+        }
+    }
+
+    fn close(&self, error: WalError) {
+        self.notify(|state| {
+            if state.status.closed_reason.is_some() {
+                return None;
+            }
+            state.status.closed_reason = Some(error);
+            Some((
+                WalEvent::WalClosed(state.status.clone()),
+                std::mem::take(&mut state.listeners),
+            ))
+        });
+    }
+
+    fn committed(&self, pending: &Pending) {
+        self.notify(|state| {
+            if state.status.closed_reason.is_some() {
+                return None;
+            }
+            state.status.last_flushed_wal_id = pending.wal_id;
+            state.status.last_flushed_seq = Some(pending.seq);
+            state.status.estimated_bytes -= pending.bytes;
+            state.status.buffered_wal_entries_count -= pending.rows;
+            Some((
+                WalEvent::WalFlushed(state.status.clone()),
+                state.listeners.clone(),
+            ))
+        });
+    }
+
+    fn notify(
+        &self,
+        update: impl FnOnce(&mut State) -> Option<(WalEvent, Vec<WalStatusListener>)>,
+    ) {
+        {
+            // Order status changes and their events together. Exactly one
+            // publisher drains the queue, without holding either lock during
+            // callbacks. Concurrent/reentrant close queues behind older flushes
+            // instead of deadlocking (a callback may even drop the writer).
+            let mut events = self.events.lock().unwrap();
+            let Some(notification) = update(&mut self.state.lock().unwrap()) else {
+                return;
+            };
+            events.pending.push_back(notification);
+            if events.publishing {
+                return;
+            }
+            events.publishing = true;
+        }
+        loop {
+            let notification = {
+                let mut events = self.events.lock().unwrap();
+                match events.pending.pop_front() {
+                    Some(notification) => notification,
+                    None => {
+                        events.publishing = false;
+                        return;
+                    }
+                }
+            };
+            for listener in notification.1 {
+                listener(notification.0.clone());
+            }
+            self.changed.send_replace(());
+        }
+    }
+
+    fn barrier(&self, wal_id: u64) -> FlushResultFuture {
+        let observer = self.clone();
+        let mut changed = self.changed.subscribe();
+        Box::pin(async move {
+            loop {
+                let status = observer.state.lock().unwrap().status.clone();
+                // A barrier completed before a subsequent close stays successful.
+                if status.last_flushed_wal_id >= wal_id {
+                    return Ok(());
+                }
+                if let Some(error) = status.closed_reason {
+                    return Err(error);
+                }
+                changed.changed().await.map_err(|_| WalError::Closed)?;
+            }
+        })
+    }
+}
+
+impl WalObserver for Observer {
+    fn status(&self) -> Result<WalStatus, WalStatus> {
+        let status = self.state.lock().unwrap().status.clone();
+        if status.closed_reason.is_some() {
+            Err(status)
+        } else {
+            Ok(status)
+        }
+    }
+
+    fn subscribe(&self, listener: WalStatusListener) -> Result<(), WalError> {
+        let mut state = self.state.lock().unwrap();
+        if let Some(error) = &state.status.closed_reason {
+            return Err(error.clone());
+        }
+        state.listeners.push(listener);
+        Ok(())
+    }
+}
+
+struct Pending {
+    completion: AppendCompletion,
+    wal_id: u64,
+    seq: u64,
+    bytes: usize,
+    rows: usize,
+}
+
+struct Writer {
+    ready: Option<oneshot::Receiver<StartedHandle>>,
+    handle: Option<WalHandle>,
+    pending: Option<mpsc::Sender<Pending>>,
+    completions: Option<JoinHandle<()>>,
+    runtime: Option<tokio::runtime::Handle>,
+    observer: Observer,
+    next_index: u64,
+    last_admitted_seq: Option<u64>,
+    config: WalEngineConfig,
+}
+
+impl Writer {
+    async fn start(&mut self) -> Result<(), WalError> {
+        self.observer.status().map_err(WalError::from)?;
+        if self.handle.is_some() {
+            return Ok(());
+        }
+        // Do not wait forever if a caller attempts to write before replay ends.
+        let mut started = self
+            .ready
+            .as_mut()
+            .ok_or(WalError::Closed)?
+            .try_recv()
+            .map_err(|_| internal_error("consume the complete SlateDB replay iterator first"))?;
+        self.ready = None;
+        let handle = started.handle.take().unwrap();
+        let (sender, mut receiver) = mpsc::channel::<Pending>(self.config.queue_capacity);
+        self.runtime = Some(tokio::runtime::Handle::current());
+        let observer = self.observer.clone();
+        self.completions = Some(tokio::spawn(async move {
+            while let Some(mut pending) = receiver.recv().await {
+                match (&mut pending.completion).await {
+                    Ok(_) => observer.committed(&pending),
+                    Err(error) => {
+                        // An ambiguous write is never retried with the same ID.
+                        // Stop the database and let takeover resolve its prefix.
+                        observer.close(wal_error(error));
+                        break;
+                    }
+                }
+            }
+        }));
+        self.pending = Some(sender);
+        self.handle = Some(handle);
+        Ok(())
+    }
+
+    async fn append_inner(&mut self, rows: &[RowEntry]) -> Result<(), WalError> {
+        self.observer.status().map_err(WalError::from)?;
+        let payload = codec::encode(rows, self.config.max_record_bytes)?;
+        let seq = rows[0].seq;
+        let last_seq = self.last_admitted_seq.or(self
+            .observer
+            .status()
+            .map_err(WalError::from)?
+            .last_flushed_seq);
+        if last_seq.is_some_and(|last| seq <= last) {
+            return Err(internal_error("SlateDB batch sequence must increase"));
+        }
+        // SlateDB internally computes last_wal_id + 1 as well.
+        self.next_index
+            .checked_add(2)
+            .ok_or_else(|| internal_error("WAL ID space exhausted"))?;
+        self.start().await?;
+        let bytes = payload.len();
+        // Reserve notification capacity BEFORE admission. Once Chorus admits
+        // the record there is no cancellation point until its completion is
+        // transferred to the independently running ordered completion task.
+        let slot = self
+            .pending
+            .as_ref()
+            .unwrap()
+            .reserve()
+            .await
+            .map_err(|_| WalError::Closed)?;
+        self.observer.status().map_err(WalError::from)?;
+        let completion = self
+            .handle
+            .as_mut()
+            .unwrap()
+            .enqueue_append(WalSeqNo::record(self.next_index), payload)
+            .await
+            .map_err(wal_error)?;
+        self.next_index += 1;
+        self.last_admitted_seq = Some(seq);
+        {
+            let mut state = self.observer.state.lock().unwrap();
+            state.status.estimated_bytes += bytes;
+            state.status.buffered_wal_entries_count += rows.len();
+        }
+        slot.send(Pending {
+            completion,
+            wal_id: self.next_index,
+            seq,
+            bytes,
+            rows: rows.len(),
+        });
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl WalWriter for Writer {
+    async fn append(&mut self, write_batch: &[RowEntry]) -> Result<(), WalError> {
+        let result = self.append_inner(write_batch).await;
+        if let Err(error) = &result {
+            self.observer.close(error.clone());
+        }
+        result
+    }
+
+    async fn flush(&mut self) -> Result<FlushResultFuture, WalError> {
+        self.observer.status().map_err(WalError::from)?;
+        // Chorus dispatches on admission; flush is a prefix durability barrier,
+        // not an instruction to seal a physical segment.
+        Ok(self.observer.barrier(self.next_index))
+    }
+
+    fn observer(&self) -> Box<dyn WalObserver> {
+        Box::new(self.observer.clone())
+    }
+
+    fn status(&self) -> Result<WalStatus, WalStatus> {
+        self.observer.status()
+    }
+
+    async fn close(&mut self) -> Result<(), WalError> {
+        if self.handle.is_none() {
+            if let Some(ready) = self.ready.as_mut() {
+                if let Ok(mut started) = ready.try_recv() {
+                    self.handle = started.handle.take();
+                }
+            }
+        }
+        // Shutdown drains the engine independently of the completion task.
+        let mut result = match self.handle.take() {
+            Some(handle) => handle.shutdown().await.map_err(wal_error),
+            None => Ok(()),
+        };
+        self.ready = None;
+        self.pending = None;
+        if let Some(task) = self.completions.take() {
+            if let Err(error) = task.await {
+                result = Err(internal_error(&format!("completion task failed: {error}")));
+            }
+        }
+        if let Err(status) = self.observer.status() {
+            if !matches!(status.closed_reason, Some(WalError::Closed)) {
+                result = Err(status.into());
+            }
+        }
+        self.observer
+            .close(result.clone().err().unwrap_or(WalError::Closed));
+        result
+    }
+}
+
+impl Drop for Writer {
+    fn drop(&mut self) {
+        if let Some(task) = self.completions.take() {
+            task.abort();
+        }
+        self.observer.close(WalError::Closed);
+        if let Some(handle) = self.handle.take() {
+            if let Some(runtime) = &self.runtime {
+                // A dropped Db/build failure must not leave a detached writer.
+                // Retain its runtime so dropping outside an entered runtime is
+                // also safe; a stopped runtime already cancels all owned tasks.
+                runtime.spawn(handle.abort());
+            }
+        }
+    }
+}
+
+fn internal_error(message: &str) -> WalError {
+    WalError::InternalError(Arc::new(std::io::Error::other(message.to_owned())))
+}
+
+fn data_error(message: &str) -> WalError {
+    WalError::DataError(Arc::new(std::io::Error::other(message.to_owned())))
+}
+
+fn wal_error(error: Error) -> WalError {
+    match error {
+        Error::Fenced(_) => WalError::Fenced,
+        Error::Closed => WalError::Closed,
+        Error::InvalidCatalog(_)
+        | Error::InvalidSegmentData(_)
+        | Error::InvalidManifest(_)
+        | Error::ConflictingPrefix { .. }
+        | Error::RecoveryPrefixTooShort { .. }
+        | Error::SealDigestMismatch { .. }
+        | Error::SealCrc32cMismatch { .. } => WalError::DataError(Arc::new(error)),
+        Error::InvalidConfig(_)
+        | Error::OutOfOrder { .. }
+        | Error::RecordTooLarge { .. }
+        | Error::SequenceExhausted
+        | Error::RecoveryIncomplete
+        | Error::Internal(_) => WalError::InternalError(Arc::new(error)),
+        _ => WalError::Unavailable(Arc::new(error)),
+    }
+}

--- a/rust/client/src/slatedb.rs
+++ b/rust/client/src/slatedb.rs
@@ -15,11 +15,12 @@
 //! initializer into SlateDB's GC builder as shown below: collection runs through
 //! the live writer's maintenance task, preserving all supplied checkpoint ranges.
 //! Only whole sealed segments from the unreferenced prefix are reclaimed.
-//! `min_age` conservatively starts when GC first observes a segment as eligible;
-//! restart or a referenced observation resets that grace period. Dry runs do not
-//! change storage or start timers. An attached, open writer is required; offline
-//! or separate-process GC is not supported. `WalReader` and `WalAdmin` remain
-//! unimplemented, so live WAL readers and WAL-based clones are unsupported.
+//! Nonzero `min_age` requires every existing replica's storage modification time
+//! to be strictly older than the cutoff. Unknown ages defer new truncation;
+//! zero disables the age gate. Dry runs do not change storage. An open writer
+//! is required; offline or separate-process GC is not supported.
+//! `WalReader` and `WalAdmin` remain unimplemented, so live WAL readers and
+//! WAL-based clones are unsupported.
 //! Do not run Chorus recovery/maintenance tools concurrently with the database:
 //! those tools claim a new writer epoch and fence the database.
 //!

--- a/rust/client/src/slatedb/codec.rs
+++ b/rust/client/src/slatedb/codec.rs
@@ -1,0 +1,187 @@
+//! Private, versioned batch encoding. This is not SlateDB's native SST format.
+
+use bytes::{Buf, BufMut, Bytes, BytesMut};
+use slatedb::wal::WalError;
+use slatedb::{RowEntry, ValueDeletable};
+
+use super::{data_error, internal_error};
+
+// Magic + format version. Changing layout requires a new version/decoder.
+const MAGIC: &[u8; 8] = b"CHSLWAL\x01";
+
+pub(super) fn encode(rows: &[RowEntry], max_bytes: usize) -> Result<Bytes, WalError> {
+    let first = rows
+        .first()
+        .ok_or_else(|| internal_error("empty SlateDB write batch"))?;
+    let count = u32::try_from(rows.len()).map_err(|_| internal_error("too many batch rows"))?;
+    let mut size = MAGIC.len() + 4 + 8;
+    for row in rows {
+        if row.seq != first.seq {
+            return Err(internal_error(
+                "all rows in a SlateDB batch must share a sequence",
+            ));
+        }
+        u32::try_from(row.key.len()).map_err(|_| internal_error("key too large"))?;
+        u32::try_from(row.value.len()).map_err(|_| internal_error("value too large"))?;
+        let metadata = 6
+            + usize::from(row.create_ts.is_some()) * 8
+            + usize::from(row.expire_ts.is_some()) * 8
+            + if row.value.is_tombstone() { 0 } else { 4 };
+        size = size
+            .checked_add(metadata)
+            .and_then(|n| n.checked_add(row.key.len()))
+            .and_then(|n| n.checked_add(row.value.len()))
+            .ok_or_else(|| internal_error("batch size overflow"))?;
+    }
+    if size > max_bytes {
+        return Err(super::wal_error(crate::Error::RecordTooLarge {
+            max: max_bytes,
+            actual: size,
+        }));
+    }
+    let mut bytes = BytesMut::with_capacity(size);
+    bytes.extend_from_slice(MAGIC);
+    bytes.put_u32(count);
+    bytes.put_u64(first.seq);
+    for row in rows {
+        bytes.put_u32(row.key.len() as u32);
+        bytes.extend_from_slice(&row.key);
+        bytes.put_u8(match row.value {
+            ValueDeletable::Value(_) => 0,
+            ValueDeletable::Merge(_) => 1,
+            ValueDeletable::Tombstone => 2,
+        });
+        bytes.put_u8(u8::from(row.create_ts.is_some()) | (u8::from(row.expire_ts.is_some()) << 1));
+        if let Some(ts) = row.create_ts {
+            bytes.put_i64(ts);
+        }
+        if let Some(ts) = row.expire_ts {
+            bytes.put_i64(ts);
+        }
+        if let Some(value) = row.value.as_bytes() {
+            bytes.put_u32(value.len() as u32);
+            bytes.extend_from_slice(&value);
+        }
+    }
+    debug_assert_eq!(size, bytes.len());
+    Ok(bytes.freeze())
+}
+
+fn take(bytes: &mut Bytes, count: usize) -> Result<Bytes, WalError> {
+    if bytes.len() < count {
+        return Err(data_error("truncated SlateDB WAL batch"));
+    }
+    Ok(bytes.split_to(count))
+}
+
+fn field(bytes: &mut Bytes) -> Result<Bytes, WalError> {
+    let size = take(bytes, 4)?.get_u32() as usize;
+    take(bytes, size)
+}
+
+pub(super) fn decode(mut bytes: Bytes) -> Result<Vec<RowEntry>, WalError> {
+    if take(&mut bytes, MAGIC.len())?.as_ref() != MAGIC {
+        return Err(data_error("unknown Chorus SlateDB WAL format/version"));
+    }
+    let count = take(&mut bytes, 4)?.get_u32() as usize;
+    let seq = take(&mut bytes, 8)?.get_u64();
+    if count == 0 || count > bytes.len() / 6 {
+        return Err(data_error("invalid SlateDB WAL row count"));
+    }
+    // Do not allocate from an untrusted count; each row must decode first.
+    let mut rows = Vec::new();
+    for _ in 0..count {
+        let key = field(&mut bytes)?;
+        let tag = take(&mut bytes, 1)?.get_u8();
+        let flags = take(&mut bytes, 1)?.get_u8();
+        if flags & !3 != 0 {
+            return Err(data_error("unknown SlateDB WAL row flags"));
+        }
+        let create_ts = if flags & 1 != 0 {
+            Some(take(&mut bytes, 8)?.get_i64())
+        } else {
+            None
+        };
+        let expire_ts = if flags & 2 != 0 {
+            Some(take(&mut bytes, 8)?.get_i64())
+        } else {
+            None
+        };
+        let value = match tag {
+            0 => ValueDeletable::Value(field(&mut bytes)?),
+            1 => ValueDeletable::Merge(field(&mut bytes)?),
+            2 => ValueDeletable::Tombstone,
+            _ => return Err(data_error("unknown SlateDB WAL value tag")),
+        };
+        rows.push(RowEntry {
+            key,
+            value,
+            seq,
+            create_ts,
+            expire_ts,
+        });
+    }
+    if !bytes.is_empty() {
+        return Err(data_error("trailing bytes in SlateDB WAL batch"));
+    }
+    Ok(rows)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rows() -> Vec<RowEntry> {
+        [
+            ValueDeletable::Value(Bytes::from_static(b"\x00value")),
+            ValueDeletable::Merge(Bytes::new()),
+            ValueDeletable::Tombstone,
+        ]
+        .into_iter()
+        .enumerate()
+        .map(|(i, value)| RowEntry {
+            key: Bytes::from(vec![0, i as u8, 255]),
+            value,
+            seq: u64::MAX,
+            create_ts: Some(i64::MIN),
+            expire_ts: if i == 0 { None } else { Some(i64::MAX) },
+        })
+        .collect()
+    }
+
+    #[test]
+    fn round_trip_all_row_fields_and_exact_size_limit() {
+        let rows = rows();
+        let encoded = encode(&rows, usize::MAX).unwrap();
+        assert_eq!(decode(encoded.clone()).unwrap(), rows);
+        assert_eq!(encode(&rows, encoded.len()).unwrap(), encoded);
+        assert!(encode(&rows, encoded.len() - 1).is_err());
+    }
+
+    #[test]
+    fn rejects_truncation_versions_counts_tags_flags_and_trailing_data() {
+        let encoded = encode(&rows(), usize::MAX).unwrap();
+        for end in 0..encoded.len() {
+            assert!(decode(encoded.slice(..end)).is_err(), "end={end}");
+        }
+        for (offset, value) in [(7, 2), (8, 255), (27, 255), (28, 255)] {
+            let mut corrupted = encoded.to_vec();
+            corrupted[offset] = value;
+            assert!(matches!(
+                decode(corrupted.into()),
+                Err(WalError::DataError(_))
+            ));
+        }
+        let mut trailing = encoded.to_vec();
+        trailing.push(0);
+        assert!(decode(trailing.into()).is_err());
+    }
+
+    #[test]
+    fn rejects_empty_and_mixed_sequence_batches() {
+        assert!(encode(&[], usize::MAX).is_err());
+        let mut rows = rows();
+        rows[1].seq = 1;
+        assert!(encode(&rows, usize::MAX).is_err());
+    }
+}

--- a/rust/client/src/slatedb/gc.rs
+++ b/rust/client/src/slatedb/gc.rs
@@ -1,0 +1,116 @@
+use std::ops::Bound;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use slatedb::wal::{WalError, WalFileRange, WalGc, WalObserver};
+
+use super::{wal_error, ChorusWal, Observer};
+
+pub(super) type Registry = Arc<Mutex<Option<Connection>>>;
+
+#[derive(Clone)]
+pub(super) struct Connection {
+    pub handle: crate::engine::GcHandle,
+    pub observer: Observer,
+}
+
+/// The first Chorus record index that any supplied range protects. SlateDB's
+/// WAL IDs are one-based, whereas Chorus record indices are zero-based.
+fn retain_from(ranges: &[WalFileRange]) -> u64 {
+    ranges
+        .iter()
+        .filter_map(|WalFileRange(start, end)| {
+            let first = match start {
+                Bound::Included(id) => *id,
+                Bound::Excluded(id) => id.checked_add(1)?,
+                Bound::Unbounded => 0,
+            };
+            let nonempty = match end {
+                Bound::Included(last) => first <= *last,
+                Bound::Excluded(end) => first < *end,
+                Bound::Unbounded => true,
+            };
+            nonempty.then_some(first.saturating_sub(1))
+        })
+        .min()
+        .unwrap_or(u64::MAX)
+}
+
+#[async_trait]
+impl WalGc for ChorusWal {
+    /// Collect an unreferenced prefix through the attached writer's maintenance
+    /// task. Pass a clone of this initializer to `with_wal_gc` on SlateDB's
+    /// `GarbageCollectorBuilder`, and attach that builder with `with_gc_builder`.
+    ///
+    /// The collector is process-local: it requires successful replay by a Db
+    /// using this initializer (or a clone), and returns `Closed` once that writer
+    /// closes. It never recovers the volume or takes ownership of its writer.
+    ///
+    /// Only whole sealed segments preceding every retained range are reclaimed;
+    /// gaps between retained ranges are intentionally kept. `min_age` is a
+    /// conservative grace period from the first collection pass that observes a
+    /// segment as sealed and unreferenced. Reopening or observing the segment as
+    /// referenced resets that period. Dry runs do not start timers or change
+    /// storage. Already committed deletion tombstones may be retried by normal
+    /// background maintenance regardless of a later dry run or retention change.
+    async fn collect(
+        &self,
+        referenced_ranges: Vec<WalFileRange>,
+        min_age: Duration,
+        dry_run: bool,
+    ) -> Result<(), WalError> {
+        let connection = self.gc.lock().unwrap().clone().ok_or(WalError::Closed)?;
+        connection.observer.status().map_err(WalError::from)?;
+        connection
+            .handle
+            .collect(retain_from(&referenced_ranges), min_age, dry_run)
+            .await
+            .map_err(wal_error)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn retained_ranges_translate_inclusive_exclusive_empty_and_extreme_bounds() {
+        assert_eq!(retain_from(&[]), u64::MAX);
+        assert_eq!(
+            retain_from(&[WalFileRange(Bound::Included(0), Bound::Unbounded)]),
+            0
+        );
+        assert_eq!(
+            retain_from(&[WalFileRange(Bound::Included(5), Bound::Unbounded)]),
+            4
+        );
+        assert_eq!(
+            retain_from(&[
+                WalFileRange(Bound::Excluded(2), Bound::Excluded(6)),
+                WalFileRange(Bound::Included(5), Bound::Unbounded)
+            ]),
+            2
+        );
+        assert_eq!(
+            retain_from(&[WalFileRange(Bound::Included(7), Bound::Excluded(7))]),
+            u64::MAX
+        );
+        assert_eq!(
+            retain_from(&[WalFileRange(Bound::Excluded(u64::MAX), Bound::Unbounded)]),
+            u64::MAX
+        );
+        assert_eq!(
+            retain_from(&[WalFileRange(
+                Bound::Included(u64::MAX),
+                Bound::Included(u64::MAX)
+            )]),
+            u64::MAX - 1
+        );
+        assert_eq!(
+            retain_from(&[WalFileRange(Bound::Unbounded, Bound::Included(3))]),
+            0
+        );
+    }
+}

--- a/rust/client/src/slatedb/gc.rs
+++ b/rust/client/src/slatedb/gc.rs
@@ -48,11 +48,12 @@ impl WalGc for ChorusWal {
     /// closes. It never recovers the volume or takes ownership of its writer.
     ///
     /// Only whole sealed segments preceding every retained range are reclaimed;
-    /// gaps between retained ranges are intentionally kept. `min_age` is a
-    /// conservative grace period from the first collection pass that observes a
-    /// segment as sealed and unreferenced. Reopening or observing the segment as
-    /// referenced resets that period. Dry runs do not start timers or change
-    /// storage. Already committed deletion tombstones may be retried by normal
+    /// gaps between retained ranges are intentionally kept. Nonzero `min_age`
+    /// checks storage modification time on every existing replica, including
+    /// newly repaired copies. Missing timestamps or unavailable listings defer
+    /// new truncation. Zero disables the age gate. Restarts and referenced
+    /// observations do not reset object age. Dry runs do not change storage.
+    /// Already committed deletion tombstones may be retried by normal
     /// background maintenance regardless of a later dry run or retention change.
     async fn collect(
         &self,

--- a/rust/client/src/slatedb/gc_tests.rs
+++ b/rust/client/src/slatedb/gc_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use chorus_fake_gcs::proto::{storage_server::Storage, GetObjectRequest, Timestamp};
 use slatedb::admin::AdminBuilder;
 use slatedb::config::{
     CheckpointOptions, CheckpointScope, GarbageCollectorDirectoryOptions, GarbageCollectorOptions,
@@ -7,6 +8,21 @@ use slatedb::wal::{WalFileRange, WalGc};
 use slatedb::GarbageCollectorBuilder;
 use std::collections::{HashMap, HashSet};
 use std::ops::Bound;
+use std::time::SystemTime;
+
+fn timestamp(time: SystemTime) -> Timestamp {
+    let time = time.duration_since(std::time::UNIX_EPOCH).unwrap();
+    Timestamp {
+        seconds: time.as_secs() as i64,
+        nanos: time.subsec_nanos() as i32,
+    }
+}
+
+async fn first_segment(servers: &[RunningFake]) -> String {
+    let metadata = manifest(servers).await;
+    let id = metadata["chorus.segments"].split(':').next().unwrap();
+    format!("slatedb-test/segments/{id}")
+}
 
 async fn manifest(servers: &[RunningFake]) -> HashMap<String, String> {
     let objects = servers[3]
@@ -51,7 +67,17 @@ async fn initialize(wal: &ChorusWal, checkpoint: u64) -> WriterInitResult {
 }
 
 async fn seeded(checkpoint: u64) -> (Vec<RunningFake>, ChorusWal, WriterInitResult) {
+    seeded_at(checkpoint, Timestamp::default()).await
+}
+
+async fn seeded_at(
+    checkpoint: u64,
+    now: Timestamp,
+) -> (Vec<RunningFake>, ChorusWal, WriterInitResult) {
     let (servers, volume) = volume().await;
+    for server in &servers {
+        server.service.set_clock(now).await;
+    }
     let wal = ChorusWal::with_config(
         volume,
         WalEngineConfig {
@@ -106,24 +132,148 @@ async fn gc_retention_can_precede_the_writer_replay_checkpoint() {
 }
 
 #[tokio::test]
-async fn gc_min_age_resets_when_referenced_and_dry_runs_do_not_start_it() {
+async fn gc_uses_object_age_on_first_eligible_pass_after_restart_and_dry_run() {
     let (servers, wal, mut writer) = seeded(0).await;
-    let age = Duration::from_millis(80);
-    wal.collect(retained(13), age, true).await.unwrap();
-    tokio::time::sleep(age + Duration::from_millis(20)).await;
-    wal.collect(retained(13), age, false).await.unwrap();
-    assert_eq!(floor(&servers).await, 0, "dry run must not age candidates");
+    let age = Duration::from_secs(3600);
+    let before = names(&servers, 0).await;
     wal.collect(retained(0), age, false).await.unwrap();
-    tokio::time::sleep(age + Duration::from_millis(20)).await;
+    writer.wal_writer.close().await.unwrap();
+    // A new initializer discards all process-local GC state. Old storage
+    // timestamps still authorize deletion on its first eligible pass.
+    let fresh = ChorusWal::with_config(wal.volume.clone(), wal.config.clone());
+    let mut writer = initialize(&fresh, 0).await;
+    fresh
+        .collect(retained(0), Duration::ZERO, false)
+        .await
+        .unwrap();
+    let snapshot = manifest(&servers).await;
+    fresh.collect(retained(13), age, true).await.unwrap();
+    assert_eq!(manifest(&servers).await, snapshot);
+    assert!(before.is_subset(&names(&servers, 0).await));
+    fresh.collect(retained(13), age, false).await.unwrap();
+    assert!(floor(&servers).await > 0);
+    assert!(!before.is_subset(&names(&servers, 0).await));
+    writer.wal_writer.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn gc_defers_young_objects_even_when_they_are_unreferenced() {
+    let (servers, wal, mut writer) = seeded_at(0, timestamp(SystemTime::now())).await;
+    let age = Duration::from_secs(3600);
+    let before = names(&servers, 0).await;
+    wal.collect(retained(13), age, true).await.unwrap();
     wal.collect(retained(13), age, false).await.unwrap();
+    assert_eq!(floor(&servers).await, 0);
+    assert_eq!(names(&servers, 0).await, before);
+    writer.wal_writer.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn gc_requires_old_valid_timestamps_on_every_existing_copy() {
+    let (servers, wal, mut writer) = seeded(0).await;
+    let age = Duration::from_secs(3600);
+    let object = first_segment(&servers).await;
+    let bucket = "projects/_/buckets/zone-2";
+    let before = names(&servers, 2).await;
+    for time in [
+        None,
+        Some(Timestamp {
+            seconds: 0,
+            nanos: -1,
+        }),
+        Some(Timestamp {
+            seconds: 0,
+            nanos: 1_000_000_000,
+        }),
+        Some(Timestamp {
+            seconds: i64::MAX,
+            nanos: 0,
+        }),
+        Some(timestamp(SystemTime::now())),
+        Some(timestamp(SystemTime::now() + age)),
+    ] {
+        servers[2]
+            .service
+            .set_object_update_time(bucket, &object, time)
+            .await;
+        wal.collect(retained(13), age, true).await.unwrap();
+        wal.collect(retained(13), age, false).await.unwrap();
+        assert_eq!(floor(&servers).await, 0, "timestamp {time:?}");
+        assert_eq!(names(&servers, 2).await, before);
+    }
+    servers[2]
+        .service
+        .set_object_update_time(bucket, &object, Some(Timestamp::default()))
+        .await;
+    wal.collect(retained(13), age, false).await.unwrap();
+    assert!(floor(&servers).await > 0);
+    writer.wal_writer.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn gc_defers_age_authorization_until_an_unavailable_zone_returns() {
+    let (servers, wal, mut writer) = seeded(0).await;
+    let age = Duration::from_secs(3600);
+    let before = names(&servers, 0).await;
+    servers[2].service.set_crashed(true).await;
+    wal.collect(retained(13), age, false).await.unwrap();
+    assert_eq!(floor(&servers).await, 0);
+    assert_eq!(names(&servers, 0).await, before);
+    servers[2].service.set_crashed(false).await;
+    wal.collect(retained(13), age, false).await.unwrap();
+    assert!(floor(&servers).await > 0);
+    writer.wal_writer.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn gc_rechecks_the_storage_age_of_a_repaired_replica() {
+    let (servers, wal, mut writer) = seeded(0).await;
+    let object = first_segment(&servers).await;
+    let bucket = "projects/_/buckets/zone-2";
+    let request = || {
+        tonic::Request::new(GetObjectRequest {
+            bucket: bucket.into(),
+            object: object.clone(),
+            ..Default::default()
+        })
+    };
+    let original = servers[2]
+        .service
+        .get_object(request())
+        .await
+        .unwrap()
+        .into_inner();
+    writer.wal_writer.close().await.unwrap();
+    let repaired_at = timestamp(SystemTime::now());
+    servers[2].service.set_clock(repaired_at).await;
+    assert!(
+        servers[2]
+            .service
+            .diverge_byte_for(bucket, &object, 0)
+            .await
+    );
+    let mut writer = initialize(&wal, 0).await;
+    // Queue behind startup repair without granting deletion authority.
+    wal.collect(retained(0), Duration::ZERO, false)
+        .await
+        .unwrap();
+    let repaired = servers[2]
+        .service
+        .get_object(request())
+        .await
+        .unwrap()
+        .into_inner();
+    assert_ne!(repaired.generation, original.generation);
+    assert_eq!(repaired.update_time, Some(repaired_at));
+    wal.collect(retained(13), Duration::from_secs(3600), false)
+        .await
+        .unwrap();
     assert_eq!(
         floor(&servers).await,
         0,
-        "a retained observation resets the grace period"
+        "the youngest copy must protect the prefix"
     );
-    tokio::time::sleep(age + Duration::from_millis(20)).await;
-    wal.collect(retained(13), age, false).await.unwrap();
-    assert!(floor(&servers).await > 0);
+    assert!(names(&servers, 0).await.contains(&object));
     writer.wal_writer.close().await.unwrap();
 }
 

--- a/rust/client/src/slatedb/gc_tests.rs
+++ b/rust/client/src/slatedb/gc_tests.rs
@@ -1,0 +1,371 @@
+use super::*;
+use slatedb::admin::AdminBuilder;
+use slatedb::config::{
+    CheckpointOptions, CheckpointScope, GarbageCollectorDirectoryOptions, GarbageCollectorOptions,
+};
+use slatedb::wal::{WalFileRange, WalGc};
+use slatedb::GarbageCollectorBuilder;
+use std::collections::{HashMap, HashSet};
+use std::ops::Bound;
+
+async fn manifest(servers: &[RunningFake]) -> HashMap<String, String> {
+    let objects = servers[3]
+        .service
+        .observe_prefix("projects/_/buckets/zone-3", "slatedb-test")
+        .await;
+    assert_eq!(objects.len(), 1);
+    objects[0].metadata.clone()
+}
+
+async fn floor(servers: &[RunningFake]) -> u64 {
+    manifest(servers).await["chorus.trunc"].parse().unwrap()
+}
+
+async fn names(servers: &[RunningFake], zone: usize) -> HashSet<String> {
+    servers[zone]
+        .service
+        .observe_prefix(
+            &format!("projects/_/buckets/zone-{zone}"),
+            "slatedb-test/segments/",
+        )
+        .await
+        .into_iter()
+        .map(|object| object.name)
+        .collect()
+}
+
+fn retained(first: u64) -> Vec<WalFileRange> {
+    vec![WalFileRange(Bound::Included(first), Bound::Unbounded)]
+}
+
+async fn initialize(wal: &ChorusWal, checkpoint: u64) -> WriterInitResult {
+    let recovery = wal
+        .volume
+        .recover(WalSeqNo::record(checkpoint))
+        .await
+        .unwrap();
+    let mut result =
+        writer_and_replay_with_gc(recovery, wal.config.clone(), wal.gc.clone()).unwrap();
+    replay(&mut result).await;
+    result
+}
+
+async fn seeded(checkpoint: u64) -> (Vec<RunningFake>, ChorusWal, WriterInitResult) {
+    let (servers, volume) = volume().await;
+    let wal = ChorusWal::with_config(
+        volume,
+        WalEngineConfig {
+            max_segment_bytes: 100,
+            ..config()
+        },
+    );
+    let mut writer = initialize(&wal, 0).await;
+    for seq in 1..=16 {
+        writer.wal_writer.append(&[row(seq)]).await.unwrap();
+        writer.wal_writer.flush().await.unwrap().await.unwrap();
+    }
+    writer.wal_writer.close().await.unwrap();
+    let writer = initialize(&wal, checkpoint).await;
+    // Also waits behind startup repair/sweeps before taking physical snapshots.
+    wal.collect(retained(0), Duration::ZERO, false)
+        .await
+        .unwrap();
+    (servers, wal, writer)
+}
+
+#[tokio::test]
+async fn gc_retention_can_precede_the_writer_replay_checkpoint() {
+    let (servers, wal, mut writer) = seeded(12).await;
+    let before = names(&servers, 0).await;
+    let old_manifest = manifest(&servers).await;
+    wal.collect(retained(6), Duration::ZERO, true)
+        .await
+        .unwrap();
+    assert_eq!(floor(&servers).await, 0);
+    assert_eq!(names(&servers, 0).await, before);
+    wal.collect(retained(6), Duration::ZERO, false)
+        .await
+        .unwrap();
+    let collected = floor(&servers).await;
+    assert!(collected > 0 && collected <= 5, "floor={collected}");
+    assert!(names(&servers, 0).await.len() < before.len());
+    let new_manifest = manifest(&servers).await;
+    assert_eq!(old_manifest["chorus.epoch"], new_manifest["chorus.epoch"]);
+    assert_eq!(old_manifest["chorus.owner"], new_manifest["chorus.owner"]);
+    writer.wal_writer.append(&[row(17)]).await.unwrap();
+    writer.wal_writer.flush().await.unwrap().await.unwrap();
+    writer.wal_writer.close().await.unwrap();
+    // The old retained checkpoint still replays, despite opening the previous
+    // writer at a newer checkpoint. No physical segment was partially deleted.
+    let mut recovered = direct_writer(&wal.volume, 5).await;
+    let batches = replay(&mut recovered).await;
+    assert_eq!(batches.len(), 12);
+    assert_eq!(batches[0].rows, vec![row(6)]);
+    assert_eq!(batches.last().unwrap().rows, vec![row(17)]);
+    recovered.wal_writer.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn gc_min_age_resets_when_referenced_and_dry_runs_do_not_start_it() {
+    let (servers, wal, mut writer) = seeded(0).await;
+    let age = Duration::from_millis(80);
+    wal.collect(retained(13), age, true).await.unwrap();
+    tokio::time::sleep(age + Duration::from_millis(20)).await;
+    wal.collect(retained(13), age, false).await.unwrap();
+    assert_eq!(floor(&servers).await, 0, "dry run must not age candidates");
+    wal.collect(retained(0), age, false).await.unwrap();
+    tokio::time::sleep(age + Duration::from_millis(20)).await;
+    wal.collect(retained(13), age, false).await.unwrap();
+    assert_eq!(
+        floor(&servers).await,
+        0,
+        "a retained observation resets the grace period"
+    );
+    tokio::time::sleep(age + Duration::from_millis(20)).await;
+    wal.collect(retained(13), age, false).await.unwrap();
+    assert!(floor(&servers).await > 0);
+    writer.wal_writer.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn gc_leaves_active_tail_and_retries_deletion_on_a_returning_zone() {
+    let (servers, wal, mut writer) = seeded(0).await;
+    let before = names(&servers, 2).await;
+    servers[2].service.set_crashed(true).await;
+    wal.collect(retained(13), Duration::ZERO, false)
+        .await
+        .unwrap();
+    assert!(floor(&servers).await > 0);
+    let deleted: HashSet<_> = before
+        .difference(&names(&servers, 0).await)
+        .cloned()
+        .collect();
+    assert!(!deleted.is_empty());
+    assert!(deleted.is_subset(&names(&servers, 2).await));
+    servers[2].service.set_crashed(false).await;
+    wal.collect(retained(13), Duration::ZERO, false)
+        .await
+        .unwrap();
+    assert!(deleted.is_disjoint(&names(&servers, 2).await));
+    // An empty retention set still grants no permission to delete active or
+    // speculative objects, only the sealed prefix already present at this pass.
+    let active = manifest(&servers).await["chorus.tail_id"].clone();
+    wal.collect(vec![], Duration::ZERO, false).await.unwrap();
+    assert!(names(&servers, 0)
+        .await
+        .contains(&format!("slatedb-test/segments/{active}")));
+    writer.wal_writer.append(&[row(17)]).await.unwrap();
+    writer.wal_writer.flush().await.unwrap().await.unwrap();
+    writer.wal_writer.close().await.unwrap();
+    let mut recovered = direct_writer(&wal.volume, 16).await;
+    assert_eq!(replay(&mut recovered).await[0].rows, vec![row(17)]);
+    recovered.wal_writer.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn gc_is_available_before_first_append_and_rebinds_after_close() {
+    let (servers, volume) = volume().await;
+    let wal = ChorusWal::new(volume);
+    assert!(matches!(
+        wal.collect(retained(0), Duration::ZERO, false).await,
+        Err(WalError::Closed)
+    ));
+    let mut writer = initialize(&wal, 0).await;
+    wal.collect(retained(0), Duration::ZERO, false)
+        .await
+        .unwrap();
+    let epoch = manifest(&servers).await["chorus.epoch"].clone();
+    writer.wal_writer.close().await.unwrap();
+    assert!(matches!(
+        wal.collect(retained(0), Duration::ZERO, false).await,
+        Err(WalError::Closed)
+    ));
+    assert_eq!(epoch, manifest(&servers).await["chorus.epoch"]);
+    let mut next = initialize(&wal, 0).await;
+    wal.collect(retained(0), Duration::ZERO, false)
+        .await
+        .unwrap();
+    next.wal_writer.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn closing_a_fenced_writer_does_not_disconnect_its_successors_gc() {
+    let (servers, wal, mut older) = seeded(0).await;
+    let mut newer = initialize(&wal, 12).await;
+    let _ = older.wal_writer.close().await;
+    let epoch = manifest(&servers).await["chorus.epoch"].clone();
+    wal.collect(retained(13), Duration::ZERO, false)
+        .await
+        .unwrap();
+    assert!(floor(&servers).await > 0);
+    assert_eq!(epoch, manifest(&servers).await["chorus.epoch"]);
+    newer.wal_writer.append(&[row(17)]).await.unwrap();
+    newer.wal_writer.flush().await.unwrap().await.unwrap();
+    newer.wal_writer.close().await.unwrap();
+}
+
+fn gc_options(interval: Option<Duration>) -> GarbageCollectorOptions {
+    GarbageCollectorOptions {
+        manifest_options: None,
+        wal_options: Some(GarbageCollectorDirectoryOptions {
+            interval,
+            min_age: Duration::ZERO,
+            dry_run: false,
+        }),
+        wal_fence_options: None,
+        compacted_options: None,
+        compactions_options: None,
+        detach_options: None,
+        ..GarbageCollectorOptions::default()
+    }
+}
+
+async fn open_with_gc(
+    wal: &ChorusWal,
+    store: Arc<dyn ObjectStore>,
+    interval: Option<Duration>,
+) -> Db {
+    let gc = GarbageCollectorBuilder::new("db", store.clone())
+        .with_wal_gc(Arc::new(wal.clone()))
+        .with_options(gc_options(interval));
+    Db::builder("db", store)
+        .with_settings(Settings {
+            flush_interval: None,
+            compactor_options: None,
+            garbage_collector_options: None,
+            ..Settings::default()
+        })
+        .with_wal_writer(Box::new(wal.clone()))
+        .with_gc_builder(gc)
+        .build()
+        .await
+        .unwrap()
+}
+
+async fn put_range(db: &Db, first: u64, end: u64) {
+    for index in first..end {
+        db.put(format!("key-{index}"), [42; 100])
+            .await
+            .unwrap()
+            .await_durable()
+            .await
+            .unwrap();
+    }
+}
+
+#[tokio::test]
+async fn slatedb_scheduled_gc_reclaims_storage_while_the_database_keeps_writing() {
+    let (servers, volume) = volume().await;
+    let wal = ChorusWal::with_config(volume.clone(), config());
+    let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let db = open_with_gc(&wal, store.clone(), Some(Duration::from_millis(10))).await;
+    put_range(&db, 0, 16).await;
+    db.flush_with_options(FlushOptions {
+        flush_type: FlushType::MemTable,
+    })
+    .await
+    .unwrap();
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while floor(&servers).await == 0 {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .unwrap();
+    put_range(&db, 16, 20).await;
+    assert_eq!(
+        db.get(b"key-0").await.unwrap(),
+        Some(Bytes::from(vec![42; 100]))
+    );
+    close(&db).await;
+    let reopened = open(&volume, store).await;
+    for index in 0..20 {
+        assert_eq!(
+            reopened.get(format!("key-{index}")).await.unwrap(),
+            Some(Bytes::from(vec![42; 100]))
+        );
+    }
+    close(&reopened).await;
+}
+
+#[tokio::test]
+async fn slatedb_gc_respects_an_actual_retained_checkpoint_then_reclaims_it() {
+    let (servers, volume) = volume().await;
+    let wal = ChorusWal::with_config(volume.clone(), config());
+    let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let db = open_with_gc(&wal, store.clone(), None).await;
+    put_range(&db, 0, 8).await;
+    let checkpoint = db
+        .create_checkpoint(CheckpointScope::Durable, &CheckpointOptions::default())
+        .await
+        .unwrap();
+    let admin = AdminBuilder::new("db", store.clone()).build();
+    let checkpoint_manifest = admin
+        .read_manifest(Some(checkpoint.manifest_id))
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(checkpoint_manifest.replay_after_wal_id(), 0);
+    assert!(
+        checkpoint_manifest.next_wal_sst_id() > 1,
+        "checkpoint must retain WAL records"
+    );
+    put_range(&db, 8, 16).await;
+    db.flush_with_options(FlushOptions {
+        flush_type: FlushType::MemTable,
+    })
+    .await
+    .unwrap();
+    // Reopen at the newer L0 checkpoint while retaining the old WAL-dependent one.
+    close(&db).await;
+    let db = open_with_gc(&wal, store.clone(), None).await;
+    let collector = GarbageCollectorBuilder::new("db", store)
+        .with_wal_gc(Arc::new(wal.clone()))
+        .with_options(gc_options(None))
+        .build();
+    collector.run_gc_once().await;
+    assert_eq!(floor(&servers).await, 0);
+    admin.delete_checkpoint(checkpoint.id).await.unwrap();
+    collector.run_gc_once().await;
+    assert!(floor(&servers).await > 0);
+    put_range(&db, 16, 17).await;
+    close(&db).await;
+}
+
+#[tokio::test]
+async fn gc_keeps_live_history_bounded_across_more_than_one_directory_of_rotations() {
+    let (servers, volume) = volume().await;
+    let wal = ChorusWal::with_config(
+        volume.clone(),
+        WalEngineConfig {
+            max_segment_bytes: 100,
+            ..config()
+        },
+    );
+    let mut writer = initialize(&wal, 0).await;
+    let mut all_objects = HashSet::new();
+    for seq in 1..=600 {
+        writer.wal_writer.append(&[row(seq)]).await.unwrap();
+        writer.wal_writer.flush().await.unwrap().await.unwrap();
+        if seq % 8 == 0 {
+            let current = names(&servers, 0).await;
+            all_objects.extend(current);
+            wal.collect(retained(seq.saturating_sub(16)), Duration::ZERO, false)
+                .await
+                .unwrap();
+            assert!(names(&servers, 0).await.len() < 30);
+        }
+    }
+    assert!(
+        all_objects.len() > 150,
+        "exercise more than one manifest directory worth of segments"
+    );
+    assert!(floor(&servers).await > 550);
+    writer.wal_writer.close().await.unwrap();
+    let mut recovered = direct_writer(&volume, 584).await;
+    let batches = replay(&mut recovered).await;
+    assert_eq!(batches.len(), 16);
+    assert_eq!(batches[0].rows, vec![row(585)]);
+    assert_eq!(batches[15].rows, vec![row(600)]);
+    recovered.wal_writer.close().await.unwrap();
+}

--- a/rust/client/src/slatedb/tests.rs
+++ b/rust/client/src/slatedb/tests.rs
@@ -1,0 +1,568 @@
+use super::*;
+use bytes::Bytes;
+use chorus_fake_gcs::{FakeGcs, RunningFake};
+use slatedb::config::{CloseOptions, FlushOptions, FlushType, Settings};
+use slatedb::object_store::{memory::InMemory, ObjectStore};
+use slatedb::{Db, ValueDeletable, WriteBatch};
+use std::time::Duration;
+
+#[path = "gc_tests.rs"]
+mod gc_tests;
+
+async fn volume() -> (Vec<RunningFake>, SegmentedVolume) {
+    let mut servers = Vec::new();
+    let mut factories = Vec::new();
+    for zone in 0..4 {
+        let server = FakeGcs::default().start().await.unwrap();
+        factories.push(
+            crate::GrpcReplicaFactory::connect(
+                zone,
+                &server.endpoint,
+                format!("projects/_/buckets/zone-{zone}"),
+                None,
+            )
+            .await
+            .unwrap(),
+        );
+        servers.push(server);
+    }
+    let manifest = factories.pop().unwrap();
+    let volume = SegmentedVolume::new(
+        factories,
+        manifest,
+        "slatedb-test",
+        crate::ClientConfig {
+            max_retries: 3,
+            retry_base: Duration::ZERO,
+        },
+    )
+    .unwrap();
+    (servers, volume)
+}
+
+fn config() -> WalEngineConfig {
+    WalEngineConfig {
+        max_segment_bytes: 256,
+        repair_interval: None,
+        shutdown_timeout: Duration::from_secs(5),
+        ..WalEngineConfig::default()
+    }
+}
+
+fn row(seq: u64) -> RowEntry {
+    RowEntry {
+        key: Bytes::from(format!("key-{seq}")),
+        value: ValueDeletable::Value(Bytes::from(format!("value-{seq}"))),
+        seq,
+        create_ts: Some(123),
+        expire_ts: None,
+    }
+}
+
+async fn direct_writer(volume: &SegmentedVolume, checkpoint: u64) -> WriterInitResult {
+    let recovery = volume.recover(WalSeqNo::record(checkpoint)).await.unwrap();
+    writer_and_replay(recovery, config()).unwrap()
+}
+
+async fn replay(result: &mut WriterInitResult) -> Vec<WalRows> {
+    let mut rows = Vec::new();
+    while let Some(batch) = result.replay_iterator.next().await.unwrap() {
+        rows.push(batch);
+    }
+    rows
+}
+
+async fn open(volume: &SegmentedVolume, store: Arc<dyn ObjectStore>) -> Db {
+    Db::builder("db", store)
+        .with_settings(Settings {
+            flush_interval: None,
+            compactor_options: None,
+            garbage_collector_options: None,
+            ..Settings::default()
+        })
+        .with_wal_writer(Box::new(ChorusWal::with_config(volume.clone(), config())))
+        .build()
+        .await
+        .unwrap()
+}
+
+async fn close(db: &Db) {
+    tokio::time::timeout(
+        Duration::from_secs(10),
+        db.close_with_options(CloseOptions::default().with_flush_type(None)),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+}
+
+#[tokio::test]
+async fn slatedb_reopens_atomic_batches_and_deletes_without_l0_flush() {
+    let (_servers, volume) = volume().await;
+    let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let db = open(&volume, store.clone()).await;
+    db.put(b"removed", b"old")
+        .await
+        .unwrap()
+        .await_durable()
+        .await
+        .unwrap();
+    let mut batch = WriteBatch::new();
+    batch.put(b"first", b"one");
+    batch.put(b"second", b"two");
+    batch.delete(b"removed");
+    db.write(batch)
+        .await
+        .unwrap()
+        .await_durable()
+        .await
+        .unwrap();
+    close(&db).await;
+
+    // Inspect the actual persisted batch boundary, not just the DB's memtable.
+    let mut recovered = direct_writer(&volume, 0).await;
+    let batches = replay(&mut recovered).await;
+    assert_eq!(batches.len(), 2);
+    assert_eq!(batches[0].last_consumed_wal_file_id, 1);
+    assert_eq!(batches[1].last_consumed_wal_file_id, 2);
+    assert_eq!(batches[1].rows.len(), 3);
+    assert!(batches[1]
+        .rows
+        .iter()
+        .all(|row| row.seq == batches[1].rows[0].seq));
+    let previous_seq = batches[1].rows[0].seq;
+    recovered.wal_writer.close().await.unwrap();
+
+    let db = open(&volume, store).await;
+    assert_eq!(
+        db.get(b"first").await.unwrap(),
+        Some(Bytes::from_static(b"one"))
+    );
+    assert_eq!(
+        db.get(b"second").await.unwrap(),
+        Some(Bytes::from_static(b"two"))
+    );
+    assert_eq!(db.get(b"removed").await.unwrap(), None);
+    db.put(b"third", b"three")
+        .await
+        .unwrap()
+        .await_durable()
+        .await
+        .unwrap();
+    close(&db).await;
+    let mut recovered = direct_writer(&volume, 2).await;
+    let batches = replay(&mut recovered).await;
+    assert_eq!(batches.len(), 1);
+    assert_eq!(batches[0].last_consumed_wal_file_id, 3);
+    assert!(batches[0].rows[0].seq > previous_seq);
+    recovered.wal_writer.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn slatedb_replays_only_the_suffix_after_an_l0_checkpoint() {
+    let (_servers, volume) = volume().await;
+    let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let db = open(&volume, store.clone()).await;
+    db.put(b"key", b"checkpointed")
+        .await
+        .unwrap()
+        .await_durable()
+        .await
+        .unwrap();
+    db.flush_with_options(FlushOptions {
+        flush_type: FlushType::MemTable,
+    })
+    .await
+    .unwrap();
+    db.put(b"key", b"wal-only")
+        .await
+        .unwrap()
+        .await_durable()
+        .await
+        .unwrap();
+    close(&db).await;
+    let db = open(&volume, store).await;
+    assert_eq!(
+        db.get(b"key").await.unwrap(),
+        Some(Bytes::from_static(b"wal-only"))
+    );
+    close(&db).await;
+    // Startup never deletes older records: a retained checkpoint may need them.
+    let mut recovered = direct_writer(&volume, 0).await;
+    assert_eq!(replay(&mut recovered).await.len(), 2);
+    recovered.wal_writer.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn takeover_fences_old_writer_and_recovers_durable_prefix() {
+    let (_servers, volume) = volume().await;
+    let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let old = open(&volume, store.clone()).await;
+    old.put(b"key", b"old")
+        .await
+        .unwrap()
+        .await_durable()
+        .await
+        .unwrap();
+    let new = open(&volume, store).await;
+    assert_eq!(
+        new.get(b"key").await.unwrap(),
+        Some(Bytes::from_static(b"old"))
+    );
+    new.put(b"key", b"new")
+        .await
+        .unwrap()
+        .await_durable()
+        .await
+        .unwrap();
+    let stale_write = tokio::time::timeout(Duration::from_secs(10), async {
+        match old.put(b"stale", b"must-not-commit").await {
+            Ok(handle) => handle.await_durable().await,
+            Err(error) => Err(error),
+        }
+    })
+    .await
+    .unwrap();
+    assert!(stale_write.is_err());
+    let _ = old
+        .close_with_options(CloseOptions::default().with_flush_type(None))
+        .await;
+    close(&new).await;
+    let mut recovered = direct_writer(&volume, 0).await;
+    let batches = replay(&mut recovered).await;
+    assert_eq!(batches.len(), 2);
+    assert!(batches
+        .iter()
+        .flat_map(|batch| &batch.rows)
+        .all(|row| row.key != b"stale"[..]));
+    recovered.wal_writer.close().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pipelined_appends_notify_only_after_quorum_and_flush_is_a_barrier() {
+    let (servers, volume) = volume().await;
+    let recovery = volume.recover(WalSeqNo::ZERO).await.unwrap();
+    let mut result = writer_and_replay(
+        recovery,
+        WalEngineConfig {
+            max_segment_bytes: 1024 * 1024,
+            ..config()
+        },
+    )
+    .unwrap();
+    assert!(replay(&mut result).await.is_empty());
+    // Holds target existing sessions, so start the lazy writer first.
+    result.wal_writer.append(&[row(1)]).await.unwrap();
+    result.wal_writer.flush().await.unwrap().await.unwrap();
+    for server in &servers[..3] {
+        server.service.inject_flush_hold().await;
+    }
+    let observer = result.wal_writer.observer();
+    let callback_observer = result.wal_writer.observer();
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let received = events.clone();
+    observer
+        .subscribe(Arc::new(move |event| {
+            // Reentrant status reads must not deadlock callbacks.
+            let _ = callback_observer.status();
+            received.lock().unwrap().push(event);
+        }))
+        .unwrap();
+    for seq in 2..=4 {
+        result.wal_writer.append(&[row(seq)]).await.unwrap();
+    }
+    let mut barrier = result.wal_writer.flush().await.unwrap();
+    assert!(
+        tokio::time::timeout(Duration::from_millis(30), &mut barrier)
+            .await
+            .is_err()
+    );
+    assert_eq!(observer.status().unwrap().last_flushed_wal_id, 1);
+    assert_eq!(observer.status().unwrap().buffered_wal_entries_count, 3);
+    assert!(observer.status().unwrap().estimated_bytes > 0);
+    servers[0].service.release_flush_holds().await;
+    assert!(
+        tokio::time::timeout(Duration::from_millis(30), &mut barrier)
+            .await
+            .is_err()
+    );
+    servers[1].service.release_flush_holds().await;
+    tokio::time::timeout(Duration::from_secs(5), barrier)
+        .await
+        .unwrap()
+        .unwrap();
+    let status = observer.status().unwrap();
+    assert_eq!(status.last_flushed_wal_id, 4);
+    assert_eq!(status.last_flushed_seq, Some(4));
+    assert_eq!(status.estimated_bytes, 0);
+    assert_eq!(status.buffered_wal_entries_count, 0);
+    let completed_barrier = result.wal_writer.flush().await.unwrap();
+    servers[2].service.release_flush_holds().await;
+    result.wal_writer.close().await.unwrap();
+    completed_barrier.await.unwrap();
+    result.wal_writer.close().await.unwrap();
+    let status = observer.status().unwrap_err();
+    assert!(matches!(status.closed_reason, Some(WalError::Closed)));
+    assert!(observer.subscribe(Arc::new(|_| {})).is_err());
+    let events = events.lock().unwrap();
+    assert_eq!(events.len(), 4);
+    for (index, event) in events[..3].iter().enumerate() {
+        assert!(
+            matches!(event, WalEvent::WalFlushed(status) if status.last_flushed_wal_id == index as u64 + 2)
+        );
+    }
+    assert!(matches!(events[3], WalEvent::WalClosed(_)));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn quorum_failure_closes_observer_and_does_not_advance_durability() {
+    let (servers, volume) = volume().await;
+    let mut result = direct_writer(&volume, 0).await;
+    replay(&mut result).await;
+    result.wal_writer.append(&[row(1)]).await.unwrap();
+    result.wal_writer.flush().await.unwrap().await.unwrap();
+    for server in &servers[..2] {
+        server.service.set_crashed(true).await;
+    }
+    if result.wal_writer.append(&[row(2)]).await.is_ok() {
+        if let Ok(barrier) = result.wal_writer.flush().await {
+            assert!(tokio::time::timeout(Duration::from_secs(10), barrier)
+                .await
+                .unwrap()
+                .is_err());
+        }
+    }
+    let status = result.wal_writer.status().unwrap_err();
+    assert_eq!(status.last_flushed_wal_id, 1);
+    assert_eq!(status.last_flushed_seq, Some(1));
+    assert!(!matches!(status.closed_reason, Some(WalError::Closed)));
+    assert!(result.wal_writer.append(&[row(3)]).await.is_err());
+    let _ = result.wal_writer.close().await;
+    for server in &servers[..2] {
+        server.service.set_crashed(false).await;
+    }
+    let mut recovered = direct_writer(&volume, 0).await;
+    let batches = replay(&mut recovered).await;
+    assert!((1..=2).contains(&batches.len()));
+    assert_eq!(batches[0].rows, vec![row(1)]);
+    if batches.len() == 2 {
+        // The failed append is allowed to replay; the rejected later append is not.
+        assert_eq!(batches[1].rows, vec![row(2)]);
+    }
+    recovered.wal_writer.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn incomplete_replay_and_oversized_batches_fail_closed() {
+    let (_servers, volume) = volume().await;
+    let mut result = direct_writer(&volume, 0).await;
+    assert!(result.wal_writer.append(&[row(1)]).await.is_err());
+    assert!(result.wal_writer.status().is_err());
+    let _ = result.wal_writer.close().await;
+
+    let recovery = volume.recover(WalSeqNo::ZERO).await.unwrap();
+    let mut result = writer_and_replay(
+        recovery,
+        WalEngineConfig {
+            max_record_bytes: 32,
+            ..config()
+        },
+    )
+    .unwrap();
+    replay(&mut result).await;
+    assert!(result.wal_writer.append(&[row(1)]).await.is_err());
+    assert_eq!(
+        result.wal_writer.status().unwrap_err().last_flushed_wal_id,
+        0
+    );
+    let _ = result.wal_writer.close().await;
+}
+
+#[tokio::test]
+async fn corrupt_or_foreign_records_fail_replay_without_starting_writer() {
+    let (_servers, volume) = volume().await;
+    let mut recovery = volume.recover(WalSeqNo::ZERO).await.unwrap();
+    assert!(recovery.try_next().await.unwrap().is_none());
+    let mut handle = recovery.start(config()).await.unwrap();
+    handle
+        .enqueue_append(WalSeqNo::ZERO, Bytes::from_static(b"not a SlateDB record"))
+        .await
+        .unwrap()
+        .await
+        .unwrap();
+    handle.shutdown().await.unwrap();
+    let mut result = direct_writer(&volume, 0).await;
+    assert!(matches!(
+        result.replay_iterator.next().await,
+        Err(WalError::DataError(_))
+    ));
+    assert!(matches!(
+        result.replay_iterator.next().await,
+        Err(WalError::DataError(_))
+    ));
+    assert!(result.wal_writer.append(&[row(1)]).await.is_err());
+    let _ = result.wal_writer.close().await;
+}
+
+#[tokio::test]
+async fn close_without_writes_shuts_down_the_replayed_engine() {
+    let (_servers, volume) = volume().await;
+    let mut result = direct_writer(&volume, 0).await;
+    replay(&mut result).await;
+    result.wal_writer.flush().await.unwrap().await.unwrap();
+    result.wal_writer.close().await.unwrap();
+    assert_eq!(
+        result.wal_writer.status().unwrap_err().last_flushed_wal_id,
+        0
+    );
+}
+
+#[tokio::test]
+async fn a_flush_barrier_does_not_include_later_appends() {
+    let (servers, volume) = volume().await;
+    let mut result = direct_writer(&volume, 0).await;
+    replay(&mut result).await;
+    result.wal_writer.append(&[row(1)]).await.unwrap();
+    result.wal_writer.flush().await.unwrap().await.unwrap();
+    let earlier = result.wal_writer.flush().await.unwrap();
+    for server in &servers[..3] {
+        server.service.inject_flush_hold().await;
+    }
+    result.wal_writer.append(&[row(2)]).await.unwrap();
+    tokio::time::timeout(Duration::from_secs(1), earlier)
+        .await
+        .unwrap()
+        .unwrap();
+    let mut later = result.wal_writer.flush().await.unwrap();
+    assert!(tokio::time::timeout(Duration::from_millis(30), &mut later)
+        .await
+        .is_err());
+    for server in &servers[..3] {
+        server.service.release_flush_holds().await;
+    }
+    result.wal_writer.close().await.unwrap();
+    later.await.unwrap();
+    assert_eq!(
+        result.wal_writer.status().unwrap_err().last_flushed_wal_id,
+        2
+    );
+}
+
+struct PausedInit {
+    wal: ChorusWal,
+    entered: Arc<tokio::sync::Notify>,
+    resume: Arc<tokio::sync::Notify>,
+}
+
+#[async_trait]
+impl WriterInit for PausedInit {
+    async fn fence_and_init(
+        &self,
+        manifest: &mut WriterManifest,
+    ) -> Result<WriterInitResult, WalError> {
+        self.entered.notify_one();
+        self.resume.notified().await;
+        self.wal.fence_and_init(manifest).await
+    }
+}
+
+#[tokio::test]
+async fn stale_initializer_cannot_start_after_a_newer_database_writer() {
+    let (_servers, volume) = volume().await;
+    let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let entered = Arc::new(tokio::sync::Notify::new());
+    let resume = Arc::new(tokio::sync::Notify::new());
+    let init = PausedInit {
+        wal: ChorusWal::with_config(volume.clone(), config()),
+        entered: entered.clone(),
+        resume: resume.clone(),
+    };
+    let older_store = store.clone();
+    let older = tokio::spawn(async move {
+        Db::builder("db", older_store)
+            .with_wal_writer(Box::new(init))
+            .build()
+            .await
+    });
+    tokio::time::timeout(Duration::from_secs(5), entered.notified())
+        .await
+        .unwrap();
+    let newer = open(&volume, store).await;
+    newer
+        .put(b"key", b"newer")
+        .await
+        .unwrap()
+        .await_durable()
+        .await
+        .unwrap();
+    resume.notify_one();
+    assert!(tokio::time::timeout(Duration::from_secs(5), older)
+        .await
+        .unwrap()
+        .unwrap()
+        .is_err());
+    // The stale initialization is rejected before it fences the newer Chorus
+    // writer, so the surviving database can still make progress.
+    newer
+        .put(b"key", b"still-newer")
+        .await
+        .unwrap()
+        .await_durable()
+        .await
+        .unwrap();
+    close(&newer).await;
+}
+
+#[tokio::test]
+async fn drop_closes_observers_and_pending_barriers() {
+    let (servers, volume) = volume().await;
+    let mut result = direct_writer(&volume, 0).await;
+    replay(&mut result).await;
+    result.wal_writer.append(&[row(1)]).await.unwrap();
+    result.wal_writer.flush().await.unwrap().await.unwrap();
+    for server in &servers[..3] {
+        server.service.inject_flush_hold().await;
+    }
+    result.wal_writer.append(&[row(2)]).await.unwrap();
+    let barrier = result.wal_writer.flush().await.unwrap();
+    let observer = result.wal_writer.observer();
+    drop(result);
+    assert!(matches!(
+        observer.status().unwrap_err().closed_reason,
+        Some(WalError::Closed)
+    ));
+    assert!(tokio::time::timeout(Duration::from_secs(1), barrier)
+        .await
+        .unwrap()
+        .is_err());
+    for server in &servers[..3] {
+        server.service.release_flush_holds().await;
+    }
+}
+
+#[test]
+fn observer_callbacks_can_close_reentrantly_without_reordering_events() {
+    let observer = Observer::new(0);
+    let reentrant = observer.clone();
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let received = events.clone();
+    observer
+        .subscribe(Arc::new(move |event| {
+            if matches!(event, WalEvent::WalFlushed(_)) {
+                reentrant.close(WalError::Closed);
+            }
+            received.lock().unwrap().push(event);
+        }))
+        .unwrap();
+    observer.notify(|state| {
+        Some((
+            WalEvent::WalFlushed(state.status.clone()),
+            state.listeners.clone(),
+        ))
+    });
+    let events = events.lock().unwrap();
+    assert_eq!(events.len(), 2);
+    assert!(matches!(events[0], WalEvent::WalFlushed(_)));
+    assert!(matches!(events[1], WalEvent::WalClosed(_)));
+    assert!(observer.state.lock().unwrap().listeners.is_empty());
+}

--- a/rust/client/src/transport.rs
+++ b/rust/client/src/transport.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::SystemTime;
 
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -25,6 +26,10 @@ pub struct ListedObject {
     pub size: i64,
     /// Whether the provider reports the object as finalized.
     pub finalized: bool,
+    /// Provider modification time, including metadata changes. Unknown times
+    /// must not authorize age-based garbage collection.
+    #[serde(default)]
+    pub last_modified: Option<SystemTime>,
     /// Provider-computed CRC32C of the complete object, when supplied. This is
     /// the same durable checksum a `stat` returns, so a listing alone decides
     /// whether a sealed copy matches the manifest's committed digest.

--- a/rust/client/tests/slatedb_integration.rs
+++ b/rust/client/tests/slatedb_integration.rs
@@ -1,0 +1,297 @@
+#![cfg(feature = "slatedb")]
+
+// Exercise the library as a downstream application: no private adapter helpers,
+// cfg(test) initialization path, WalReader, or WalAdmin implementation.
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::sync::Arc;
+use std::time::Duration;
+
+use bytes::Bytes;
+use chorus_client::{
+    slatedb::ChorusWal, ClientConfig, GrpcReplicaFactory, SegmentedVolume, WalEngineConfig,
+};
+use chorus_fake_gcs::{FakeGcs, RunningFake};
+use slatedb::config::{
+    CloseOptions, FlushOptions, FlushType, GarbageCollectorDirectoryOptions,
+    GarbageCollectorOptions, Settings,
+};
+use slatedb::object_store::{memory::InMemory, ObjectStore};
+use slatedb::{Db, GarbageCollectorBuilder, WriteBatch};
+
+const PREFIX: &str = "public-slatedb";
+const KEY_COUNT: u64 = 97;
+type Model = BTreeMap<Bytes, Bytes>;
+
+struct Fixture {
+    servers: Vec<RunningFake>,
+    store: Arc<dyn ObjectStore>,
+}
+
+impl Fixture {
+    async fn new() -> Self {
+        let mut servers = Vec::new();
+        for _ in 0..4 {
+            servers.push(FakeGcs::default().start().await.unwrap());
+        }
+        Self {
+            servers,
+            store: Arc::new(InMemory::new()),
+        }
+    }
+
+    async fn open(&self) -> (Db, GarbageCollectorBuilder<&'static str>) {
+        // Recreate transports, volume, initializer, and GC registry on every
+        // open, so replay cannot succeed by retaining a previous writer's state.
+        let mut factories = Vec::new();
+        for (zone, server) in self.servers.iter().enumerate() {
+            factories.push(
+                GrpcReplicaFactory::connect(
+                    zone,
+                    &server.endpoint,
+                    format!("projects/_/buckets/zone-{zone}"),
+                    None,
+                )
+                .await
+                .unwrap(),
+            );
+        }
+        let regional = factories.pop().unwrap();
+        let volume = SegmentedVolume::new(
+            factories,
+            regional,
+            PREFIX,
+            ClientConfig {
+                max_retries: 3,
+                retry_base: Duration::ZERO,
+            },
+        )
+        .unwrap();
+        let wal = ChorusWal::with_config(
+            volume,
+            WalEngineConfig {
+                max_segment_bytes: 1024,
+                repair_interval: None,
+                shutdown_timeout: Duration::from_secs(5),
+                ..WalEngineConfig::default()
+            },
+        );
+        let gc_builder = || {
+            GarbageCollectorBuilder::new("db", self.store.clone())
+                .with_wal_gc(Arc::new(wal.clone()))
+                .with_options(GarbageCollectorOptions {
+                    manifest_options: None,
+                    wal_options: Some(GarbageCollectorDirectoryOptions {
+                        interval: None,
+                        min_age: Duration::ZERO,
+                        dry_run: false,
+                    }),
+                    wal_fence_options: None,
+                    compacted_options: None,
+                    compactions_options: None,
+                    detach_options: None,
+                    ..GarbageCollectorOptions::default()
+                })
+        };
+        let collector = gc_builder();
+        let db = Db::builder("db", self.store.clone())
+            .with_settings(Settings {
+                flush_interval: None,
+                compactor_options: None,
+                garbage_collector_options: None,
+                l0_max_ssts: 64,
+                l0_max_ssts_per_key: 64,
+                ..Settings::default()
+            })
+            .with_wal_writer(Box::new(wal.clone()))
+            .with_gc_builder(gc_builder())
+            .build()
+            .await
+            .unwrap();
+        (db, collector)
+    }
+
+    async fn manifest(&self) -> HashMap<String, String> {
+        let objects = self.servers[3]
+            .service
+            .observe_prefix("projects/_/buckets/zone-3", PREFIX)
+            .await;
+        assert_eq!(objects.len(), 1);
+        objects[0].metadata.clone()
+    }
+
+    async fn segments(&self, zone: usize) -> BTreeSet<String> {
+        self.servers[zone]
+            .service
+            .observe_prefix(
+                &format!("projects/_/buckets/zone-{zone}"),
+                &format!("{PREFIX}/segments/"),
+            )
+            .await
+            .into_iter()
+            .map(|object| object.name)
+            .collect()
+    }
+}
+
+fn key(index: u64) -> Bytes {
+    Bytes::from(format!("key-{index:03}"))
+}
+
+async fn write_batches(db: &Db, model: &mut Model, state: &mut u64, batches: usize) {
+    for _ in 0..batches {
+        let mut batch = WriteBatch::new();
+        for _ in 0..4 {
+            // Fixed seeds make the mixed overwrite/delete workload reproducible.
+            *state = state.wrapping_mul(6364136223846793005).wrapping_add(1);
+            let key = key((*state >> 32) % KEY_COUNT);
+            if state.is_multiple_of(5) {
+                batch.delete(&key);
+                model.remove(&key);
+            } else {
+                let value = Bytes::from(vec![(*state >> 24) as u8; (*state >> 40) as usize % 192]);
+                batch.put(&key, &value);
+                model.insert(key, value);
+            }
+        }
+        db.write(batch)
+            .await
+            .unwrap()
+            .await_durable()
+            .await
+            .unwrap();
+    }
+}
+
+async fn verify(db: &Db, model: &Model) {
+    for index in 0..KEY_COUNT {
+        let key = key(index);
+        assert_eq!(db.get(&key).await.unwrap(), model.get(&key).cloned());
+    }
+    let mut scan = db.scan(..).await.unwrap();
+    let mut actual = Vec::new();
+    while let Some(row) = scan.next().await.unwrap() {
+        actual.push((row.key, row.value));
+    }
+    assert_eq!(actual, model.clone().into_iter().collect::<Vec<_>>());
+
+    let mut scan = db.scan(key(20)..key(50)).await.unwrap();
+    let mut actual = Vec::new();
+    while let Some(row) = scan.next().await.unwrap() {
+        actual.push((row.key, row.value));
+    }
+    assert_eq!(
+        actual,
+        model
+            .range(key(20)..key(50))
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+async fn flush_l0(db: &Db) {
+    db.flush_with_options(FlushOptions {
+        flush_type: FlushType::MemTable,
+    })
+    .await
+    .unwrap();
+}
+
+async fn close(db: &Db) {
+    // Leave the suffix only in Chorus, forcing WAL replay on the next open.
+    db.close_with_options(CloseOptions::default().with_flush_type(None))
+        .await
+        .unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn public_api_matches_model_across_gc_and_fresh_client_reopens() {
+    tokio::time::timeout(Duration::from_secs(60), async {
+        for seed in [1, 7, 42, 0xdead_beef] {
+            let fixture = Fixture::new().await;
+            let mut model = Model::new();
+            let mut state = seed;
+            let mut previous_floor = 0;
+            for _ in 0..4 {
+                let (db, collector) = fixture.open().await;
+                let collector = collector.build();
+                verify(&db, &model).await;
+                write_batches(&db, &mut model, &mut state, 40).await;
+                flush_l0(&db).await;
+                let before = fixture.segments(0).await;
+                let manifest = fixture.manifest().await;
+                collector.run_gc_once().await;
+                let collected = fixture.manifest().await;
+                let floor: u64 = collected["chorus.trunc"].parse().unwrap();
+                assert!(floor > previous_floor, "GC did not advance: {collected:?}");
+                previous_floor = floor;
+                assert_eq!(manifest["chorus.epoch"], collected["chorus.epoch"]);
+                assert_eq!(manifest["chorus.owner"], collected["chorus.owner"]);
+                for zone in 0..3 {
+                    assert!(fixture.segments(zone).await.len() < before.len());
+                }
+                write_batches(&db, &mut model, &mut state, 8).await;
+                verify(&db, &model).await;
+                close(&db).await;
+            }
+            let (db, _) = fixture.open().await;
+            verify(&db, &model).await;
+            close(&db).await;
+        }
+    })
+    .await
+    .expect("public SlateDB lifecycle test timed out");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn public_api_survives_zone_loss_gc_and_writer_takeover() {
+    tokio::time::timeout(Duration::from_secs(30), async {
+        let fixture = Fixture::new().await;
+        let mut model = Model::new();
+        let mut state = 123;
+        let (old, collector) = fixture.open().await;
+        let collector = collector.build();
+        write_batches(&old, &mut model, &mut state, 32).await;
+        flush_l0(&old).await;
+        let before = fixture.segments(0).await;
+
+        fixture.servers[2].service.set_crashed(true).await;
+        write_batches(&old, &mut model, &mut state, 16).await;
+        collector.run_gc_once().await;
+        let deleted: BTreeSet<_> = before
+            .difference(&fixture.segments(0).await)
+            .cloned()
+            .collect();
+        assert!(!deleted.is_empty(), "GC must reclaim the flushed prefix");
+        assert!(deleted.is_subset(&fixture.segments(2).await));
+        verify(&old, &model).await;
+
+        // Take ownership without closing the previous Db, while a zone is down.
+        let (new, collector) = fixture.open().await;
+        let collector = collector.build();
+        verify(&new, &model).await;
+        let stale_write = match old.put(b"stale-writer", b"must-not-commit").await {
+            Ok(handle) => handle.await_durable().await,
+            Err(error) => Err(error),
+        };
+        assert!(
+            stale_write.is_err(),
+            "the fenced writer acknowledged a write"
+        );
+        let _ = old
+            .close_with_options(CloseOptions::default().with_flush_type(None))
+            .await;
+        write_batches(&new, &mut model, &mut state, 16).await;
+
+        fixture.servers[2].service.set_crashed(false).await;
+        collector.run_gc_once().await;
+        assert!(deleted.is_disjoint(&fixture.segments(2).await));
+        verify(&new, &model).await;
+        close(&new).await;
+        let (reopened, _) = fixture.open().await;
+        verify(&reopened, &model).await;
+        assert_eq!(reopened.get(b"stale-writer").await.unwrap(), None);
+        close(&reopened).await;
+    })
+    .await
+    .expect("public SlateDB fault test timed out");
+}

--- a/rust/client/tests/slatedb_integration.rs
+++ b/rust/client/tests/slatedb_integration.rs
@@ -10,7 +10,7 @@ use bytes::Bytes;
 use chorus_client::{
     slatedb::ChorusWal, ClientConfig, GrpcReplicaFactory, SegmentedVolume, WalEngineConfig,
 };
-use chorus_fake_gcs::{FakeGcs, RunningFake};
+use chorus_fake_gcs::{FakeGcs, LatencyProfile, Operation, RunningFake, SimulatedLatency};
 use slatedb::config::{
     CloseOptions, FlushOptions, FlushType, GarbageCollectorDirectoryOptions,
     GarbageCollectorOptions, Settings,
@@ -29,9 +29,28 @@ struct Fixture {
 
 impl Fixture {
     async fn new() -> Self {
+        Self::with_slow_zone(false).await
+    }
+
+    async fn with_slow_zone(slow_zone: bool) -> Self {
         let mut servers = Vec::new();
-        for _ in 0..4 {
-            servers.push(FakeGcs::default().start().await.unwrap());
+        for zone in 0..4 {
+            let service = if slow_zone && zone == 2 {
+                FakeGcs::with_latency(
+                    LatencyProfile::new(7)
+                        .with_operation(
+                            Operation::BidiCreate,
+                            SimulatedLatency::fixed(Duration::from_millis(5)),
+                        )
+                        .with_operation(
+                            Operation::BidiFinalize,
+                            SimulatedLatency::fixed(Duration::from_millis(3)),
+                        ),
+                )
+            } else {
+                FakeGcs::default()
+            };
+            servers.push(service.start().await.unwrap());
         }
         Self {
             servers,
@@ -203,11 +222,36 @@ async fn close(db: &Db) {
         .unwrap();
 }
 
+// Object counts are not comparable across replicas: speculative provisioning
+// and catch-up can leave different numbers of objects in each zone. Instead,
+// check the exact sealed objects whose deletion the committed floor authorizes.
+fn collected_objects(manifest: &HashMap<String, String>, floor: u64) -> BTreeSet<String> {
+    let entries: Vec<_> = manifest["chorus.segments"]
+        .split(',')
+        .filter(|entry| !entry.is_empty())
+        .map(|entry| {
+            let mut fields = entry.split(':');
+            let id = fields.next().unwrap();
+            let base = fields.next().unwrap().parse::<u64>().unwrap();
+            (id, base)
+        })
+        .collect();
+    let tail = manifest["chorus.tail_base"].parse().unwrap();
+    entries
+        .iter()
+        .enumerate()
+        .filter(|(index, _)| entries.get(index + 1).map_or(tail, |entry| entry.1) <= floor)
+        .map(|(_, (id, _))| format!("{PREFIX}/segments/{id}"))
+        .collect()
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn public_api_matches_model_across_gc_and_fresh_client_reopens() {
     tokio::time::timeout(Duration::from_secs(60), async {
         for seed in [1, 7, 42, 0xdead_beef] {
-            let fixture = Fixture::new().await;
+            // Exercise asymmetric provisioning/finalization as well as fast
+            // replicas; per-zone object counts need not agree at GC boundaries.
+            let fixture = Fixture::with_slow_zone(seed == 7).await;
             let mut model = Model::new();
             let mut state = seed;
             let mut previous_floor = 0;
@@ -217,7 +261,6 @@ async fn public_api_matches_model_across_gc_and_fresh_client_reopens() {
                 verify(&db, &model).await;
                 write_batches(&db, &mut model, &mut state, 40).await;
                 flush_l0(&db).await;
-                let before = fixture.segments(0).await;
                 let manifest = fixture.manifest().await;
                 collector.run_gc_once().await;
                 let collected = fixture.manifest().await;
@@ -226,8 +269,14 @@ async fn public_api_matches_model_across_gc_and_fresh_client_reopens() {
                 previous_floor = floor;
                 assert_eq!(manifest["chorus.epoch"], collected["chorus.epoch"]);
                 assert_eq!(manifest["chorus.owner"], collected["chorus.owner"]);
+                let deleted = collected_objects(&manifest, floor);
+                assert!(!deleted.is_empty(), "GC must reclaim physical objects");
                 for zone in 0..3 {
-                    assert!(fixture.segments(zone).await.len() < before.len());
+                    let remaining = fixture.segments(zone).await;
+                    assert!(
+                        deleted.is_disjoint(&remaining),
+                        "zone {zone}: {remaining:?}"
+                    );
                 }
                 write_batches(&db, &mut model, &mut state, 8).await;
                 verify(&db, &model).await;

--- a/rust/dst/src/sim_transport.rs
+++ b/rust/dst/src/sim_transport.rs
@@ -173,6 +173,20 @@ impl ReplicaFactory for InMemoryReplicaFactory {
                 generation: object.generation,
                 size: object.size,
                 finalized: object.finalize_time.is_some(),
+                last_modified: object.update_time.and_then(|time| {
+                    if !(-62_135_596_800..=253_402_300_799).contains(&time.seconds)
+                        || !(0..1_000_000_000).contains(&time.nanos)
+                    {
+                        return None;
+                    }
+                    let seconds = std::time::Duration::from_secs(time.seconds.unsigned_abs());
+                    let base = if time.seconds < 0 {
+                        std::time::UNIX_EPOCH.checked_sub(seconds)
+                    } else {
+                        std::time::UNIX_EPOCH.checked_add(seconds)
+                    }?;
+                    base.checked_add(std::time::Duration::from_nanos(time.nanos as u64))
+                }),
                 crc32c: object
                     .checksums
                     .as_ref()

--- a/rust/fake-gcs/proto/storage_subset.proto
+++ b/rust/fake-gcs/proto/storage_subset.proto
@@ -62,6 +62,7 @@ message Object {
   string content_type = 13;
   optional ObjectChecksums checksums = 16;
   map<string, string> metadata = 22;
+  optional Timestamp update_time = 17;
   optional Timestamp finalize_time = 36;
 }
 

--- a/rust/fake-gcs/src/lib.rs
+++ b/rust/fake-gcs/src/lib.rs
@@ -161,6 +161,8 @@ pub struct FakeGcs {
 #[derive(Default)]
 struct State {
     objects: HashMap<String, StoredObject>,
+    // Explicit provider clock, initially UNIX epoch, keeps DST deterministic.
+    clock: Timestamp,
     next_generation: i64,
     next_stream_id: u64,
     crashed: bool,
@@ -192,6 +194,7 @@ struct StoredObject {
     name: String,
     generation: i64,
     metageneration: i64,
+    update_time: Option<Timestamp>,
     metadata: HashMap<String, String>,
     content_type: String,
     bytes: Vec<u8>,
@@ -256,6 +259,29 @@ impl Drop for RunningFake {
 }
 
 impl FakeGcs {
+    /// Set the provider clock used by subsequent creates, metadata updates and
+    /// finalizations. It does not advance automatically or change old objects.
+    pub async fn set_clock(&self, now: Timestamp) {
+        self.inner.lock().await.clock = now;
+    }
+
+    /// Override an object's update timestamp, including missing/malformed
+    /// metadata, for deterministic age-based collection tests.
+    pub async fn set_object_update_time(
+        &self,
+        bucket: &str,
+        name: &str,
+        update_time: Option<Timestamp>,
+    ) {
+        self.inner
+            .lock()
+            .await
+            .objects
+            .get_mut(&object_key(bucket, name))
+            .expect("object must exist")
+            .update_time = update_time;
+    }
+
     pub fn with_latency(profile: LatencyProfile) -> Self {
         let state = State {
             latency_profile: profile,
@@ -1184,6 +1210,7 @@ impl FakeGcs {
             name: resource.name,
             generation: state.next_generation,
             metageneration: 1,
+            update_time: Some(state.clock),
             metadata: resource.metadata,
             content_type: resource.content_type,
             integrity_crc32c: crc32c::crc32c(&bytes),
@@ -1466,6 +1493,7 @@ impl Storage for FakeGcs {
         check_metadata_size(&update.metadata)?;
         let mut state = self.inner.lock().await;
         let key = object_key(&update.bucket, &update.name);
+        let now = state.clock;
         let object = state
             .objects
             .get_mut(&key)
@@ -1482,6 +1510,7 @@ impl Storage for FakeGcs {
         }
         object.metadata = update.metadata;
         object.metageneration += 1;
+        object.update_time = Some(now);
         let proto = object.to_proto();
         if let Some(code) = state
             .response_losses
@@ -1717,6 +1746,7 @@ impl FakeGcs {
         stream_id: Option<u64>,
     ) -> Result<BidiWriteObjectResponse, Status> {
         let mut state = self.inner.lock().await;
+        let now = state.clock;
         match request.first_message.as_ref() {
             Some(FirstMessage::WriteObjectSpec(spec)) => {
                 let is_create = spec.if_generation_match == Some(0);
@@ -1755,6 +1785,7 @@ impl FakeGcs {
                     name: resource.name,
                     generation: state.next_generation,
                     metageneration: 1,
+                    update_time: Some(now),
                     metadata: resource.metadata,
                     content_type: resource.content_type,
                     bytes: Vec::new(),
@@ -1829,6 +1860,7 @@ impl FakeGcs {
                 append_data(object, &request)?;
                 if request.finish_write {
                     object.finalized = true;
+                    object.update_time = Some(now);
                     object.active_stream = None;
                     return Ok(BidiWriteObjectResponse {
                         write_status: Some(WriteStatus::Resource(object.to_proto())),
@@ -1867,6 +1899,7 @@ impl FakeGcs {
         }
         let mut state = self.inner.lock().await;
         let partial_write = state.partial_writes.pop_front();
+        let now = state.clock;
         if partial_write.is_some() {
             state.observed_faults += 1;
         }
@@ -1896,6 +1929,7 @@ impl FakeGcs {
         append_data(object, &request)?;
         if request.finish_write {
             object.finalized = true;
+            object.update_time = Some(now);
             object.active_stream = None;
             return Ok(BidiWriteObjectResponse {
                 write_status: Some(WriteStatus::Resource(object.to_proto())),
@@ -2073,6 +2107,7 @@ impl StoredObject {
                 md5_hash: Vec::new(),
             }),
             metadata: self.metadata.clone(),
+            update_time: self.update_time,
             finalize_time: self.finalized.then_some(Timestamp {
                 seconds: 1,
                 nanos: 0,
@@ -2147,6 +2182,7 @@ mod tests {
             name: "object".into(),
             generation: 1,
             metageneration: 1,
+            update_time: Some(Timestamp::default()),
             metadata: HashMap::new(),
             content_type: String::new(),
             bytes: Vec::new(),
@@ -2736,6 +2772,19 @@ mod tests {
             .unwrap();
         let bucket = "projects/_/buckets/zone-0";
         let name = "finalized";
+        let created_at = Timestamp {
+            seconds: 10,
+            nanos: 123,
+        };
+        let finalized_at = Timestamp {
+            seconds: 20,
+            nanos: 456,
+        };
+        let updated_at = Timestamp {
+            seconds: 30,
+            nanos: 789,
+        };
+        server.service.set_clock(created_at).await;
         create_appendable(&mut client, bucket, name).await;
         let open = client
             .get_object(GetObjectRequest {
@@ -2747,6 +2796,8 @@ mod tests {
             .unwrap()
             .into_inner();
         assert_eq!(open.size, 0);
+        assert_eq!(open.update_time, Some(created_at));
+        server.service.set_clock(finalized_at).await;
 
         let mut finalize = append_request(
             bucket,
@@ -2774,6 +2825,8 @@ mod tests {
             .unwrap()
             .into_inner();
         assert_eq!(finalized.size, 6);
+        assert_eq!(finalized.update_time, Some(finalized_at));
+        server.service.set_clock(updated_at).await;
         let updated = client
             .update_object(UpdateObjectRequest {
                 object: Some(Object {
@@ -2791,6 +2844,7 @@ mod tests {
             .unwrap()
             .into_inner();
         assert_eq!(updated.metageneration, finalized.metageneration + 1);
+        assert_eq!(updated.update_time, Some(updated_at));
 
         let mut rejected = client
             .bidi_write_object(tokio_stream::iter([append_request(


### PR DESCRIPTION
## Summary

Provide an out-of-the-box Chorus implementation of SlateDB's pluggable WAL behind the disabled-by-default `slatedb` Cargo feature. This includes writer initialization/fencing, streaming startup replay, atomic batch writes, quorum-driven durability, flush barriers, and retained-history garbage collection.

**Keep this PR in draft and do not merge/publish until SlateDB ships a suitable stable release.** Development currently pins [`31656fe3`](https://github.com/slatedb/slatedb/commit/31656fe30064ce0d7991a578085341e21438af5e), the verified upstream main revision.

## Design and safety

- Expose `chorus_client::slatedb::ChorusWal` as `WriterInit` and `WalGc`. The writer and GC builder receive clones of the same initializer, using one dedicated Chorus volume per database.
- Store each complete SlateDB write batch in one versioned Chorus record, preserving values, tombstones, merge operands, sequence numbers, and creation/expiry timestamps. Record index `n` maps to WAL ID `n + 1`.
- Fence through SlateDB's manifest / Chorus recovery / manifest-recheck protocol. Replay streams the suffix not yet stored in L0; the engine starts after replay completes.
- Keep admission pipelined and bounded. Publish durability only after ordered quorum completions. Flush covers preceding admissions without forcing segment rotation. Oversized batches are rejected atomically; ambiguous failures close the writer and require recovery rather than an in-place retry.
- Run GC through the live writer's maintenance queue without taking over the volume. Its retention boundary is derived from **all** referenced ranges, not just the current writer's replay checkpoint. Reclaim only whole sealed segments in the unreferenced prefix, preserving active tails and pending seals.
- Reuse committed truncation floors and generation-guarded deletion tombstones, including deletion retries when a zone returns. Wake rotation after collection frees capacity.
- Apply nonzero `min_age` to GCS object modification time (`update_time`), matching SlateDB's native object-age semantics. Every existing replica must be strictly older than the cutoff, including repaired/replaced copies. Unknown/invalid/future timestamps and failed zone listings defer new truncation; zero disables the age gate and permits degraded-zone truncation. Restarts and referenced observations do not reset object age. Dry runs use the same checks without changing storage; previously authorized tombstone cleanup may continue independently.

## Scope and limitations

- Ordinary `Db::get` / `Db::scan` work. Separate live WAL readers, `WalAdmin`, and WAL-based cloning are intentionally out of scope.
- GC currently requires an open Db sharing the initializer; separate-process/offline GC is unsupported.
- Interior gaps between retained ranges are not reclaimed. Long retention, a long minimum age, or unavailable zones can still fill the bounded manifest directory.
- Do not switch a database with an existing native WAL merely by changing the builder option. Upstream does not persist/validate the custom backend identity. Do not run Chorus recovery/maintenance CLI commands against a live database; they fence it.
- SlateDB is not compiled with the feature disabled, but Cargo still resolves optional dependencies, so the temporary git pin can require GitHub access even for feature-off dependency resolution.
- No live-cloud validation or new protocol-model proof is claimed.

## Verification

- [x] `cargo test --workspace --all-features --quiet` — full workspace, including deterministic simulations and doc tests
- [x] `cargo test -p chorus-client --no-default-features --quiet` — 136 client unit tests, public integration tests, and doc test
- [x] `cargo test -p chorus-client --features slatedb --test slatedb_integration -- --nocapture` — exported API with only the SlateDB feature enabled
- [x] Public integration tests repeated **20 times** with all features enabled
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`

The feature adds 29 unit tests plus two external integration tests. Coverage includes atomic replay, L0 resume, stale writer rejection, quorum-only durability, terminal failures, corrupt records, callback reentrancy, retained checkpoints predating startup replay, object-age/dry-run semantics across fresh initializers, repaired replicas, missing/invalid/future timestamps, age checks with unavailable zones, scheduled GC during live writes, deletion retries, and bounded physical history across more than one directory of rotations. The full client suite has 165 unit tests with all features enabled.

The external tests use real SlateDB with only Chorus's public API over loopback fake-GCS servers. They compare mixed writes, overwrites, deletes, point reads, and full/range scans with a reference model across physical GC and fresh-client reopens, and exercise writer takeover while a zone is unavailable. The CI regression now verifies that the exact floor-authorized objects disappear from every zone, rather than comparing different zones' object counts; it also exercises asymmetric provisioning/finalization latency. **These are fake-GCS tests, not live-GCS tests.**

## Before marking ready

- [ ] Replace the git pin with a stable SlateDB release containing the pluggable-WAL API.
- [ ] Revalidate fencing, durability, recovery, and GC contracts against that release and rerun the tests.
