### PR TITLE
Reduce recovery quorum-selection memory usage

### DIFF
--- a/rust/client/src/grpc.rs
+++ b/rust/client/src/grpc.rs
@@ -60,6 +60,17 @@ pub struct GrpcReplicaFactory {
     routing_token: RoutingToken,
 }
 
+#[cfg(test)]
+impl GrpcReplicaFactory {
+    // The in-process fake returns an entire object in one read response.
+    // Large manual recovery fixtures need a higher limit than real GCS's
+    // chunked responses; production channels keep the default message limit.
+    pub(crate) fn with_test_read_message_limit(mut self, limit: usize) -> Self {
+        self.client = self.client.max_decoding_message_size(limit);
+        self
+    }
+}
+
 /// A live appendable write stream: an ordered request sender plus a
 /// background reader translating flush acknowledgments into a watchable
 /// durable tail. Send-ahead lanes write through `tx` while waiting on

--- a/rust/client/src/grpc_internal_tests/recovery.rs
+++ b/rust/client/src/grpc_internal_tests/recovery.rs
@@ -1,5 +1,105 @@
 use super::*;
 
+/// Run alone in an optimized test binary under a peak-RSS profiler. The fake
+/// servers live in this process, so their storage and gRPC buffers count too;
+/// compare identical fixtures/binaries, not this RSS with the WAL byte budget.
+/// Set CHORUS_RECOVERY_PROFILE_MIB to change the per-replica segment size.
+#[tokio::test]
+#[ignore = "manual full-segment recovery memory profile"]
+async fn seal_recovery_memory_profile() {
+    use crate::metrics::Metrics;
+    use crate::protocol::{digest_bytes, protocol_metadata, QuorumVolume};
+    use chorus_fake_gcs::proto;
+
+    let mib: usize = std::env::var("CHORUS_RECOVERY_PROFILE_MIB")
+        .unwrap_or_else(|_| "64".into())
+        .parse()
+        .unwrap();
+    assert!((1..=256).contains(&mib));
+    let framed = record(&vec![0x5a; 4092]).encode().unwrap();
+    let records = mib * 1024 * 1024 / framed.len();
+    let mut bytes = Vec::with_capacity(records * framed.len());
+    for _ in 0..records {
+        bytes.extend_from_slice(&framed);
+    }
+    let data = bytes::Bytes::from(bytes);
+    let expected_digest = digest_bytes(&data);
+    let expected_crc32c = crc32c::crc32c(&data);
+    let mut servers = Vec::new();
+    let mut factories = Vec::new();
+    for zone in 0..3 {
+        let server = FakeGcs::default().start().await.unwrap();
+        let factory = GrpcReplicaFactory::connect(
+            zone,
+            &server.endpoint,
+            format!("projects/_/buckets/zone-{zone}"),
+            None,
+        )
+        .await
+        .unwrap()
+        .with_test_read_message_limit(data.len() + 1024);
+        servers.push(server);
+        factories.push(factory);
+    }
+    let object = "seal-recovery-memory/segment";
+    // Seed finalized objects without retaining a writer or timing population.
+    // Recovery still takes the actual gRPC snapshot and canonical-selection
+    // paths, followed by committed-seal enforcement and its verification reads.
+    for (zone, server) in servers.iter().take(3).enumerate() {
+        server
+            .service
+            .sim_write_object(proto::WriteObjectRequest {
+                first_message: Some(proto::write_object_request::FirstMessage::WriteObjectSpec(
+                    proto::WriteObjectSpec {
+                        resource: Some(proto::Object {
+                            bucket: format!("projects/_/buckets/zone-{zone}"),
+                            name: object.into(),
+                            metadata: protocol_metadata(),
+                            ..Default::default()
+                        }),
+                        if_generation_match: Some(0),
+                        ..Default::default()
+                    },
+                )),
+                data: Some(proto::write_object_request::Data::ChecksummedData(
+                    proto::ChecksummedData {
+                        content: data.to_vec(),
+                        crc32c: Some(expected_crc32c),
+                    },
+                )),
+                finish_write: true,
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+    }
+    drop(data);
+    let volume = QuorumVolume::with_metadata(
+        factories
+            .iter()
+            .map(|factory| factory.replica(object))
+            .collect(),
+        test_config(),
+        protocol_metadata(),
+        Arc::new(Metrics::new(&crate::NoopMetricsRecorder, 3)),
+    )
+    .unwrap();
+    let start = std::time::Instant::now();
+    let recovered = volume.recover_for_seal(Some(records)).await.unwrap();
+    assert_eq!(recovered.digest(), expected_digest);
+    assert_eq!(recovered.crc32c(), expected_crc32c);
+    assert_eq!(recovered.canonical().len(), records);
+    assert!(!recovered.had_discarded_suffix());
+    volume.enforce_seal(recovered.canonical()).await.unwrap();
+    for server in servers.iter().take(3) {
+        assert!(server.service.operation_count(Operation::Read).await >= 2);
+    }
+    eprintln!(
+        "seal recovery: replicas=3 segment_mib={mib} records={records} elapsed={:?}",
+        start.elapsed()
+    );
+}
+
 #[tokio::test]
 async fn recovery_does_not_promote_a_tail_below_the_second_largest_size() {
     let (servers, factories, manifest_factory) = factory_cluster().await;

--- a/rust/client/src/protocol.rs
+++ b/rust/client/src/protocol.rs
@@ -211,7 +211,7 @@ impl SealReport {
     }
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Debug, Default)]
 pub(crate) struct CanonicalPrefix {
     bytes: Vec<u8>,
     records: Vec<RecordFrame>,
@@ -1128,7 +1128,7 @@ impl QuorumVolume {
             metadata: self.metadata.clone(),
             bytes: Vec::new(),
         }));
-        let (mut canonical, _) = select_canonical_quorum(&recovery_snapshots, self.quorum())?;
+        let mut canonical = select_canonical_quorum(&recovery_snapshots, self.quorum())?;
         let had_discarded_suffix = max_observed_size > canonical.bytes.len();
         if let Some(expected) = expected_records {
             if canonical.len() < expected {
@@ -2571,7 +2571,7 @@ pub(crate) fn canonical_prefix(
     snapshots: &[ReplicaSnapshot],
     quorum: usize,
 ) -> Result<Vec<RecordFrame>, ProtocolError> {
-    select_canonical_quorum(snapshots, quorum).map(|(prefix, _)| prefix.into_records())
+    select_canonical_quorum(snapshots, quorum).map(CanonicalPrefix::into_records)
 }
 
 /// Ascending index combinations of size `quorum` out of `count` snapshots,
@@ -2608,11 +2608,11 @@ fn quorum_subsets(count: usize, quorum: usize) -> Vec<Vec<usize>> {
 fn select_canonical_quorum(
     snapshots: &[ReplicaSnapshot],
     quorum: usize,
-) -> Result<(CanonicalPrefix, Vec<ReplicaSnapshot>), ProtocolError> {
+) -> Result<CanonicalPrefix, ProtocolError> {
     if snapshots.len() < quorum {
         return Err(ProtocolError::NoQuorum);
     }
-    let decoded: Vec<_> = snapshots
+    let mut decoded: Vec<_> = snapshots
         .iter()
         .map(CanonicalPrefix::from_snapshot)
         .collect();
@@ -2646,47 +2646,46 @@ fn select_canonical_quorum(
                 longest_member = member;
             }
         }
-        candidates.push((
-            decoded[longest_member].clone(),
-            subset
-                .iter()
-                .map(|&member| snapshots[member].clone())
-                .collect::<Vec<_>>(),
-        ));
+        // Candidates only identify existing buffers. Cloning a canonical
+        // prefix and every witness here duplicates whole segments for each
+        // quorum combination, although callers only need the selected prefix.
+        candidates.push((longest_member, subset));
     }
     let longest = candidates
         .iter()
-        .map(|(candidate, _)| candidate.len())
+        .map(|&(candidate, _)| decoded[candidate].len())
         .max()
         .ok_or(ProtocolError::ConflictingPrefix {
             record_index: first_conflict.unwrap_or(0),
         })?;
     let mut longest_candidates = candidates
         .into_iter()
-        .filter(|(candidate, _)| candidate.len() == longest);
+        .filter(|&(candidate, _)| decoded[candidate].len() == longest);
     let first = longest_candidates
         .next()
         .expect("longest length came from a candidate");
     let mut equivalent = vec![first];
     for candidate in longest_candidates {
-        if candidate.0.bytes != equivalent[0].0.bytes {
-            let record_index = (0..candidate.0.len())
-                .find(|index| {
-                    candidate.0.record_bytes(*index) != equivalent[0].0.record_bytes(*index)
-                })
+        let other = &decoded[candidate.0];
+        let first = &decoded[equivalent[0].0];
+        if other.bytes != first.bytes {
+            let record_index = (0..other.len())
+                .find(|index| other.record_bytes(*index) != first.record_bytes(*index))
                 .unwrap_or(0);
             return Err(ProtocolError::ConflictingPrefix { record_index });
         }
         equivalent.push(candidate);
     }
-    Ok(equivalent
+    let (selected, _) = equivalent
         .into_iter()
         .max_by(|(_, left_witnesses), (_, right_witnesses)| {
-            let left_zones: Vec<_> = left_witnesses.iter().map(|copy| copy.zone).collect();
-            let right_zones: Vec<_> = right_witnesses.iter().map(|copy| copy.zone).collect();
-            right_zones.cmp(&left_zones)
+            let left_zones = left_witnesses.iter().map(|&index| snapshots[index].zone);
+            let right_zones = right_witnesses.iter().map(|&index| snapshots[index].zone);
+            right_zones.cmp(left_zones)
         })
-        .expect("at least one equivalent candidate remains"))
+        .expect("at least one equivalent candidate remains");
+    // Move the winner once; all other decoded prefixes are released here.
+    Ok(decoded.swap_remove(selected))
 }
 
 pub(crate) fn protocol_metadata() -> HashMap<String, String> {
@@ -3412,6 +3411,108 @@ mod tests {
             canonical_prefix(&snapshots, 3).unwrap(),
             vec![first, second]
         );
+    }
+
+    #[test]
+    fn canonical_selection_matches_record_level_reference() {
+        // Deliberately compare decoded records rather than the production
+        // byte-range conflict table and candidate representation. Exhaustive
+        // assignments cover minority divergence, ambiguous maximal candidates,
+        // compatible shorter candidates, missing witnesses and truncated tails.
+        fn reference(
+            snapshots: &[ReplicaSnapshot],
+            quorum: usize,
+        ) -> Result<Vec<RecordFrame>, ProtocolError> {
+            if snapshots.len() < quorum {
+                return Err(ProtocolError::NoQuorum);
+            }
+            let records: Vec<_> = snapshots
+                .iter()
+                .map(|copy| RecordFrame::decode_complete_prefix(&copy.bytes).0)
+                .collect();
+            let conflict = |left: usize, right: usize| {
+                records[left]
+                    .iter()
+                    .zip(&records[right])
+                    .position(|(left, right)| left != right)
+            };
+            let first_conflict = (0..records.len())
+                .find_map(|left| (left + 1..records.len()).find_map(|right| conflict(left, right)));
+            let mut candidates = Vec::new();
+            for subset in quorum_subsets(records.len(), quorum) {
+                if subset.iter().enumerate().all(|(position, &left)| {
+                    subset[position + 1..]
+                        .iter()
+                        .all(|&right| conflict(left, right).is_none())
+                }) {
+                    let longest = subset
+                        .into_iter()
+                        .max_by_key(|&member| records[member].len())
+                        .unwrap();
+                    candidates.push(longest);
+                }
+            }
+            let longest = candidates
+                .iter()
+                .map(|&member| records[member].len())
+                .max()
+                .ok_or(ProtocolError::ConflictingPrefix {
+                    record_index: first_conflict.unwrap_or(0),
+                })?;
+            let mut maximal = candidates
+                .into_iter()
+                .filter(|&member| records[member].len() == longest);
+            let first = maximal.next().unwrap();
+            for other in maximal {
+                if let Some(record_index) = conflict(first, other) {
+                    return Err(ProtocolError::ConflictingPrefix { record_index });
+                }
+            }
+            Ok(records[first].clone())
+        }
+
+        let a = record(b"a");
+        let b = record(b"b");
+        let mut partial = encode_records(&[a.clone(), b.clone()]).unwrap();
+        partial.pop();
+        let mut malformed = encode_records(std::slice::from_ref(&a)).unwrap();
+        malformed.extend_from_slice(&[0, 0, 0, 3]);
+        let variants = [
+            Vec::new(),
+            encode_records(&[record(b"")]).unwrap(),
+            encode_records(std::slice::from_ref(&a)).unwrap(),
+            encode_records(std::slice::from_ref(&b)).unwrap(),
+            encode_records(&[a.clone(), a.clone()]).unwrap(),
+            encode_records(&[a.clone(), b.clone()]).unwrap(),
+            encode_records(&[b, a]).unwrap(),
+            partial,
+            malformed,
+        ];
+        let zones = [4, 0, 3, 1, 2];
+        for width in [1usize, 3, 5] {
+            let quorum = majority(width);
+            for readable in 0..=width {
+                for assignment in 0..variants.len().pow(readable as u32) {
+                    let mut remaining = assignment;
+                    let snapshots: Vec<_> = zones[..readable]
+                        .iter()
+                        .map(|&zone| {
+                            let bytes = variants[remaining % variants.len()].clone();
+                            remaining /= variants.len();
+                            ReplicaSnapshot {
+                                bytes,
+                                ..snapshot(zone, &[])
+                            }
+                        })
+                        .collect();
+                    assert_eq!(
+                        canonical_prefix(&snapshots, quorum).map_err(|error| error.to_string()),
+                        reference(&snapshots, quorum).map_err(|error| error.to_string()),
+                        "width={width} readable={readable} assignment={assignment}"
+                    );
+                }
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Remove whole-segment buffer duplication during recovery quorum selection. Candidate quorums now hold indices into existing buffers, and the winning canonical prefix is moved out once. Both callers discarded the returned witness copies, so those copies and the unused return value are removed.

The quorum/conflict rules, deterministic tie-break, fencing, public API, wire format, and queue/window behavior are unchanged. This PR is independent of the window experiment. Full-segment reads remain; this is not a streaming-recovery or total-memory-bound change.

## Verification

- 171 workspace tests passed; strict Clippy and formatting passed.
- Record-level reference matched 67,260 assignments across 1/3/5 replicas, missing witnesses, divergence and malformed tails.
- 100 seeds × 1,000 DST steps passed. Branch-built PObserve accepted all 100 traces; the final 118,119-event trace passed structural validation.
- Twelve paired local forced-recovery profiles passed. Median whole-process peak RSS:

| Per-replica segment | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| 64 MiB | 1,556.84 MiB | 978.44 MiB | 37.15% |
| 256 MiB | 6,181.42 MiB | 3,866.98 MiB | 37.44% |

The local fixture includes in-process fake GCS storage and gRPC buffers, so these absolute figures are not production-client RSS estimates. Its larger decoding limit is test-only; production transport settings are untouched. The large fixture is ignored in normal test runs and can be run explicitly under a memory profiler.

## Review

- Self-review: no actionable findings; checked caller behavior, conflict/error ordering, witness tie-breaking, ownership/drop behavior and test-only transport configuration.
- Fable through Claude Code (`claude-fable-5`): independent read-only source review completed with **no actionable findings**. It checked selection/error equivalence, witness-zone tie-breaking, ownership/drop behavior, reference-test fidelity and test-only limits; it did not independently rerun the tests.

## CI follow-up

The first CI attempt hit the unchanged append benchmark harness's 30-second child-process timeout. No source or timeout changes were made: the exact debug command `cargo test --workspace --all-features` passed locally (171 tests), both debug benchmark tests passed 20 consecutive paired repetitions (40 test executions), and the same-commit CI rerun passed both the Rust/DST job and the 1,000-schedule P semantic gate. The cause of the initial stall was not established; it is not claimed fixed by this PR.
