### PR TITLE
Add pluggable WAL archival

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,29 +1,52 @@
+FROM eclipse-temurin:11-jdk-jammy AS verifier
+
+# The published v0.9.5 zip predates PVerifier's datatype and -M support.
+# Build immutable source revisions and use matching Java/native Z3 bindings.
+ARG UCLID_COMMIT=a4e4e7a22780833c86d6a650af2fcf88a7d00a06
+ARG Z3_COMMIT=e417f7d78509b2d0c9ebc911fee7632e6ef546b6
+ARG SBT_LAUNCH_SHA256=6581531c0188aef375b1a80eca877643d9fcae316299e0a67761d4c0ad7473e2
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential ca-certificates curl git python3 unzip \
+    && rm -rf /var/lib/apt/lists/*
+RUN git init /tmp/z3 \
+    && git -C /tmp/z3 fetch --depth 1 https://github.com/Z3Prover/z3.git "${Z3_COMMIT}" \
+    && git -C /tmp/z3 checkout --detach FETCH_HEAD \
+    && cd /tmp/z3 && python3 scripts/mk_make.py --java \
+    && cd build && make -j2 \
+    && mkdir /opt/z3 \
+    && cp z3 libz3.so libz3java.so com.microsoft.z3.jar /opt/z3/
+RUN git init /tmp/uclid \
+    && git -C /tmp/uclid fetch --depth 1 https://github.com/uclid-org/uclid.git "${UCLID_COMMIT}" \
+    && git -C /tmp/uclid checkout --detach FETCH_HEAD \
+    && cp /opt/z3/com.microsoft.z3.jar /tmp/uclid/lib/com.microsoft.z3.jar \
+    && curl -fL --retry 5 -o /tmp/sbt-launch.jar \
+       https://repo.maven.apache.org/maven2/org/scala-sbt/sbt-launch/1.4.9/sbt-launch-1.4.9.jar \
+    && echo "${SBT_LAUNCH_SHA256}  /tmp/sbt-launch.jar" | sha256sum --check \
+    && cd /tmp/uclid && java -jar /tmp/sbt-launch.jar universal:packageBin \
+    && unzip -q target/universal/uclid-0.9.5.zip -d /opt \
+    && mv /opt/uclid-0.9.5 /opt/uclid
+
 FROM mcr.microsoft.com/dotnet/sdk:8.0-jammy
 
 ARG P_VERSION=3.1.0
-ARG UCLID_VERSION=0.9.5
-ARG UCLID_SHA256=57dfe2eebbbd9111d9cbf87dc2d8ce4d11a3f2390c5a97f2ba5217d5ac8aa23a
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
        build-essential ca-certificates curl jq maven openjdk-17-jdk-headless pkg-config \
-       python3 unzip z3 \
+       python3 unzip \
     && rm -rf /var/lib/apt/lists/*
 
 RUN dotnet tool install --tool-path /opt/p-tools P --version "${P_VERSION}"
 
-RUN curl -L --fail --retry 5 \
-      -o /tmp/uclid.zip \
-      "https://github.com/uclid-org/uclid/releases/download/v${UCLID_VERSION}/uclid-${UCLID_VERSION}.zip" \
-    && echo "${UCLID_SHA256}  /tmp/uclid.zip" | sha256sum --check \
-    && unzip -q /tmp/uclid.zip -d /opt \
-    && mv "/opt/uclid-${UCLID_VERSION}" /opt/uclid \
-    && rm /tmp/uclid.zip
+COPY --from=verifier /opt/uclid /opt/uclid
+COPY --from=verifier /opt/z3 /opt/z3
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
       | sh -s -- -y --profile minimal --default-toolchain none
 
-ENV PATH=/root/.cargo/bin:/opt/p-tools:/opt/uclid/bin:${PATH}
+ENV PATH=/root/.cargo/bin:/opt/p-tools:/opt/uclid/bin:/opt/z3:${PATH}
+ENV LD_LIBRARY_PATH=/opt/z3
+ENV JAVA_OPTS=-Djava.library.path=/opt/z3
 WORKDIR /workspace
 
 # rust-toolchain.toml is the one toolchain pin, shared with CI and local
@@ -34,7 +57,7 @@ RUN rustup toolchain install
 COPY . .
 RUN p --version \
     && z3 --version \
-    && uclid 2>&1 | grep -q 'uclid 0.9.5' \
+    && uclid --help 2>&1 | grep -q 'mod-set-analysis' \
     && cargo fetch --manifest-path rust/Cargo.toml \
     && mvn -q -f p/pobserve/pom.xml dependency:go-offline \
     && cd p \

--- a/docker/scripts/check_archive_proof.py
+++ b/docker/scripts/check_archive_proof.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Check the archive proof and require unsafe mutations to be rejected."""
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+
+import orchestrate
+
+
+def main() -> None:
+    environment = (os.environ.copy() if "CHORUS_UCLID_REAL" in os.environ
+                   else orchestrate._verification_environment())
+    source = (orchestrate.P_ROOT / "proof/ArchiveProof.p").read_text()
+    cases = [
+        ("safe", source, True, ""),
+        ("delete_before_publish", source.replace(
+            "if (deletedEnd < archiveEnd)", "if (deletedEnd < sealedEnd)"), False, "archive_prefix_order"),
+        ("publish_before_index", source.replace(
+            "proposalParent == archiveEnd && proposalEnd <= indexedEnd",
+            "proposalParent == archiveEnd"), False, "archive_prefix_order"),
+        ("refresh_recovery_root", source.replace(
+            "recoveryPhase = 2;", "recoveryArchiveEnd = archiveEnd; recoveryPhase = 2;"),
+         False, "archive_recovery_snapshot_join"),
+    ]
+    if "--mutations-only" in sys.argv:
+        cases = cases[1:]
+    for name, model, expected, failed_invariant in cases:
+        if not expected and model == source:
+            raise RuntimeError(f"{name}: mutation no longer matches source")
+        with tempfile.TemporaryDirectory(prefix=f"chorus-proof-{name}.") as temporary:
+            directory = Path(temporary)
+            (directory / "ArchiveProof.p").write_text(model)
+            (directory / "Check.pproj").write_text(
+                '<Project><ProjectName>ArchiveCheck</ProjectName><InputFiles>'
+                '<PFile>./ArchiveProof.p</PFile></InputFiles>'
+                '<OutputDir>./generated/</OutputDir><Target>PVerifier</Target></Project>')
+            result = subprocess.run(
+                ["p", "compile", "-pp", "Check.pproj", "-md", "verification"],
+                cwd=directory, env=environment, text=True, capture_output=True,
+            )
+            output = result.stdout + result.stderr
+            valid = (result.returncode == 0 and "Verified 14 invariants!" in output
+                     and "Failed to verify" not in output
+                     if expected else
+                     f"❌ Failed to verify invariant archive_transfer_inductive_{failed_invariant}" in output)
+            if not valid:
+                raise RuntimeError(f"{name}: unexpected verifier result\n{output}")
+            print(f"{name}: {'proved' if expected else 'rejected as expected'}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/docker/scripts/check_manifest_field_parity.py
+++ b/docker/scripts/check_manifest_field_parity.py
@@ -27,6 +27,7 @@ FIELD_GROUPS = (
     ("sealed directory", {"segments"}, {"directory"}),
     ("pending segment", {"pending_id"}, {"pending"}),
     ("deployment topology", {"buckets"}, set()),
+    ("archive binding root and cleanup", {"archive"}, {"archive"}),
 )
 
 

--- a/docker/scripts/orchestrate.py
+++ b/docker/scripts/orchestrate.py
@@ -278,16 +278,30 @@ def _pobserve_regressions(jar: Path) -> None:
 
 def _verification_environment() -> dict[str, str]:
     environment = os.environ.copy()
-    if shutil.which("uclid", path=environment.get("PATH")):
-        return environment
-
+    executable = shutil.which("uclid", path=environment.get("PATH"))
     fallback = Path("/tmp/chorus-uclid/uclid-0.9.5/bin/uclid")
-    if fallback.is_file() and os.access(fallback, os.X_OK):
-        environment["PATH"] = (
-            f"{fallback.parent}{os.pathsep}{environment.get('PATH', '')}"
-        )
-        return environment
-    raise OrchestrationError("uclid 0.9.5 is required for PVerifier")
+    if executable is None and fallback.is_file() and os.access(fallback, os.X_OK):
+        executable = str(fallback)
+    if executable is None:
+        raise OrchestrationError("a PVerifier-compatible UCLID build is required")
+    wrapper_directory = Path(tempfile.mkdtemp(prefix="chorus-checked-uclid."))
+    (wrapper_directory / "uclid").symlink_to(ROOT / "docker/scripts/uclid_checked.py")
+    environment["CHORUS_UCLID_REAL"] = executable
+    environment["PATH"] = f"{wrapper_directory}{os.pathsep}{environment.get('PATH', '')}"
+    return environment
+
+
+def _prove(project: str, environment: dict[str, str], expected: int) -> None:
+    result = subprocess.run(
+        ("p", "compile", "-pp", project, "-md", "verification"),
+        cwd=P_ROOT, env=environment, text=True, capture_output=True,
+    )
+    output = result.stdout + result.stderr
+    print(output, end="", flush=True)
+    # P 3.1 exits zero even when individual invariants fail.
+    if (result.returncode or "Failed to verify" in output or
+            f"Verified {expected} invariants!" not in output):
+        raise OrchestrationError(f"{project}: proof obligations were not all verified")
 
 
 def _parse_model_test_cases(output: str) -> tuple[str, ...]:
@@ -426,8 +440,10 @@ def verify(*, quick: bool) -> int:
         os.close(descriptor)
         Path(temporary_name).unlink()
         shutil.move(verifier_cache, temporary_name)
+    _prove("QuorumProof.pproj", environment, 41)
+    _prove("ArchiveProof.pproj", environment, 14)
     _run(
-        ("p", "compile", "-pp", "QuorumProof.pproj", "-md", "verification"),
+        (sys.executable, ROOT / "docker/scripts/check_archive_proof.py", "--mutations-only"),
         cwd=P_ROOT,
         env=environment,
     )

--- a/docker/scripts/test_orchestrate.py
+++ b/docker/scripts/test_orchestrate.py
@@ -1,11 +1,27 @@
 #!/usr/bin/env python3
 
 import unittest
+from unittest.mock import patch
+from subprocess import CompletedProcess
 
 import orchestrate
+import uclid_checked
 
 
 class ModelTestCaseParsingTests(unittest.TestCase):
+    def test_zero_exit_failed_proof_is_rejected(self) -> None:
+        with patch("orchestrate.subprocess.run", return_value=CompletedProcess(
+                [], 0, "Verified 7 invariants!\nFailed to verify 3 properties!", "")):
+            with self.assertRaises(orchestrate.OrchestrationError):
+                orchestrate._prove("ArchiveProof.pproj", {}, 14)
+
+    def test_verifier_requires_actual_obligations(self) -> None:
+        self.assertFalse(uclid_checked.has_verification_results("Error: Unknown option -M"))
+        self.assertFalse(uclid_checked.has_verification_results("Syntax error"))
+        self.assertFalse(uclid_checked.has_verification_results("0 assertions passed.\n0 assertions failed.\n0 assertions indeterminate."))
+        self.assertTrue(uclid_checked.has_verification_results("9 assertions passed.\n0 assertions failed.\n0 assertions indeterminate."))
+        self.assertTrue(uclid_checked.has_verification_results("8 assertions passed.\n1 assertions failed.\n0 assertions indeterminate."))
+
     def test_extracts_only_the_reported_test_cases(self) -> None:
         output = """\
 .. List of test cases:

--- a/docker/scripts/uclid_checked.py
+++ b/docker/scripts/uclid_checked.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Fail closed when UCLID does not actually execute verification obligations."""
+
+import os
+import re
+import subprocess
+import sys
+
+
+def has_verification_results(output: str) -> bool:
+    counts = [re.findall(rf"(\d+) assertions {kind}\.", output)
+              for kind in ("passed", "failed", "indeterminate")]
+    return all(len(values) == 1 for values in counts) and sum(
+        int(values[0]) for values in counts
+    ) > 0
+
+
+def main() -> int:
+    real = os.environ["CHORUS_UCLID_REAL"]
+    environment = os.environ.copy()
+    if "CHORUS_UCLID_JAVA_HOME" in environment:
+        environment["JAVA_HOME"] = environment["CHORUS_UCLID_JAVA_HOME"]
+    # P's nested records require UCLID's Z3 Java interface.
+    result = subprocess.run(
+        [real, *sys.argv[1:]],
+        text=True, capture_output=True, env=environment,
+    )
+    print(result.stdout, end="")
+    print(result.stderr, end="", file=sys.stderr)
+    if result.returncode or not has_verification_results(result.stdout):
+        print("UCLID did not produce a complete verification result", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/p/ARCHIVE_SAFETY.md
+++ b/p/ARCHIVE_SAFETY.md
@@ -1,0 +1,157 @@
+# WAL archival safety
+
+## Storage and publication
+
+The live `ManifestStore` remains a linearizable, bounded CAS register. It holds
+the writer epoch, current/pending segment names, newest seal, checkpoint floor,
+hot directory, and one archive root. `ArchiveStore` holds both canonical sealed
+WAL bytes and immutable catalog pages. Its contract requires complete atomic
+publication, durability, immediate readability, and idempotence for identical
+content. A lost response can leave an object durable without publishing it.
+
+The catalog is a sequence-ordered copy-on-write B+ tree with fanout 32, pages
+bounded at 64 KiB, and bounded-height traversal. References include range,
+height, exact byte length, and SHA-256. Append copies only the rightmost path;
+seek reads one path. Old roots remain valid while readers hold them. There is
+no whole-history read/rewrite, bucket listing, or mutable linked-list traversal
+on the archive lookup path. Superseded and orphaned pages are currently retained.
+
+One archival step does the following:
+
+1. Read the oldest hot descriptor and its exclusive end from the next entry.
+   It must precede the current seal, whose finalization witness stays hot.
+2. Read and verify canonical sealed bytes and conditionally upload them.
+3. Prepare and durably upload the new immutable catalog path.
+4. In one manifest CAS, publish that root and remove that exact descriptor.
+   Retry against the latest manifest, preserving concurrent checkpoint/epoch
+   updates and rechecking the expected parent, segment ID, bounds, and checksum.
+5. Delete redundant zonal copies with generation guards. Advance the bounded
+   cleanup cursor only after every zone confirms absence. An unavailable zone
+   holds this cursor, not a hot directory slot.
+
+Steps 2–3 alone never authorize deletion. Crashes before step 4 can leak archive
+objects but cannot lose hot history. Crashes after step 4 leave the published
+catalog as the durable cleanup work list. Stale readers that fail to read a hot
+segment refresh the manifest and resolve its exact archived identity. Missing
+or corrupt referenced data returns an error, never a skipped range.
+
+Startup recovery captures the archive root together with its adopted hot
+directory. Later recovery CAS retries may refresh the live manifest but must
+not replace that captured root: the newer root can contain segments still in
+the adopted hot directory, causing duplicate replay. The retained root and hot
+descriptors remain a disjoint replay catalog; descriptors whose zonal copies
+are subsequently deleted use the exact-identity archive fallback.
+
+`keep_sealed_segments` is a target count, with a minimum of one. Checkpointed
+predecessors may also move to the archive. A long archive outage can still fill
+the bounded directory and backpressure new writes; it never authorizes data
+loss. Archive availability and eventual successful CAS are liveness assumptions,
+not safety assumptions. Slow or stale repairers may leave redundant zonal
+copies for a later dead-segment sweep; those copies do not become authoritative.
+Once archival or truncation frees hot-directory capacity, refresh failures are
+retried with backoff so a lost notification cannot leave rotation permanently
+blocked. When archive passes overrun their period, maintenance alternates an
+overdue pass with a ready seal/truncate command so neither source of work can
+starve the other.
+
+## Compatibility and recovery
+
+Archive activation is writer-claimed and persists format 2, a stable backing
+namespace, and the then-current truncation floor. Old clients reject format 2;
+opens without that namespace fail. Format 1 volumes retain existing behavior.
+Records below the activation floor are not promised. Truncation after activation
+does not delete promised history. Writer startup still requires a current
+database checkpoint; historical PITR replay uses a readonly stream and a
+separate application restore. WAL retention does not itself provide database
+snapshots or a timestamp-to-sequence mapping.
+
+Readers lazily seek catalog pages but verify one complete segment before
+exposing its records. Dropping a follower cancels its owned poller/read work;
+no registration or explicit upper-bound API is required. Startup recovery must
+still be fully consumed before starting a writer.
+
+## Machine-checked argument
+
+`model/Archive.p` composes with the actual P `ManifestRegister`. It bounds the
+history to eight one-record seals and explores two independently cached worker
+proposals, immutable pages, lost requests/responses, publication CAS races,
+worker crashes, per-zone deletion, checkpoint/epoch changes, stale readers, and
+early stream drops. Assertions check canonical contiguous history, the hot/archive
+join, preservation of the newest seal, durable recovery sources, and reader prefixes.
+The existing quorum model supplies the canonical-byte/finalization premise.
+
+`model/ArchiveRecovery.p` separately exercises a recovery snapshot, archival
+publication and deletion, and a conflicting recovery CAS followed by refresh.
+It traverses the captured archive pages and hot descriptors independently and
+checks every emitted sequence number and the complete replay range, including
+archive fallback for deleted hot copies. It covers empty/existing roots and
+nonzero checkpoints. Substituting the refreshed root reproduces duplicate
+replay and fails the ordering assertion.
+
+`proof/ArchiveProof.p` proves an inductive invariant over unbounded integer
+prefix boundaries. Writing `D`, `A`, `I`, `U`, `F`, and `S` for deletion,
+publication, indexing, upload, finalization, and sealing boundaries:
+
+```
+0 <= D <= A <= I <= U <= F < S
+hot_start = A
+```
+
+These inequalities imply that any evicted sealed record has durable indexed
+archive bytes, the current seal remains hot, and checkpoint advancement alone
+cannot authorize eviction. Auxiliary invariants establish CAS proposal bounds,
+monotone versions, a bounded reader cursor, and no delivery after drop. Recovery
+invariants additionally keep the adopted archive/hot boundary fixed while the
+live manifest advances, then establish ordered concatenation and completion
+of its captured replay range. The
+proof is of this reduced transfer protocol under the store/quorum premises,
+not a formal refinement proof of Rust, gRPC, GCS, cryptography, or the B+ tree.
+Rust regression tests cover the concrete tree and storage implementations.
+The existing DST/PObserve gates exercise the quorum protocol; archive-specific
+behavior is covered by the P archive driver and Rust archival tests, not by
+archive events in the production DST trace.
+
+## Reproducing checks
+
+From the repository root, with P, Java, a compatible UCLID build and its native
+Z3 bindings installed:
+
+```sh
+python3 docker/scripts/check_archive_proof.py
+cd p
+p compile -pp QuorumModel.pproj
+python3 ../docker/scripts/orchestrate.py check-model --schedules 1000 --max-steps 10000
+cd ../rust
+cargo test -p chorus-client archive_ --lib
+```
+
+The archive proof checker uses fresh temporary outputs and checks both the
+correct protocol and mutations permitting premature deletion/publication or
+replacing an adopted recovery root after refresh. The correct model must prove
+all thirteen named invariants plus P's default obligations. The first two
+mutations must fail the prefix-order invariant; the last must fail the
+recovery snapshot-join invariant.
+
+Do not rely on the historical UCLID `v0.9.5` release zip: it lacks the `-M`
+option and algebraic data types needed by P 3.1.0. P can misinterpret its
+zero-exit usage message as successful verification. The checked wrapper
+requires nonempty assertion results and the verification workflow discards
+old cached results. It also checks P's reported invariant results because P
+can exit zero after reporting failed invariants. The source build used for these
+checks is UCLID commit
+`a4e4e7a22780833c86d6a650af2fcf88a7d00a06` with Z3 4.12.2 Java/native bindings.
+See the [PVerifier installation instructions](https://p-org.github.io/P/advanced/PVerifierLanguageExtensions/install-pverifier/)
+for the source-build dependency requirements.
+
+Validation for this change passed the full Rust workspace tests and strict
+Clippy checks; all 21 P model cases at 1,000 schedules each; the quick DST and
+PObserve verification gates; all 41 existing quorum invariants and 14 archive
+invariants/obligations; and all three deliberately unsafe archive proof mutations.
+The ten archival tests include a multi-level catalog, response-loss retries,
+publication races, unavailable archive/zonal storage, stale readers, recovery,
+automatic hot-directory pressure relief, and the regional GCS adapters against
+the fake gRPC server. Both recovery-race regressions failed with duplicate
+sequence numbers before the fix and passed afterward; the bounded P model's
+refreshed-root mutation also fails. Separate liveness regressions inject the
+first capacity refresh failure after truncation and keep the archive timer
+overdue while a command is queued. Live cloud GCS behavior was not exercised.

--- a/p/ArchiveProof.pproj
+++ b/p/ArchiveProof.pproj
@@ -1,7 +1,7 @@
 <Project>
-  <ProjectName>QuorumProof</ProjectName>
+  <ProjectName>ArchiveProof</ProjectName>
   <InputFiles>
-    <PFile>./proof/QuorumProof.p</PFile>
+    <PFile>./proof/ArchiveProof.p</PFile>
   </InputFiles>
   <OutputDir>./PVerifierGenerated/</OutputDir>
   <Target>PVerifier</Target>

--- a/p/model/Archive.p
+++ b/p/model/Archive.p
@@ -1,0 +1,191 @@
+// The existing quorum model establishes canonical sealed bytes and the
+// finalization gate. This composition models archival of those bytes through
+// the real ManifestRegister transitions. Eight one-record seals bound history;
+// two independently cached proposals represent competing/restarted workers.
+// Immutable pages stand for the transitive closure of a paged catalog root.
+type tArchiveProposal = (valid: bool, version: int, previous: int,
+    root: int, segmentEntry: tDirectoryEntry, end: int);
+event eArchiveStep;
+
+machine ArchiveLifecycle {
+    var manifest: ManifestRegister;
+    var view: tManifestRecord;
+    var version: int;
+    var proposals: seq[tArchiveProposal];
+    var durableData: set[int];
+    var pages: map[int, seq[int]];
+    var hotCopies: map[int, set[int]];
+    var finalized: set[int];
+    var readerSnapshot: tManifestRecord;
+    var readerNext: int;
+    var readerDropped: bool;
+    var emitted: seq[int];
+    var steps: int;
+
+    start state Running {
+        entry {
+            var response: tManifestCasResponse;
+            manifest = new ManifestRegister((failures=8,));
+            send manifest, eArchiveEnable, (caller=this,);
+            receive { case eManifestCasResponse: (r: tManifestCasResponse) { response = r; } }
+            view = response.rec;
+            version = response.metagen;
+            proposals += (0, default(tArchiveProposal));
+            proposals += (1, default(tArchiveProposal));
+            readerSnapshot = view;
+            send this, eArchiveStep;
+        }
+        on eArchiveStep do Step;
+    }
+
+    fun Refresh() {
+        var response: tManifestReadResponse;
+        send manifest, eManifestRead, (caller=this,);
+        receive { case eManifestReadResponse: (r: tManifestReadResponse) { response = r; } }
+        if (response.status == STATUS_OK) {
+            view = response.rec;
+            version = response.metagen;
+        }
+    }
+
+    fun Step() {
+        var op: int;
+        var slot: int;
+        var zone: int;
+        var index: int;
+        var next: tManifestRecord;
+        var proposal: tArchiveProposal;
+        var page: seq[int];
+        var copies: set[int];
+        var response: tManifestCasResponse;
+        var canRead: bool;
+        Refresh();
+        op = 0;
+        if ($) { op = op + 1; }
+        if ($) { op = op + 2; }
+        if ($) { op = op + 4; }
+        slot = 0;
+        if ($) { slot = 1; }
+        proposal = proposals[slot];
+        if (op == 0) {
+            if (view.tailBase < 8 && sizeof(view.directory) < 4) {
+                next = view;
+                if (next.sealId >= 0) { finalized += (next.sealId); }
+                copies = default(set[int]);
+                copies += (0); copies += (1); copies += (2);
+                hotCopies[view.tailBase] = copies;
+                next.directory += (sizeof(next.directory), (base=view.tailBase, id=100 + view.tailBase));
+                next.sealBase = view.tailBase;
+                next.sealId = 100 + view.tailBase;
+                next.tailBase = view.tailBase + 1;
+                next.sealEnd = next.tailBase;
+                next.sealSum = next.sealId;
+                send manifest, eManifestCas, (caller=this, expMetagen=version, rec=next);
+                receive { case eManifestCasResponse: (r: tManifestCasResponse) { response = r; } }
+            }
+        } else if (op == 1) {
+            if (sizeof(view.directory) >= 2) {
+                proposals[slot] = (valid=true, version=version,
+                    previous=view.archive.root, root=view.directory[1].base,
+                    segmentEntry=view.directory[0], end=view.directory[1].base);
+            }
+        } else if (op == 2) {
+            // Request loss leaves no data. Response loss can leave durable data
+            // without advancing the worker; a retry finds identical content.
+            if (proposal.valid && proposal.segmentEntry.id in finalized && $) {
+                durableData += (proposal.segmentEntry.base);
+            }
+        } else if (op == 3) {
+            if (proposal.valid && proposal.segmentEntry.base in durableData &&
+                (proposal.previous == 0 || proposal.previous in pages)) {
+                page = default(seq[int]);
+                if (proposal.previous != 0) { page = pages[proposal.previous]; }
+                page += (sizeof(page), proposal.segmentEntry.base);
+                if (proposal.root in pages) {
+                    assert pages[proposal.root] == page, "immutable catalog root overwritten";
+                } else if ($) { pages[proposal.root] = page; }
+            }
+        } else if (op == 4) {
+            if (proposal.valid && proposal.root in pages) {
+                send manifest, eArchivePublish, (caller=this,
+                    expMetagen=proposal.version, previous=proposal.previous,
+                    root=proposal.root, segmentEntry=proposal.segmentEntry, end=proposal.end);
+                receive { case eManifestCasResponse: (r: tManifestCasResponse) { response = r; } }
+                // A worker can crash after the CAS, including after a lost
+                // response. Durable data/pages/register are not rolled back.
+                if ($) { proposals[slot] = default(tArchiveProposal); }
+            }
+        } else if (op == 5) {
+            zone = 0;
+            if ($) { zone = 1; } else if ($) { zone = 2; }
+            index = 0;
+            while (index < view.archive.end) {
+                if (zone in hotCopies[index] && $) {
+                    assert view.archive.root in pages && index in durableData,
+                        "zonal deletion preceded durable archive publication";
+                    copies = hotCopies[index]; copies -= (zone); hotCopies[index] = copies;
+                    break;
+                }
+                index = index + 1;
+            }
+        } else if (op == 6) {
+            if ($) { readerSnapshot = view; }
+            if (!readerDropped && readerNext < readerSnapshot.tailBase) {
+                canRead = sizeof(hotCopies[readerNext]) > 0;
+                if (!canRead && view.archive.root in pages &&
+                    readerNext < view.archive.end) {
+                    assert readerNext in durableData, "archive fallback lost a record";
+                    canRead = true;
+                }
+                if (canRead) {
+                    emitted += (sizeof(emitted), readerNext);
+                    readerNext = readerNext + 1;
+                }
+            }
+            if ($ && sizeof(emitted) > 0) { readerDropped = true; }
+        } else {
+            // Checkpoint/epoch mutations race cached archival proposals. They
+            // must preserve the root. Truncation does not delete archive data.
+            next = view;
+            if ($) { next.trunc = view.tailBase; }
+            else { next.epoch = view.epoch + 1; next.owner = next.epoch; }
+            send manifest, eManifestCas, (caller=this, expMetagen=version, rec=next);
+            receive { case eManifestCasResponse: (r: tManifestCasResponse) { response = r; } }
+            if ($) { proposals[slot] = default(tArchiveProposal); }
+        }
+        // Strong snapshots can only lag on injected read failures; the safety
+        // assertions apply to every successfully observed register state.
+        Refresh();
+        if (view.archive.root != 0) {
+            assert view.archive.root in pages, "published catalog is missing";
+            assert sizeof(pages[view.archive.root]) == view.archive.end,
+                "published archive contains a hole or an overlapping range";
+            index = 0;
+            while (index < view.archive.end) {
+                assert pages[view.archive.root][index] == index && index in durableData,
+                    "published catalog names noncanonical or missing bytes";
+                index = index + 1;
+            }
+            assert sizeof(view.directory) > 0 &&
+                view.directory[0].base == view.archive.end,
+                "archive and hot directory do not join";
+            assert view.archive.end <= view.sealBase,
+                "archival evicted the latest finalization witness";
+        }
+        index = 0;
+        while (index < view.tailBase) {
+            assert sizeof(hotCopies[index]) > 0 ||
+                (index < view.archive.end && index in durableData),
+                "recovery lost a committed record";
+            index = index + 1;
+        }
+        index = 0;
+        while (index < sizeof(emitted)) {
+            assert emitted[index] == index, "reader skipped or duplicated a record";
+            index = index + 1;
+        }
+        assert readerNext == sizeof(emitted), "reader cursor differs from delivered prefix";
+        steps = steps + 1;
+        if (steps < 200) { send this, eArchiveStep; }
+    }
+}

--- a/p/model/ArchiveRecovery.p
+++ b/p/model/ArchiveRecovery.p
@@ -1,0 +1,121 @@
+// Recovery retains a hot directory and archive root from one manifest version.
+// Publication and deletion race a later recovery CAS, whose retry refreshes the
+// live register but must not replace the adopted replay root.
+machine ArchiveRecoverySnapshot {
+    var manifest: ManifestRegister;
+    var view: tManifestRecord;
+    var version: int;
+    var pages: map[int, seq[int]];
+    var hotRecords: set[int];
+    var durable: set[int];
+    var checkpoint: int;
+    var emitted: seq[int];
+
+    start state Running {
+        entry {
+            var response: tManifestCasResponse;
+            var adopted: tManifestRecord;
+            var adoptedVersion: int;
+            var next: tManifestRecord;
+            var replayRoot: int;
+            var index: int;
+            var value: int;
+            manifest = new ManifestRegister((failures=0,));
+            send manifest, eArchiveEnable, (caller=this,);
+            receive { case eManifestCasResponse: (r: tManifestCasResponse) { response = r; } }
+            view = response.rec;
+            version = response.metagen;
+            while (view.tailBase < 4) {
+                next = view;
+                hotRecords += (view.tailBase);
+                next.directory += (sizeof(next.directory), (base=view.tailBase, id=100 + view.tailBase));
+                next.sealBase = view.tailBase;
+                next.sealId = 100 + view.tailBase;
+                next.tailBase = view.tailBase + 1;
+                next.sealEnd = next.tailBase;
+                next.sealSum = next.sealId;
+                send manifest, eManifestCas, (caller=this, expMetagen=version, rec=next);
+                receive { case eManifestCasResponse: (r: tManifestCasResponse) { response = r; } }
+                assert response.status == STATUS_OK;
+                view = response.rec;
+                version = response.metagen;
+            }
+            // Exercise both no archive root and an existing archived prefix.
+            if ($) { PublishAndDelete(); }
+            checkpoint = 0;
+            if ($) { checkpoint = checkpoint + 1; }
+            if ($) { checkpoint = checkpoint + 2; }
+            adopted = view;
+            adoptedVersion = version;
+            PublishAndDelete();
+            // A stale recovery CAS conflicts, then succeeds after refreshing.
+            next = adopted;
+            next.epoch = next.epoch + 1;
+            next.owner = next.epoch;
+            send manifest, eManifestCas, (caller=this, expMetagen=adoptedVersion, rec=next);
+            receive { case eManifestCasResponse: (r: tManifestCasResponse) { response = r; } }
+            assert response.status == STATUS_FENCED;
+            view = response.rec;
+            version = response.metagen;
+            next = view;
+            next.epoch = next.epoch + 1;
+            next.owner = next.epoch;
+            send manifest, eManifestCas, (caller=this, expMetagen=version, rec=next);
+            receive { case eManifestCasResponse: (r: tManifestCasResponse) { response = r; } }
+            assert response.status == STATUS_OK;
+            view = response.rec;
+            assert view.archive.end > adopted.archive.end;
+            replayRoot = adopted.archive.root;
+            if (replayRoot != 0) {
+                index = 0;
+                while (index < sizeof(pages[replayRoot])) {
+                    value = pages[replayRoot][index];
+                    assert value in durable;
+                    Emit(value);
+                    index = index + 1;
+                }
+            }
+            index = 0;
+            while (index < sizeof(adopted.directory)) {
+                value = adopted.directory[index].base;
+                // A deleted captured hot entry resolves through the newer root.
+                if (!(value in hotRecords)) {
+                    assert value in durable && view.archive.root in pages &&
+                        pages[view.archive.root][value] == value;
+                }
+                Emit(value);
+                index = index + 1;
+            }
+            assert sizeof(emitted) == adopted.tailBase - checkpoint,
+                "recovery omitted records from its fixed replay range";
+        }
+    }
+
+    fun Emit(value: int) {
+        if (value >= checkpoint) {
+            assert value == checkpoint + sizeof(emitted),
+                "recovery skipped or duplicated a record across archive/hot snapshots";
+            emitted += (sizeof(emitted), value);
+        }
+    }
+
+    fun PublishAndDelete() {
+        var response: tManifestCasResponse;
+        var page: seq[int];
+        var value: int;
+        var root: int;
+        value = view.directory[0].base;
+        root = view.directory[1].base;
+        if (view.archive.root != 0) { page = pages[view.archive.root]; }
+        page += (sizeof(page), value);
+        durable += (value);
+        pages[root] = page;
+        send manifest, eArchivePublish, (caller=this, expMetagen=version,
+            previous=view.archive.root, root=root, segmentEntry=view.directory[0], end=root);
+        receive { case eManifestCasResponse: (r: tManifestCasResponse) { response = r; } }
+        assert response.status == STATUS_OK;
+        view = response.rec;
+        version = response.metagen;
+        hotRecords -= (value);
+    }
+}

--- a/p/model/Drivers.p
+++ b/p/model/Drivers.p
@@ -245,7 +245,7 @@ machine HistoricalMaintenanceRepairDriver {
                 sealEnd=2,
                 sealSum=88,
                 trunc=readResponse.rec.trunc,
-                directory=nextDirectory);
+                archive=readResponse.rec.archive, directory=nextDirectory);
             send manifest, eManifestCas, (
                 caller=this, expMetagen=readResponse.metagen, rec=next);
             receive { case eManifestCasResponse: (r: tManifestCasResponse) {
@@ -888,7 +888,7 @@ machine StaleReplicaRecoveryDriver {
             next = (epoch=1, owner=1, tailBase=0, tailGen=0,
                 pending=-1, sealBase=-1,
                 sealId=-1, sealEnd=0, sealSum=0, trunc=0,
-                directory=default(seq[tDirectoryEntry]));
+                archive=default(tArchiveRecord), directory=default(seq[tDirectoryEntry]));
             send manifest, eManifestCas, (
                 caller=this, expMetagen=readResponse.metagen, rec=next);
             receive { case eManifestCasResponse: (r: tManifestCasResponse) {

--- a/p/model/Manifest.p
+++ b/p/model/Manifest.p
@@ -21,7 +21,7 @@ machine ManifestRegister {
             rec = (epoch=0, owner=0, tailBase=0, tailGen=0,
                 pending=-1, sealBase=-1,
                 sealId=-1, sealEnd=0, sealSum=0, trunc=0,
-                directory=default(seq[tDirectoryEntry]));
+                archive=default(tArchiveRecord), directory=default(seq[tDirectoryEntry]));
             faultBudget = config.failures;
         }
 
@@ -76,6 +76,48 @@ machine ManifestRegister {
         }
 
         on eDirectoryRemove do HandleDirectoryRemove;
+        on eArchiveEnable do (request: (caller: machine)) {
+            if (!rec.archive.enabled) {
+                rec.archive = (enabled=true, startOffset=rec.trunc, root=0,
+                    end=rec.trunc, cleaned=rec.trunc);
+                metagen = metagen + 1;
+            }
+            send request.caller, eManifestCasResponse,
+                (status=STATUS_OK, metagen=metagen, rec=rec);
+        }
+        on eArchivePublish do (request: (caller: machine, expMetagen: int,
+            previous: int, root: int, segmentEntry: tDirectoryEntry, end: int)) {
+            if (Flaky()) {
+                send request.caller, eManifestCasResponse,
+                    (status=STATUS_TRANSIENT, metagen=0, rec=rec);
+                return;
+            }
+            if (request.expMetagen != metagen || !rec.archive.enabled ||
+                request.previous != rec.archive.root || sizeof(rec.directory) < 2) {
+                send request.caller, eManifestCasResponse,
+                    (status=STATUS_FENCED, metagen=metagen, rec=rec);
+                return;
+            }
+            if (rec.directory[0] != request.segmentEntry ||
+                rec.directory[1].base != request.end ||
+                request.segmentEntry.id == rec.sealId ||
+                request.segmentEntry.base != rec.archive.end) {
+                send request.caller, eManifestCasResponse,
+                    (status=STATUS_FENCED, metagen=metagen, rec=rec);
+                return;
+            }
+            rec.archive.root = request.root;
+            rec.archive.end = request.end;
+            rec.directory -= (0);
+            metagen = metagen + 1;
+            if (Flaky()) {
+                send request.caller, eManifestCasResponse,
+                    (status=STATUS_TRANSIENT, metagen=0, rec=rec);
+            } else {
+                send request.caller, eManifestCasResponse,
+                    (status=STATUS_OK, metagen=metagen, rec=rec);
+            }
+        }
     }
 
     // Regular register CASes either preserve the directory exactly or append
@@ -83,6 +125,7 @@ machine ManifestRegister {
     // removal transition below.
     fun ValidCasDirectory(next: tManifestRecord): bool {
         var index: int;
+        if (next.archive != rec.archive) { return false; }
         if (sizeof(next.directory) > 4) { return false; }
         if (next.sealId == rec.sealId) {
             return next.directory == rec.directory &&
@@ -165,6 +208,7 @@ machine ManifestRegister {
             return;
         }
         if (request.floor > rec.trunc ||
+            (rec.archive.enabled && request.floor > rec.archive.startOffset) ||
             !(0 in request.absentZones) ||
             !(1 in request.absentZones) ||
             !(2 in request.absentZones)) {

--- a/p/model/PipelinedWal.p
+++ b/p/model/PipelinedWal.p
@@ -43,7 +43,7 @@ machine PipelinedWriter {
                 pending=view.pending,
                 sealBase=view.sealBase, sealId=view.sealId,
                 sealEnd=view.sealEnd, sealSum=view.sealSum, trunc=view.trunc,
-                directory=view.directory);
+                archive=view.archive, directory=view.directory);
             send manifest, eManifestCas, (
                 caller=this, expMetagen=viewMetagen, rec=next);
             receive { case eManifestCasResponse: (r: tManifestCasResponse) {
@@ -207,7 +207,7 @@ machine PipelinedWriter {
                 tailGen=view.tailGen, pending=view.pending,
                 sealBase=0, sealId=1, sealEnd=2,
                 sealSum=record0.value * 1 + record1.value * 2,
-                trunc=view.trunc, directory=nextDirectory);
+                trunc=view.trunc, archive=view.archive, directory=nextDirectory);
             send manifest, eManifestCas, (
                 caller=this, expMetagen=viewMetagen, rec=next);
             receive { case eManifestCasResponse: (r: tManifestCasResponse) {
@@ -290,7 +290,7 @@ machine PipelinedWriter {
                     tailGen=view.tailGen, pending=view.pending,
                     sealBase=2, sealId=21, sealEnd=3,
                     sealSum=record2.value, trunc=view.trunc,
-                    directory=nextDirectory);
+                    archive=view.archive, directory=nextDirectory);
                 send manifest, eManifestCas, (
                     caller=this, expMetagen=viewMetagen, rec=next);
                 receive { case eManifestCasResponse: (r: tManifestCasResponse) {
@@ -465,7 +465,7 @@ machine PendingSegmentWriter {
             pending=view.pending,
             sealBase=view.sealBase, sealId=view.sealId,
             sealEnd=view.sealEnd, sealSum=view.sealSum, trunc=view.trunc,
-            directory=view.directory);
+            archive=view.archive, directory=view.directory);
         send manifest, eManifestCas, (
             caller=this, expMetagen=readResponse.metagen, rec=next);
         receive { case eManifestCasResponse: (r: tManifestCasResponse) {
@@ -517,7 +517,7 @@ machine PendingSegmentWriter {
             pending=id,
             sealBase=view.sealBase, sealId=view.sealId,
             sealEnd=view.sealEnd, sealSum=view.sealSum, trunc=view.trunc,
-            directory=view.directory);
+            archive=view.archive, directory=view.directory);
         send manifest, eManifestCas, (
             caller=this, expMetagen=viewMetagen, rec=next);
         receive { case eManifestCasResponse: (r: tManifestCasResponse) {
@@ -583,7 +583,7 @@ machine PendingSegmentWriter {
         next = (epoch=epoch, owner=writerId,
             tailBase=1, tailGen=view.pending, pending=refill,
             sealBase=0, sealId=0, sealEnd=1, sealSum=400,
-            trunc=view.trunc, directory=nextDirectory);
+            trunc=view.trunc, archive=view.archive, directory=nextDirectory);
         send manifest, eManifestCas, (
             caller=this, expMetagen=viewMetagen, rec=next);
         receive { case eManifestCasResponse: (r: tManifestCasResponse) {
@@ -656,7 +656,7 @@ machine DirectoryRotation {
                 pending=view.pending,
                 sealBase=view.sealBase, sealId=view.sealId,
                 sealEnd=view.sealEnd, sealSum=view.sealSum, trunc=view.trunc,
-                directory=view.directory);
+                archive=view.archive, directory=view.directory);
             send payload.manifest, eManifestCas, (
                 caller=this, expMetagen=readResponse.metagen, rec=next);
             receive { case eManifestCasResponse: (r: tManifestCasResponse) {
@@ -738,7 +738,7 @@ machine DirectoryRotation {
                 pending=view.pending,
                 sealBase=payload.base, sealId=sealId,
                 sealEnd=payload.base + 1, sealSum=payload.value,
-                trunc=view.trunc, directory=nextDirectory);
+                trunc=view.trunc, archive=view.archive, directory=nextDirectory);
             send payload.manifest, eManifestCas, (
                 caller=this, expMetagen=casResponse.metagen, rec=next);
             receive { case eManifestCasResponse: (r: tManifestCasResponse) {
@@ -858,7 +858,7 @@ machine DirectoryCleanupCoordinator {
                     pending=current.pending,
                     sealBase=current.sealBase, sealId=current.sealId,
                     sealEnd=current.sealEnd, sealSum=current.sealSum,
-                    trunc=payload.floor, directory=current.directory);
+                    trunc=payload.floor, archive=current.archive, directory=current.directory);
                 send payload.manifest, eManifestCas, (
                     caller=this, expMetagen=currentMetagen, rec=next);
                 receive { case eManifestCasResponse: (
@@ -1083,7 +1083,7 @@ machine TruncationCoordinator {
                     sealId=readResponse.rec.sealId,
                     sealEnd=readResponse.rec.sealEnd,
                     sealSum=readResponse.rec.sealSum, trunc=2,
-                    directory=readResponse.rec.directory);
+                    archive=readResponse.rec.archive, directory=readResponse.rec.directory);
                 send payload.manifest, eManifestCas, (
                     caller=this, expMetagen=readResponse.metagen, rec=next);
                 receive { case eManifestCasResponse: (r: tManifestCasResponse) {

--- a/p/model/Tests.p
+++ b/p/model/Tests.p
@@ -1,3 +1,9 @@
+test tcArchiveLifecycle [main=ArchiveLifecycle]:
+    (union { ArchiveLifecycle }, { ManifestRegister });
+
+test tcArchiveRecoverySnapshot [main=ArchiveRecoverySnapshot]:
+    (union { ArchiveRecoverySnapshot }, { ManifestRegister });
+
 test tcConcurrentCreators [main=ConcurrentWritersDriver]:
     assert QuorumLinearizability, SingleWriterPerSegment, ManifestSafety,
         PendingRegistrationSafety, DirectoryStructure,

--- a/p/model/Types.p
+++ b/p/model/Types.p
@@ -120,6 +120,10 @@ type tDirectoryEntry = (
 // empty or absent never reuses the name: it commits tailGen+1 through the
 // register (the implementation mints a fresh successor id via commit_view), so
 // bytes under a retired name can never rejoin the log.
+// Immutable catalog identity is a finite surrogate for the production root
+// reference; pages/data are modeled by ArchiveLifecycle below.
+type tArchiveRecord = (enabled: bool, startOffset: int, root: int, end: int, cleaned: int);
+
 type tManifestRecord = (
     epoch: int,
     owner: int,
@@ -131,6 +135,7 @@ type tManifestRecord = (
     sealEnd: int,
     sealSum: int,
     trunc: int,
+    archive: tArchiveRecord,
     directory: seq[tDirectoryEntry]
 );
 type tManifestReadRequest = (caller: machine);
@@ -186,6 +191,9 @@ event eManifestRead: tManifestReadRequest;
 event eManifestReadResponse: tManifestReadResponse;
 event eManifestCas: tManifestCasRequest;
 event eManifestCasResponse: tManifestCasResponse;
+event eArchiveEnable: (caller: machine);
+event eArchivePublish: (caller: machine, expMetagen: int, previous: int,
+    root: int, segmentEntry: tDirectoryEntry, end: int);
 event eDirectoryRemove: tDirectoryRemoveRequest;
 event eDirectoryRemoveResponse: tDirectoryRemoveResponse;
 

--- a/p/model/WriterProcess.p
+++ b/p/model/WriterProcess.p
@@ -269,7 +269,7 @@ machine WriterProcess {
                 pending=view.pending,
                 sealBase=view.sealBase, sealId=view.sealId,
                 sealEnd=view.sealEnd, sealSum=view.sealSum, trunc=view.trunc,
-                directory=view.directory);
+                archive=view.archive, directory=view.directory);
             send manifest, eManifestCas, (
                 caller=this, expMetagen=viewMetagen, rec=candidate);
             receive { case eManifestCasResponse: (r: tManifestCasResponse) {
@@ -394,7 +394,7 @@ machine WriterProcess {
                 tailGen=view.tailGen, pending=view.pending,
                 sealBase=segBase, sealId=sealId,
                 sealEnd=segBase + count, sealSum=sum, trunc=view.trunc,
-                directory=nextDirectory);
+                archive=view.archive, directory=nextDirectory);
             send manifest, eManifestCas, (
                 caller=this, expMetagen=viewMetagen, rec=next);
             receive { case eManifestCasResponse: (r: tManifestCasResponse) {
@@ -447,7 +447,7 @@ machine WriterProcess {
                 tailGen=target, pending=view.pending,
                 sealBase=view.sealBase, sealId=view.sealId,
                 sealEnd=view.sealEnd, sealSum=view.sealSum, trunc=view.trunc,
-                directory=view.directory);
+                archive=view.archive, directory=view.directory);
             send manifest, eManifestCas, (
                 caller=this, expMetagen=viewMetagen, rec=next);
             receive { case eManifestCasResponse: (r: tManifestCasResponse) {
@@ -847,7 +847,7 @@ machine PendingChainRecovery {
             pending=view.pending,
             sealBase=view.sealBase, sealId=view.sealId,
             sealEnd=view.sealEnd, sealSum=view.sealSum, trunc=view.trunc,
-            directory=view.directory);
+            archive=view.archive, directory=view.directory);
         send manifest, eManifestCas, (
             caller=this, expMetagen=readResponse.metagen, rec=next);
         receive { case eManifestCasResponse: (r: tManifestCasResponse) {

--- a/p/proof/ArchiveProof.p
+++ b/p/proof/ArchiveProof.p
@@ -1,0 +1,190 @@
+// Inductive transfer proof over unbounded integer prefix boundaries. Quorum
+// finalization and immutable storage durability/integrity are premises. This
+// proves the publication/eviction protocol, not the Rust implementation or the
+// provider. The explicit ArchiveLifecycle model additionally exercises two
+// cached proposals, per-zone cleanup, and the shared manifest implementation.
+event eArchiveProofStep;
+machine ArchiveProofModel {
+    var sealedEnd: int;
+    var finalizedEnd: int;
+    var uploadedEnd: int;
+    var indexedEnd: int;
+    var archiveEnd: int;
+    var hotStart: int;
+    var deletedEnd: int;
+    var checkpoint: int;
+    var version: int;
+    var proposalValid: bool;
+    var proposalParent: int;
+    var proposalEnd: int;
+    var proposalVersion: int;
+    var readerNext: int;
+    var readerDropped: bool;
+    var droppedAt: int;
+    // Recovery scans an adopted archive prefix followed by its hot suffix.
+    // Phase 1 allows publication/CAS refreshes after adoption, before replay.
+    var recoveryPhase: int;
+    var recoveryArchiveEnd: int;
+    var recoveryHotStart: int;
+    var recoveryFrom: int;
+    var recoveryEnd: int;
+    var recoveryNext: int;
+    var recoveryDelivered: int;
+
+    start state Running {
+        entry { send this, eArchiveProofStep; }
+        on eArchiveProofStep do Step;
+    }
+
+    fun Step() {
+        if ($) {
+            // The next fold follows enforcement of the preceding seal.
+            finalizedEnd = sealedEnd;
+            sealedEnd = sealedEnd + 1;
+            version = version + 1;
+        } else if ($) {
+            if (archiveEnd < finalizedEnd) {
+                proposalValid = true;
+                proposalParent = archiveEnd;
+                proposalEnd = archiveEnd + 1;
+                proposalVersion = version;
+            }
+        } else if ($) {
+            // Failures can leave durable bytes but never advance publication.
+            if (proposalValid && proposalEnd == uploadedEnd + 1) {
+                uploadedEnd = proposalEnd;
+            }
+        } else if ($) {
+            if (proposalValid && proposalEnd <= uploadedEnd &&
+                proposalEnd > indexedEnd) { indexedEnd = proposalEnd; }
+        } else if ($) {
+            // Exact parent/version CAS. A response loss is equivalent to this
+            // transition followed by a retry or crash of the worker.
+            if (proposalValid && proposalVersion == version &&
+                proposalParent == archiveEnd && proposalEnd <= indexedEnd) {
+                archiveEnd = proposalEnd;
+                hotStart = archiveEnd;
+                version = version + 1;
+            }
+        } else if ($) {
+            if (deletedEnd < archiveEnd) { deletedEnd = deletedEnd + 1; }
+        } else if ($) {
+            checkpoint = sealedEnd;
+            version = version + 1;
+        } else if ($) {
+            // Worker crash discards only volatile proposal state.
+            proposalValid = false;
+            version = version + 1;
+        } else if ($) {
+            // Stale hot reads may require refresh and archive fallback. The
+            // disjunction is exactly the two durable sources of sealed data.
+            if (!readerDropped && readerNext < sealedEnd &&
+                (readerNext >= deletedEnd || readerNext < archiveEnd)) {
+                readerNext = readerNext + 1;
+            }
+        } else if ($) {
+            readerDropped = true;
+            droppedAt = readerNext;
+        } else if ($) {
+            recoveryPhase = 1;
+            recoveryArchiveEnd = archiveEnd;
+            recoveryHotStart = hotStart;
+            recoveryFrom = checkpoint;
+            recoveryEnd = sealedEnd;
+            recoveryNext = checkpoint;
+            recoveryDelivered = checkpoint;
+        } else if (recoveryPhase == 1) {
+            // Live manifest refreshes do not change the adopted replay root.
+            recoveryPhase = 2;
+        } else if (recoveryPhase == 2) {
+            if (recoveryNext < recoveryArchiveEnd && recoveryNext < recoveryEnd) {
+                assert recoveryNext == recoveryDelivered, "archive replay is not ordered";
+                recoveryNext = recoveryNext + 1;
+                recoveryDelivered = recoveryDelivered + 1;
+            } else {
+                recoveryPhase = 3;
+                recoveryNext = recoveryHotStart;
+                if (recoveryNext < recoveryFrom) { recoveryNext = recoveryFrom; }
+            }
+        } else if (recoveryPhase == 3) {
+            if (recoveryNext < recoveryEnd) {
+                assert recoveryNext == recoveryDelivered, "hot replay skipped or duplicated a record";
+                recoveryNext = recoveryNext + 1;
+                recoveryDelivered = recoveryDelivered + 1;
+            } else { recoveryPhase = 4; }
+        }
+        send this, eArchiveProofStep;
+    }
+}
+
+init-condition forall (a: ArchiveProofModel) ::
+    a.sealedEnd == 1 && a.finalizedEnd == 0 && a.uploadedEnd == 0 &&
+    a.indexedEnd == 0 && a.archiveEnd == 0 && a.hotStart == 0 &&
+    a.deletedEnd == 0 && a.checkpoint == 0 && a.version == 0 &&
+    !a.proposalValid && a.proposalParent == 0 && a.proposalEnd == 0 &&
+    a.proposalVersion == 0 && a.readerNext == 0 &&
+    !a.readerDropped && a.droppedAt == 0 &&
+    a.recoveryPhase == 0 && a.recoveryArchiveEnd == 0 && a.recoveryHotStart == 0 &&
+    a.recoveryFrom == 0 && a.recoveryEnd == 0 && a.recoveryNext == 0 &&
+    a.recoveryDelivered == 0;
+
+Lemma archive_transfer_inductive {
+    invariant archive_prefix_order:
+        forall (a: ArchiveProofModel) ::
+            0 <= a.deletedEnd && a.deletedEnd <= a.archiveEnd &&
+            a.archiveEnd <= a.indexedEnd && a.indexedEnd <= a.uploadedEnd &&
+            a.uploadedEnd <= a.finalizedEnd && a.finalizedEnd < a.sealedEnd;
+    invariant archive_publication_and_hot_removal_are_atomic:
+        forall (a: ArchiveProofModel) :: a.hotStart == a.archiveEnd;
+    invariant archive_current_seal_remains_hot:
+        forall (a: ArchiveProofModel) :: a.hotStart < a.sealedEnd;
+    invariant archive_checkpoint_is_not_eviction_authority:
+        forall (a: ArchiveProofModel) ::
+            0 <= a.checkpoint && a.checkpoint <= a.sealedEnd &&
+            a.deletedEnd <= a.archiveEnd;
+    invariant archive_proposal_is_a_finalized_successor:
+        forall (a: ArchiveProofModel) :: a.proposalValid ==>
+            (0 <= a.proposalParent && a.proposalParent <= a.archiveEnd &&
+             a.proposalEnd == a.proposalParent + 1 &&
+             a.proposalEnd <= a.finalizedEnd &&
+             0 <= a.proposalVersion && a.proposalVersion <= a.version);
+    invariant archive_version_is_nonnegative:
+        forall (a: ArchiveProofModel) :: a.version >= 0;
+    invariant archive_reader_is_bounded:
+        forall (a: ArchiveProofModel) ::
+            0 <= a.readerNext && a.readerNext <= a.sealedEnd;
+    invariant archive_drop_stops_delivery:
+        forall (a: ArchiveProofModel) :: a.readerDropped ==>
+            a.readerNext == a.droppedAt;
+    invariant archive_recovery_has_a_durable_source:
+        forall (a: ArchiveProofModel) ::
+            a.deletedEnd <= a.archiveEnd && a.archiveEnd <= a.uploadedEnd;
+    invariant archive_recovery_snapshot_bounds:
+        forall (a: ArchiveProofModel) ::
+            0 <= a.recoveryPhase && a.recoveryPhase <= 4 &&
+            (a.recoveryPhase != 0 ==>
+                (0 <= a.recoveryFrom && a.recoveryFrom <= a.recoveryEnd &&
+                 a.recoveryEnd <= a.sealedEnd &&
+                 a.recoveryFrom <= a.recoveryDelivered && a.recoveryDelivered <= a.recoveryEnd));
+    invariant archive_recovery_snapshot_join:
+        forall (a: ArchiveProofModel) :: a.recoveryPhase != 0 ==>
+            (0 <= a.recoveryArchiveEnd && a.recoveryArchiveEnd == a.recoveryHotStart &&
+             a.recoveryHotStart < a.recoveryEnd);
+    invariant archive_recovery_replay_cursor:
+        forall (a: ArchiveProofModel) ::
+            (a.recoveryPhase == 1 ==>
+                (a.recoveryNext == a.recoveryFrom && a.recoveryDelivered == a.recoveryFrom)) &&
+            (a.recoveryPhase == 2 ==>
+                (a.recoveryNext == a.recoveryDelivered &&
+                 (a.recoveryNext <= a.recoveryArchiveEnd || a.recoveryNext == a.recoveryFrom))) &&
+            (a.recoveryPhase >= 3 ==>
+                (a.recoveryNext == a.recoveryDelivered && a.recoveryNext >= a.recoveryHotStart));
+    invariant archive_recovery_completed_range:
+        forall (a: ArchiveProofModel) :: a.recoveryPhase == 4 ==>
+            a.recoveryDelivered == a.recoveryEnd;
+}
+
+Proof {
+    prove archive_transfer_inductive;
+    prove default using archive_transfer_inductive;
+}

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -380,6 +380,7 @@ dependencies = [
  "prost",
  "prost-types",
  "serde",
+ "serde_json",
  "sha2 0.10.9",
  "thiserror",
  "tokio",

--- a/rust/client/Cargo.toml
+++ b/rust/client/Cargo.toml
@@ -31,6 +31,7 @@ google-cloud-auth.workspace = true
 prost.workspace = true
 prost-types.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 tokio.workspace = true

--- a/rust/client/README.md
+++ b/rust/client/README.md
@@ -133,17 +133,17 @@ while let Some(record) = follower.try_next().await? {
 ```
 
 Readonly open never creates the manifest, claims a writer epoch, opens append
-streams, repairs data, or changes the truncation floor. It reads only immutable
-segments already published in the manifest directory plus the manifest-selected
-active appendable object through GCS `BidiReadObject`. A complete active frame
+streams, repairs data, or changes the truncation floor. It reads immutable
+segments published in the hot directory or archive catalog, plus the
+manifest-selected active appendable object through GCS `BidiReadObject`. A complete active frame
 is emitted only when identical bytes are visible on a strict majority, so a
 minority-only or partial suffix is never exposed. The follower keeps one
 `BidiReadObject` RPC open per zone for the current active object, sends a new
 range message on each poll, and returns as soon as the first matching strict
 majority responds; a slow remaining request stays in flight for a later poll.
 Manifest refresh runs independently on `manifest_poll_interval` and does not
-delay active-tail delivery. The manifest changes only when the writer rotates,
-seals, or truncates, so that interval is normally much larger than
+delay active-tail delivery. The manifest changes on rotation, sealing,
+truncation, archival, and maintenance rather than on each append, so that interval is normally much larger than
 `poll_interval`; polling it at the active-tail rate multiplies regional reads
 without observing anything new.
 
@@ -155,7 +155,10 @@ follower catches up, the next record still waits up to `poll_interval` to be
 observed, which is the latency against request-rate tradeoff that interval
 controls. Segment rotation is never required for delivery.
 
-Followers do not register with the writer. Retain WAL history long enough for
+Followers do not register with the writer. Drop the stream to stop at an
+application-selected sequence number. With archival enabled, followers can
+read history back to the floor recorded at archive activation, independently
+of subsequent checkpoint advances. Without archival, retain WAL history long enough for
 every replica to advance its own durable checkpoint. If truncation overtakes a
 follower, the stream returns `Error::ReadOnlyLagged` rather than skipping
 records; resnapshot that replica before reopening it at a newer checkpoint.
@@ -184,11 +187,65 @@ can implement `ManifestStore` and use
 Spanner, SQL, or another strongly consistent compare-and-swap store. Segment
 data remains in the zonal buckets.
 
+## Archival and long retention
+
+Attach an immutable `ArchiveStore` and choose the hot sealed-segment target:
+
+```rust,ignore
+use chorus_client::{ArchivePolicy, GcsArchiveStore};
+use std::sync::Arc;
+
+let archive = Arc::new(GcsArchiveStore::new(regional_factory, "orders/archive")?);
+let volume = volume.with_archive(archive, ArchivePolicy {
+    keep_sealed_segments: 8,
+})?;
+```
+
+Maintenance uploads finalized segments and immutable catalog pages, then
+atomically publishes the catalog root and removes the old hot directory entry.
+Only afterward does it delete the redundant zonal copies. The count is a
+placement target, not a deletion policy: archived history is retained
+indefinitely. The minimum is one because the latest seal remains a recovery
+finalization witness. Upload failures retain hot data; continued archive
+unavailability can still cause non-poisoning directory backpressure.
+After archival or truncation frees directory capacity, the engine retries a
+failed manifest refresh until it can reconsider blocked rotation. Periodic
+archive work and queued seal/truncate commands also alternate priority when
+maintenance is overdue, so either class of work continues to make progress.
+
+The control manifest stores one bounded root reference. The copy-on-write
+catalog has bounded pages and logarithmic seek/append cost; readers do not load
+the complete archive directory. `ArchiveStore` provides immutable conditional
+uploads and streaming reads (optionally by byte range), and is shared by WAL
+objects and catalog pages. It does not expose mutable whole-history manifests.
+
+`GcsBodyManifestStore` separately implements the existing `ManifestStore` with
+a generation-CAS GCS object body and a configurable directory budget. Pass it
+to `SegmentedVolume::new_with_manifest_store` when the hot register needs more
+capacity. Each update replaces that bounded body; it is not the archive index.
+Do not switch a running volume between metadata and body storage in place.
+
+Enabling archival persists format 2 and the backing namespace during recovery.
+Old clients reject this format. All subsequent opens must supply the same
+archive namespace. Already-truncated history is not restored. Writer recovery
+still requires the current database checkpoint; use a readonly stream for
+historical replay into a separate restored database. PITR also requires an
+application snapshot and transaction/time mapping; Chorus stores opaque records.
+
+Archive objects, including superseded and uncommitted catalog pages, are not
+garbage-collected in this version. Do not configure bucket lifecycle deletion
+for the archive prefix. Reads validate the complete segment's length, SHA-256,
+CRC32C, and framing before yielding records, so memory is bounded by a segment
+and the catalog traversal, not by retained history.
+
+See [the archival safety argument](../../p/ARCHIVE_SAFETY.md) for the publication
+protocol, proof assumptions, and verification commands.
+
 ## Important behavior
 
 - Segment rotation and immutable sealed-segment repair are automatic.
-- Truncation and replacement deletion are permanent. Archive sealed history
-  first if the application needs point-in-time recovery.
+- Without archival, truncation and replacement deletion are permanent. Enable
+  archival before advancing checkpoints if historical WAL replay is required.
 - `Error::ActiveSegmentFull` is non-poisoning backpressure and does not consume
   the attempted sequence number.
 - `SegmentedVolume::new_with_metrics_recorder` connects Chorus to an

--- a/rust/client/src/archive.rs
+++ b/rust/client/src/archive.rs
@@ -1,0 +1,504 @@
+//! Immutable archive storage and a copy-on-write, sequence-ordered catalog.
+//!
+//! Only the control manifest publishes roots. Uploading an object or preparing
+//! a root does not authorize removal of any hot copy. Catalog pages and WAL
+//! objects share the same backend and are never overwritten.
+
+use std::{ops::Range, sync::Arc};
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::{future::BoxFuture, stream::BoxStream, FutureExt, StreamExt};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+/// A lazily consumed archive read or upload. Dropping it cancels owned work.
+pub type ArchiveByteStream = BoxStream<'static, Result<Bytes, ArchiveError>>;
+
+/// Stable, namespace-relative immutable object identity and integrity metadata.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ArchiveObjectRef {
+    /// Object key relative to the store's namespace.
+    pub key: String,
+    /// Exact complete-object byte length.
+    pub byte_len: u64,
+    /// SHA-256 of the complete immutable object.
+    pub sha256: [u8; 32],
+}
+
+impl ArchiveObjectRef {
+    pub(crate) fn for_bytes(kind: &str, bytes: &[u8]) -> Self {
+        let sha256: [u8; 32] = Sha256::digest(bytes).into();
+        let hash: String = sha256.iter().map(|b| format!("{b:02x}")).collect();
+        Self {
+            key: format!("{kind}/{hash}"),
+            byte_len: bytes.len() as u64,
+            sha256,
+        }
+    }
+
+    pub(crate) fn verify(&self, bytes: &[u8]) -> Result<(), ArchiveError> {
+        if self.byte_len != bytes.len() as u64
+            || self.sha256 != <[u8; 32]>::from(Sha256::digest(bytes))
+        {
+            return Err(ArchiveError::Corrupt(self.key.clone()));
+        }
+        Ok(())
+    }
+}
+
+/// Archive failures never authorize eviction of hot data.
+#[derive(Clone, Debug, thiserror::Error)]
+pub enum ArchiveError {
+    /// An object referenced by a committed catalog is missing.
+    #[error("archive object not found: {0}")]
+    NotFound(String),
+    /// Retryable service failure, possibly after a successful write.
+    #[error("archive unavailable: {0}")]
+    Unavailable(String),
+    /// Invalid bytes, catalog structure, or conflicting immutable content.
+    #[error("archive integrity or immutable-key conflict: {0}")]
+    Corrupt(String),
+    /// A terminal configuration, authentication, or backend failure.
+    #[error("archive backend: {0}")]
+    Backend(String),
+}
+
+/// Immutable storage shared by archive data and catalog pages.
+///
+/// `namespace` is a stable identity for the backing bucket AND prefix; it must
+/// not change across restarts. Writes atomically publish complete objects.
+/// Success means durable, immediately readable bytes matching the reference.
+/// Retrying identical bytes is idempotent; different bytes must never replace
+/// an existing key. Errors may follow successful publication. Callers retry
+/// with a fresh upload stream and the same reference. Reads must not silently
+/// truncate or substitute missing data. Dropping futures/streams must cancel
+/// their owned tasks. No listing or deletion is needed for normal operation.
+#[async_trait]
+pub trait ArchiveStore: Send + Sync {
+    /// Stable backing-store and prefix identity, persisted in the manifest.
+    fn namespace(&self) -> &str;
+    /// Atomically publish the bytes or validate an identical existing object.
+    async fn put_if_absent(
+        &self,
+        object: &ArchiveObjectRef,
+        contents: ArchiveByteStream,
+    ) -> Result<(), ArchiveError>;
+    /// Byte ranges are half-open. `None` requests the entire object. Partial
+    /// reads do not prove a full-object digest; Chorus currently verifies whole
+    /// segments before exposing any records.
+    async fn read(
+        &self,
+        object: &ArchiveObjectRef,
+        byte_range: Option<Range<u64>>,
+    ) -> Result<ArchiveByteStream, ArchiveError>;
+}
+
+/// Automatic hot placement policy; archived history is retained indefinitely.
+#[derive(Clone, Copy, Debug)]
+pub struct ArchivePolicy {
+    /// Target hot sealed count. Must be at least one: recovery still enforces
+    /// the most recent seal. The target plus pipeline headroom must fit the
+    /// manifest's directory budget. Active/pending objects do not count. Failures may
+    /// temporarily exceed the target; actual directory capacity remains hard.
+    pub keep_sealed_segments: usize,
+}
+
+#[derive(Clone)]
+pub(crate) struct ArchiveConfig {
+    pub store: Arc<dyn ArchiveStore>,
+    pub policy: ArchivePolicy,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub(crate) struct ArchiveState {
+    pub namespace: String,
+    /// History predating archive activation is not promised, even when a
+    /// containing archived segment happens to include some older records.
+    pub start: u64,
+    pub root: Option<ArchiveRoot>,
+    /// Exclusive boundary whose redundant zonal copies are all confirmed gone.
+    pub cleaned: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub(crate) struct ArchivedSegment {
+    pub id: String,
+    pub start: u64,
+    pub end: u64,
+    pub crc32c: u32,
+    pub object: ArchiveObjectRef,
+}
+
+/// A range- and height-qualified node reference. Format 1 is a bounded B+ tree.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub(crate) struct ArchiveRoot {
+    pub format: u32,
+    pub height: u32,
+    pub start: u64,
+    pub end: u64,
+    pub object: ArchiveObjectRef,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+enum Page {
+    Leaf(Vec<ArchivedSegment>),
+    Branch(Vec<ArchiveRoot>),
+}
+
+const FANOUT: usize = 32;
+const MAX_PAGE_BYTES: u64 = 64 * 1024;
+const MAX_HEIGHT: u32 = 16;
+
+pub(crate) fn valid_namespace(namespace: &str) -> bool {
+    // Bound the serialized form too: control characters can expand sixfold.
+    !namespace.is_empty() && serde_json::to_string(namespace).is_ok_and(|s| s.len() <= 514)
+}
+
+pub(crate) fn bytes_stream(bytes: Bytes) -> ArchiveByteStream {
+    futures::stream::once(async { Ok(bytes) }).boxed()
+}
+
+pub(crate) async fn read_all(
+    store: &dyn ArchiveStore,
+    object: &ArchiveObjectRef,
+) -> Result<Bytes, ArchiveError> {
+    let mut stream = store.read(object, None).await?;
+    let mut bytes = Vec::new();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk?;
+        if (bytes.len() as u64).saturating_add(chunk.len() as u64) > object.byte_len {
+            return Err(ArchiveError::Corrupt(object.key.clone()));
+        }
+        bytes.extend_from_slice(&chunk);
+    }
+    object.verify(&bytes)?;
+    Ok(bytes.into())
+}
+
+#[derive(Clone)]
+pub(crate) struct ArchiveCatalog {
+    store: Arc<dyn ArchiveStore>,
+}
+
+impl ArchiveCatalog {
+    pub fn new(store: Arc<dyn ArchiveStore>) -> Self {
+        Self { store }
+    }
+
+    async fn load(&self, root: &ArchiveRoot) -> Result<Page, ArchiveError> {
+        if root.format != 1
+            || root.height > MAX_HEIGHT
+            || root.start >= root.end
+            || root.object.byte_len > MAX_PAGE_BYTES
+        {
+            return Err(ArchiveError::Corrupt("invalid catalog root".into()));
+        }
+        let bytes = read_all(self.store.as_ref(), &root.object).await?;
+        let page: Page =
+            serde_json::from_slice(&bytes).map_err(|e| ArchiveError::Corrupt(e.to_string()))?;
+        let mut next = root.start;
+        let count = match &page {
+            Page::Leaf(entries) if root.height == 0 => {
+                for entry in entries {
+                    if entry.start != next || entry.start >= entry.end {
+                        return Err(ArchiveError::Corrupt("noncontiguous archive leaf".into()));
+                    }
+                    next = entry.end;
+                }
+                entries.len()
+            }
+            Page::Branch(children) if root.height > 0 => {
+                for child in children {
+                    if child.format != 1
+                        || child.height.checked_add(1) != Some(root.height)
+                        || child.start != next
+                        || child.start >= child.end
+                    {
+                        return Err(ArchiveError::Corrupt("invalid archive branch".into()));
+                    }
+                    next = child.end;
+                }
+                children.len()
+            }
+            _ => return Err(ArchiveError::Corrupt("catalog height mismatch".into())),
+        };
+        if count == 0 || count > FANOUT || next != root.end {
+            return Err(ArchiveError::Corrupt("invalid catalog page bounds".into()));
+        }
+        Ok(page)
+    }
+
+    async fn write(&self, page: Page, height: u32) -> Result<ArchiveRoot, ArchiveError> {
+        let (start, end) = match &page {
+            Page::Leaf(entries) => (entries[0].start, entries.last().unwrap().end),
+            Page::Branch(children) => (children[0].start, children.last().unwrap().end),
+        };
+        let bytes = Bytes::from(
+            serde_json::to_vec(&page).map_err(|e| ArchiveError::Backend(e.to_string()))?,
+        );
+        if bytes.len() as u64 > MAX_PAGE_BYTES || height > MAX_HEIGHT {
+            return Err(ArchiveError::Backend("archive catalog page limit".into()));
+        }
+        let object = ArchiveObjectRef::for_bytes("catalog", &bytes);
+        self.store
+            .put_if_absent(&object, bytes_stream(bytes))
+            .await?;
+        Ok(ArchiveRoot {
+            format: 1,
+            height,
+            start,
+            end,
+            object,
+        })
+    }
+
+    fn append<'a>(
+        &'a self,
+        root: &'a ArchiveRoot,
+        entry: ArchivedSegment,
+    ) -> BoxFuture<'a, Result<Vec<ArchiveRoot>, ArchiveError>> {
+        async move {
+            let page = match self.load(root).await? {
+                Page::Leaf(mut entries) => {
+                    entries.push(entry);
+                    if entries.len() > FANOUT {
+                        let last = entries.pop().unwrap();
+                        return Ok(vec![
+                            root.clone(),
+                            self.write(Page::Leaf(vec![last]), 0).await?,
+                        ]);
+                    }
+                    Page::Leaf(entries)
+                }
+                Page::Branch(mut children) => {
+                    let last = children.pop().unwrap();
+                    children.extend(self.append(&last, entry).await?);
+                    if children.len() > FANOUT {
+                        let right = children.split_off(FANOUT);
+                        return Ok(vec![
+                            self.write(Page::Branch(children), root.height).await?,
+                            self.write(Page::Branch(right), root.height).await?,
+                        ]);
+                    }
+                    Page::Branch(children)
+                }
+            };
+            Ok(vec![self.write(page, root.height).await?])
+        }
+        .boxed()
+    }
+
+    /// Prepares a new immutable root. No control state or hot data is changed.
+    pub async fn prepare_append(
+        &self,
+        previous: Option<&ArchiveRoot>,
+        entry: ArchivedSegment,
+    ) -> Result<ArchiveRoot, ArchiveError> {
+        if entry.start >= entry.end || previous.is_some_and(|root| root.end != entry.start) {
+            return Err(ArchiveError::Corrupt(
+                "archive append is not contiguous".into(),
+            ));
+        }
+        match previous {
+            None => self.write(Page::Leaf(vec![entry]), 0).await,
+            Some(root) => {
+                let mut children = self.append(root, entry).await?;
+                if children.len() == 1 {
+                    Ok(children.remove(0))
+                } else {
+                    self.write(Page::Branch(children), root.height + 1).await
+                }
+            }
+        }
+    }
+
+    /// Traversal retains at most FANOUT siblings per level, never all history.
+    pub fn scan_from(
+        &self,
+        root: ArchiveRoot,
+        start: u64,
+    ) -> BoxStream<'static, Result<ArchivedSegment, ArchiveError>> {
+        let catalog = self.clone();
+        async_stream::try_stream! {
+            let mut stack = vec![root];
+            while let Some(node) = stack.pop() {
+                if node.end <= start { continue; }
+                match catalog.load(&node).await? {
+                    Page::Leaf(entries) => for entry in entries {
+                        if entry.end > start { yield entry; }
+                    },
+                    Page::Branch(children) => stack.extend(children.into_iter().rev()),
+                }
+            }
+        }
+        .boxed()
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use futures::TryStreamExt;
+    use std::{
+        collections::HashMap,
+        sync::{
+            atomic::{AtomicBool, AtomicUsize, Ordering},
+            Mutex,
+        },
+    };
+
+    #[derive(Default)]
+    pub(crate) struct MemoryArchive {
+        pub objects: Mutex<HashMap<String, Bytes>>,
+        pub unavailable: AtomicBool,
+        pub lose_write_response: AtomicBool,
+        pub reads: AtomicUsize,
+    }
+    #[async_trait]
+    impl ArchiveStore for MemoryArchive {
+        fn namespace(&self) -> &str {
+            "memory/archive"
+        }
+        async fn put_if_absent(
+            &self,
+            object: &ArchiveObjectRef,
+            mut contents: ArchiveByteStream,
+        ) -> Result<(), ArchiveError> {
+            if self.unavailable.load(Ordering::SeqCst) {
+                return Err(ArchiveError::Unavailable("injected".into()));
+            }
+            let mut bytes = Vec::new();
+            while let Some(chunk) = contents.next().await {
+                bytes.extend_from_slice(&chunk?);
+            }
+            object.verify(&bytes)?;
+            let mut objects = self.objects.lock().unwrap();
+            if let Some(existing) = objects.get(&object.key) {
+                object.verify(existing)?;
+            } else {
+                objects.insert(object.key.clone(), bytes.into());
+            }
+            if self.lose_write_response.swap(false, Ordering::SeqCst) {
+                return Err(ArchiveError::Unavailable("lost response".into()));
+            }
+            Ok(())
+        }
+        async fn read(
+            &self,
+            object: &ArchiveObjectRef,
+            byte_range: Option<Range<u64>>,
+        ) -> Result<ArchiveByteStream, ArchiveError> {
+            self.reads.fetch_add(1, Ordering::SeqCst);
+            if self.unavailable.load(Ordering::SeqCst) {
+                return Err(ArchiveError::Unavailable("injected".into()));
+            }
+            let bytes = self
+                .objects
+                .lock()
+                .unwrap()
+                .get(&object.key)
+                .cloned()
+                .ok_or_else(|| ArchiveError::NotFound(object.key.clone()))?;
+            let range = byte_range.unwrap_or(0..bytes.len() as u64);
+            if range.start > range.end || range.end > bytes.len() as u64 {
+                return Err(ArchiveError::Backend("invalid range".into()));
+            }
+            Ok(bytes_stream(
+                bytes.slice(range.start as usize..range.end as usize),
+            ))
+        }
+    }
+
+    fn entry(index: u64) -> ArchivedSegment {
+        ArchivedSegment {
+            id: index.to_string(),
+            start: index * 2,
+            end: index * 2 + 2,
+            crc32c: 0,
+            object: ArchiveObjectRef::for_bytes("segments", &index.to_be_bytes()),
+        }
+    }
+
+    #[tokio::test]
+    async fn archive_catalog_splits_seek_lazily_and_preserves_old_roots() {
+        let store = Arc::new(MemoryArchive::default());
+        let catalog = ArchiveCatalog::new(store.clone());
+        let mut root = None;
+        let mut old = None;
+        for i in 0..1100 {
+            root = Some(
+                catalog
+                    .prepare_append(root.as_ref(), entry(i))
+                    .await
+                    .unwrap(),
+            );
+            if i == 20 {
+                old = root.clone();
+            }
+        }
+        let root = root.unwrap();
+        assert_eq!(root.height, 2);
+        store.reads.store(0, Ordering::SeqCst);
+        let mut stream = catalog.scan_from(root.clone(), 2198);
+        assert_eq!(store.reads.load(Ordering::SeqCst), 0);
+        assert_eq!(stream.try_next().await.unwrap().unwrap(), entry(1099));
+        assert!(stream.try_next().await.unwrap().is_none());
+        assert_eq!(store.reads.load(Ordering::SeqCst), 3);
+        let historical = catalog
+            .scan_from(old.unwrap(), 0)
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        assert_eq!(historical.len(), 21);
+        let all = catalog
+            .scan_from(root, 0)
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        assert_eq!(all, (0..1100).map(entry).collect::<Vec<_>>());
+    }
+
+    #[tokio::test]
+    async fn archive_catalog_rejects_gaps_corruption_and_missing_pages() {
+        let store = Arc::new(MemoryArchive::default());
+        let catalog = ArchiveCatalog::new(store.clone());
+        let root = catalog.prepare_append(None, entry(0)).await.unwrap();
+        assert!(catalog.prepare_append(Some(&root), entry(2)).await.is_err());
+        store
+            .objects
+            .lock()
+            .unwrap()
+            .insert(root.object.key.clone(), Bytes::from_static(b"corrupt"));
+        assert!(matches!(
+            catalog.scan_from(root.clone(), 0).try_next().await,
+            Err(ArchiveError::Corrupt(_))
+        ));
+        store.objects.lock().unwrap().remove(&root.object.key);
+        assert!(matches!(
+            catalog.scan_from(root, 0).try_next().await,
+            Err(ArchiveError::NotFound(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn archive_upload_lost_response_retries_identical_content() {
+        let store = MemoryArchive::default();
+        let bytes = Bytes::from_static(b"immutable");
+        let object = ArchiveObjectRef::for_bytes("segments", &bytes);
+        store.lose_write_response.store(true, Ordering::SeqCst);
+        assert!(store
+            .put_if_absent(&object, bytes_stream(bytes.clone()))
+            .await
+            .is_err());
+        store
+            .put_if_absent(&object, bytes_stream(bytes.clone()))
+            .await
+            .unwrap();
+        assert_eq!(read_all(&store, &object).await.unwrap(), bytes);
+        assert!(store
+            .put_if_absent(&object, bytes_stream(Bytes::from_static(b"different")))
+            .await
+            .is_err());
+    }
+}

--- a/rust/client/src/engine.rs
+++ b/rust/client/src/engine.rs
@@ -477,17 +477,18 @@ impl WalEngine {
         // published through the watch channel and an epoch-free manifest
         // handle of its own.
         let (catalog_tx, catalog_rx) = watch::channel(writer.sealed_segments_snapshot());
+        let (rotation_recheck, rotation_rechecks) = mpsc::channel(1);
         let (maintenance, maintenance_task) = crate::maintenance::start(
             writer.maintenance_config(config.repair_interval),
             catalog_rx,
             Arc::clone(&metrics),
+            rotation_recheck.clone(),
         );
         let (active_capacity_tx, active_capacity) = watch::channel(ActiveSegmentCapacity {
             admission_start_bytes: 0,
             existing_bytes: active_segment_bytes,
             seal_room: active_segment_seal_room,
         });
-        let (rotation_recheck, rotation_rechecks) = mpsc::channel(1);
         let (provision_requests, provision_attempts) = mpsc::channel::<ProvisionAttempt>(1);
         let (provision_results_tx, provision_results) = mpsc::channel(1);
         let (provisioner_shutdown, provisioner_shutdown_rx) = watch::channel(false);
@@ -847,6 +848,7 @@ async fn run_engine(
                 successor_due: false,
             });
     let mut rotation_rechecks_open = true;
+    let mut rotation_recheck_retry: Option<Pin<Box<Sleep>>> = None;
     // Spare provisioning runs on a dedicated worker; its result channel is a
     // `select!` wake source, so a swap waiting on a slow spare can never park
     // the engine. `spare_requested` keeps at most one attempt outstanding.
@@ -1209,24 +1211,45 @@ async fn run_engine(
             request = rotation_rechecks.recv(), if rotation_rechecks_open => {
                 match request {
                     Some(()) => {
-                        match writer.refresh_rotation_due(config.max_segment_bytes).await {
-                            Ok(due) => {
-                                rotation.release_fold_capacity_block();
-                                rotation.mark_due(due);
-                                active_capacity.send_modify(|capacity| {
-                                    capacity.seal_room =
-                                        writer.active_segment_has_seal_room();
-                                });
-                            }
+                        match refresh_rotation_capacity(
+                            &mut writer,
+                            config.max_segment_bytes,
+                            &mut rotation,
+                            &active_capacity,
+                        ).await {
+                            Ok(()) => rotation_recheck_retry = None,
                             Err(error) => {
                                 tracing::warn!(
                                     %error,
-                                    "failed to refresh rotation eligibility after truncation"
+                                    "failed to refresh rotation eligibility after capacity change; will retry"
                                 );
+                                rotation_recheck_retry = Some(Box::pin(tokio::time::sleep(
+                                    rotation_recheck_retry_delay(&client_config),
+                                )));
                             }
                         }
                     }
                     None => rotation_rechecks_open = false,
+                }
+            }
+            () = wait_rotation_recheck_retry(&mut rotation_recheck_retry), if rotation_recheck_retry.is_some() => {
+                rotation_recheck_retry = None;
+                match refresh_rotation_capacity(
+                    &mut writer,
+                    config.max_segment_bytes,
+                    &mut rotation,
+                    &active_capacity,
+                ).await {
+                    Ok(()) => {}
+                    Err(error) => {
+                        tracing::warn!(
+                            %error,
+                            "failed to refresh rotation eligibility after retry; will retry"
+                        );
+                        rotation_recheck_retry = Some(Box::pin(tokio::time::sleep(
+                            rotation_recheck_retry_delay(&client_config),
+                        )));
+                    }
                 }
             }
             // provisioning results arrive the same way: with every caller
@@ -1328,6 +1351,32 @@ async fn run_engine(
         tracing::warn!("WAL engine stopped without graceful shutdown");
     }
     metrics.queue_bytes.set(0);
+}
+
+async fn refresh_rotation_capacity(
+    writer: &mut SegmentedWriter,
+    max_segment_bytes: usize,
+    rotation: &mut Rotation,
+    active_capacity: &watch::Sender<ActiveSegmentCapacity>,
+) -> Result<(), Error> {
+    let due = writer.refresh_rotation_due(max_segment_bytes).await?;
+    rotation.release_fold_capacity_block();
+    rotation.mark_due(due);
+    active_capacity.send_modify(|capacity| {
+        capacity.seal_room = writer.active_segment_has_seal_room();
+    });
+    Ok(())
+}
+
+fn rotation_recheck_retry_delay(config: &crate::ClientConfig) -> Duration {
+    crate::protocol::retry_delay(config, config.max_retries).max(Duration::from_millis(20))
+}
+
+async fn wait_rotation_recheck_retry(retry: &mut Option<Pin<Box<Sleep>>>) {
+    match retry {
+        Some(retry) => retry.as_mut().await,
+        None => std::future::pending().await,
+    }
 }
 
 /// What the rotation wake arm of the engine's `select!` observed: the two

--- a/rust/client/src/error.rs
+++ b/rust/client/src/error.rs
@@ -16,6 +16,9 @@ use crate::transport::{TransportCode, TransportError};
 #[derive(Clone, Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum Error {
+    /// Archive storage, integrity, or availability failure.
+    #[error(transparent)]
+    Archive(#[from] crate::archive::ArchiveError),
     /// The background WAL task was aborted, failed, or shut down.
     #[error("WAL engine is closed")]
     Closed,

--- a/rust/client/src/grpc.rs
+++ b/rust/client/src/grpc.rs
@@ -26,6 +26,10 @@ use crate::transport::{
     ReplicaFactory, ReplicaRangeRead, ReplicaSnapshot, TransportCode, TransportError,
 };
 
+#[path = "grpc_archive.rs"]
+mod archive_transport;
+pub use archive_transport::{GcsArchiveStore, GcsBodyManifestStore};
+
 /// Cached zonal routing token, learned from a bidirectional read or write
 /// redirect and replayed in `x-goog-request-params` to land on the bucket's
 /// location. Shared across every replica produced by one factory.

--- a/rust/client/src/grpc_archive.rs
+++ b/rust/client/src/grpc_archive.rs
@@ -56,6 +56,17 @@ impl Drop for UploadTask {
     }
 }
 
+enum WriteError {
+    Conflict,
+    Archive(ArchiveError),
+}
+
+impl From<ArchiveError> for WriteError {
+    fn from(error: ArchiveError) -> Self {
+        Self::Archive(error)
+    }
+}
+
 async fn stat(replica: &GrpcReplica) -> Result<Object, Status> {
     let request = replica
         .request(GetObjectRequest {
@@ -121,7 +132,7 @@ fn write_bytes(
     generation: i64,
     expected: ArchiveObjectRef,
     mut contents: ArchiveByteStream,
-) -> BoxFuture<'static, Result<Object, ArchiveError>> {
+) -> BoxFuture<'static, Result<Object, WriteError>> {
     async move {
     let resource = Object { bucket: replica.bucket.clone(), name: replica.object.clone(), content_type: "application/octet-stream".into(), ..Default::default() };
     let upload_error = Arc::new(std::sync::Mutex::new(None));
@@ -163,15 +174,15 @@ fn write_bytes(
     }));
     let request = replica.request(ReceiverStream::new(rx)).map_err(archive_error)?;
     let result = replica.client.clone().write_object(request).await;
-    if let Some(error) = upload_error.lock().unwrap().take() { return Err(error); }
+    if let Some(error) = upload_error.lock().unwrap().take() { return Err(error.into()); }
     let response = result.map_err(|status| {
         if matches!(status.code(), Code::AlreadyExists | Code::FailedPrecondition) {
-            ArchiveError::Corrupt("conditional write conflict".into())
-        } else { status_error(status) }
+            WriteError::Conflict
+        } else { WriteError::Archive(status_error(status)) }
     })?.into_inner();
     match response.write_status {
         Some(write_object_response::WriteStatus::Resource(object)) => Ok(object),
-        _ => Err(ArchiveError::Unavailable("write response omitted object identity".into())),
+        _ => Err(ArchiveError::Unavailable("write response omitted object identity".into()).into()),
     }
     }.boxed()
 }
@@ -235,12 +246,12 @@ impl ArchiveStore for GcsArchiveStore {
         let replica = self.replica(object)?;
         match write_bytes(replica, 0, object.clone(), contents).await {
             Ok(_) => Ok(()),
-            Err(ArchiveError::Corrupt(message)) if message == "conditional write conflict" => {
+            Err(WriteError::Conflict) => {
                 // Check the entire existing object, not merely user metadata.
                 crate::archive::read_all(self, object).await?;
                 Ok(())
             }
-            Err(error) => Err(error),
+            Err(WriteError::Archive(error)) => Err(error),
         }
     }
     async fn read(
@@ -306,15 +317,17 @@ impl GcsBodyManifestStore {
         )
         .await
         .map_err(|e| match e {
-            ArchiveError::Corrupt(message) if message == "conditional write conflict" => {
+            WriteError::Conflict => {
                 if generation == 0 {
                     ManifestStoreError::AlreadyExists
                 } else {
                     ManifestStoreError::Conflict
                 }
             }
-            ArchiveError::Unavailable(message) => ManifestStoreError::Unavailable(message),
-            error => ManifestStoreError::Backend(error.to_string()),
+            WriteError::Archive(ArchiveError::Unavailable(message)) => {
+                ManifestStoreError::Unavailable(message)
+            }
+            WriteError::Archive(error) => ManifestStoreError::Backend(error.to_string()),
         })?;
         Ok(VersionedManifest {
             version: ManifestVersion(object.generation as u64),

--- a/rust/client/src/grpc_archive.rs
+++ b/rust/client/src/grpc_archive.rs
@@ -1,0 +1,381 @@
+//! Ordinary regional-object I/O; no zonal append or takeover semantics.
+use super::*;
+use crate::archive::{ArchiveByteStream, ArchiveError, ArchiveObjectRef, ArchiveStore};
+use crate::manifest_store::{
+    ManifestStore, ManifestStoreError, ManifestVersion, VersionedManifest,
+};
+use futures::{future::BoxFuture, FutureExt, StreamExt};
+use googleapis_tonic_google_storage_v2::google::storage::v2::ReadObjectRequest;
+use sha2::{Digest, Sha256};
+use std::ops::Range;
+
+fn bind(factory: &GrpcReplicaFactory, object: String) -> GrpcReplica {
+    GrpcReplica {
+        zone: factory.zone,
+        bucket: factory.bucket.clone(),
+        object,
+        auth: factory.auth.clone(),
+        client: factory.client.clone(),
+        routing_token: factory.routing_token.clone(),
+        read_session: Arc::new(SessionMutex::new(None)),
+        session: Arc::new(SessionSlot::new()),
+    }
+}
+
+fn archive_error(error: impl std::fmt::Display) -> ArchiveError {
+    ArchiveError::Backend(error.to_string())
+}
+fn status_error(status: Status) -> ArchiveError {
+    match status.code() {
+        Code::NotFound => ArchiveError::NotFound(status.to_string()),
+        Code::Unavailable
+        | Code::DeadlineExceeded
+        | Code::ResourceExhausted
+        | Code::Aborted
+        | Code::FailedPrecondition => ArchiveError::Unavailable(status.to_string()),
+        Code::DataLoss => ArchiveError::Corrupt(status.to_string()),
+        _ => archive_error(status),
+    }
+}
+
+fn manifest_read_error(error: ArchiveError) -> ManifestStoreError {
+    match error {
+        // A generation-pinned read can race replacement of an unversioned
+        // object after stat. Re-read the new generation, never mix bodies.
+        ArchiveError::Unavailable(message) | ArchiveError::NotFound(message) => {
+            ManifestStoreError::Unavailable(message)
+        }
+        error => ManifestStoreError::Backend(error.to_string()),
+    }
+}
+
+struct UploadTask(tokio::task::JoinHandle<()>);
+impl Drop for UploadTask {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+
+async fn stat(replica: &GrpcReplica) -> Result<Object, Status> {
+    let request = replica
+        .request(GetObjectRequest {
+            bucket: replica.bucket.clone(),
+            object: replica.object.clone(),
+            ..Default::default()
+        })
+        .map_err(|e| Status::internal(e.to_string()))?;
+    replica
+        .client
+        .clone()
+        .get_object(request)
+        .await
+        .map(|response| response.into_inner())
+}
+
+async fn read_bytes(
+    replica: &GrpcReplica,
+    object: Object,
+    range: Range<u64>,
+) -> Result<ArchiveByteStream, ArchiveError> {
+    if range.start > range.end || range.end > object.size as u64 || object.size < 0 {
+        return Err(ArchiveError::Backend("invalid object byte range".into()));
+    }
+    if range.is_empty() {
+        return Ok(futures::stream::empty().boxed());
+    }
+    let request = replica
+        .request(ReadObjectRequest {
+            bucket: replica.bucket.clone(),
+            object: replica.object.clone(),
+            generation: object.generation,
+            read_offset: range.start as i64,
+            read_limit: (range.end - range.start) as i64,
+            ..Default::default()
+        })
+        .map_err(archive_error)?;
+    let mut responses = replica
+        .client
+        .clone()
+        .read_object(request)
+        .await
+        .map_err(status_error)?
+        .into_inner();
+    Ok(async_stream::try_stream! {
+        let mut received = 0u64;
+        while let Some(response) = responses.message().await.map_err(status_error)? {
+            if let Some(data) = response.checksummed_data {
+                if data.crc32c.is_some_and(|crc| crc32c::crc32c(&data.content) != crc) {
+                    Err(ArchiveError::Corrupt("archive response checksum".into()))?;
+                }
+                received = received.checked_add(data.content.len() as u64).ok_or_else(|| ArchiveError::Corrupt("archive length overflow".into()))?;
+                if received > range.end - range.start { Err(ArchiveError::Corrupt("archive response overrun".into()))?; }
+                yield data.content;
+            }
+        }
+        if received != range.end - range.start { Err(ArchiveError::Corrupt("short archive read".into()))?; }
+    }.boxed())
+}
+
+fn write_bytes(
+    replica: GrpcReplica,
+    generation: i64,
+    expected: ArchiveObjectRef,
+    mut contents: ArchiveByteStream,
+) -> BoxFuture<'static, Result<Object, ArchiveError>> {
+    async move {
+    let resource = Object { bucket: replica.bucket.clone(), name: replica.object.clone(), content_type: "application/octet-stream".into(), ..Default::default() };
+    let upload_error = Arc::new(std::sync::Mutex::new(None));
+    let stream_error = upload_error.clone();
+    let requests = async_stream::stream! {
+        yield WriteObjectRequest { first_message: Some(write_object_request::FirstMessage::WriteObjectSpec(WriteObjectSpec {
+            resource: Some(resource), if_generation_match: Some(generation), ..Default::default()
+        })), ..Default::default() };
+        let mut offset = 0u64;
+        let mut digest = Sha256::new();
+        while let Some(chunk) = contents.next().await {
+            let chunk = match chunk { Ok(chunk) => chunk, Err(error) => { *stream_error.lock().unwrap() = Some(error); return; } };
+            let mut position = 0;
+            while position < chunk.len() {
+                let end = (position + 256 * 1024).min(chunk.len());
+                let bytes = chunk.slice(position..end);
+                if offset.saturating_add(bytes.len() as u64) > expected.byte_len {
+                    *stream_error.lock().unwrap() = Some(ArchiveError::Corrupt("upload exceeds reference length".into())); return;
+                }
+                digest.update(&bytes);
+                yield WriteObjectRequest { write_offset: offset as i64, data: Some(write_object_request::Data::ChecksummedData(ChecksummedData {
+                    content: bytes.clone(), crc32c: Some(crc32c::crc32c(&bytes))
+                })), ..Default::default() };
+                offset += bytes.len() as u64;
+                position = end;
+            }
+        }
+        if offset != expected.byte_len || <[u8;32]>::from(digest.finalize()) != expected.sha256 {
+            *stream_error.lock().unwrap() = Some(ArchiveError::Corrupt("upload does not match reference".into())); return;
+        }
+        yield WriteObjectRequest { write_offset: offset as i64, finish_write: true, ..Default::default() };
+    };
+    let (tx, rx) = mpsc::channel(2);
+    let mut requests = requests.boxed();
+    let _upload = UploadTask(tokio::spawn(async move {
+        while let Some(request) = requests.next().await {
+            if tx.send(request).await.is_err() { break; }
+        }
+    }));
+    let request = replica.request(ReceiverStream::new(rx)).map_err(archive_error)?;
+    let result = replica.client.clone().write_object(request).await;
+    if let Some(error) = upload_error.lock().unwrap().take() { return Err(error); }
+    let response = result.map_err(|status| {
+        if matches!(status.code(), Code::AlreadyExists | Code::FailedPrecondition) {
+            ArchiveError::Corrupt("conditional write conflict".into())
+        } else { status_error(status) }
+    })?.into_inner();
+    match response.write_status {
+        Some(write_object_response::WriteStatus::Resource(object)) => Ok(object),
+        _ => Err(ArchiveError::Unavailable("write response omitted object identity".into())),
+    }
+    }.boxed()
+}
+
+/// Immutable WAL/catalog objects in an ordinary regional GCS bucket.
+#[derive(Clone)]
+pub struct GcsArchiveStore {
+    factory: GrpcReplicaFactory,
+    prefix: String,
+    namespace: String,
+}
+
+impl GcsArchiveStore {
+    /// Bind a regional bucket connection to one WAL's archive prefix.
+    pub fn new(factory: GrpcReplicaFactory, prefix: impl Into<String>) -> Result<Self, Error> {
+        let prefix = prefix.into().trim_matches('/').to_string();
+        if prefix.is_empty() {
+            return Err(Error::InvalidConfig("archive prefix must not be empty"));
+        }
+        let namespace = format!("{}/{}", factory.bucket, prefix);
+        if !crate::archive::valid_namespace(&namespace) {
+            return Err(Error::InvalidConfig(
+                "archive namespace exceeds its encoded byte limit",
+            ));
+        }
+        Ok(Self {
+            factory,
+            prefix,
+            namespace,
+        })
+    }
+
+    fn replica(&self, object: &ArchiveObjectRef) -> Result<GrpcReplica, ArchiveError> {
+        if object.key.is_empty()
+            || object.key.starts_with('/')
+            || object
+                .key
+                .split('/')
+                .any(|part| part == ".." || part.is_empty())
+            || object.byte_len > i64::MAX as u64
+        {
+            return Err(archive_error("invalid archive object reference"));
+        }
+        Ok(bind(
+            &self.factory,
+            format!("{}/{}", self.prefix, object.key),
+        ))
+    }
+}
+
+#[async_trait]
+impl ArchiveStore for GcsArchiveStore {
+    fn namespace(&self) -> &str {
+        &self.namespace
+    }
+    async fn put_if_absent(
+        &self,
+        object: &ArchiveObjectRef,
+        contents: ArchiveByteStream,
+    ) -> Result<(), ArchiveError> {
+        let replica = self.replica(object)?;
+        match write_bytes(replica, 0, object.clone(), contents).await {
+            Ok(_) => Ok(()),
+            Err(ArchiveError::Corrupt(message)) if message == "conditional write conflict" => {
+                // Check the entire existing object, not merely user metadata.
+                crate::archive::read_all(self, object).await?;
+                Ok(())
+            }
+            Err(error) => Err(error),
+        }
+    }
+    async fn read(
+        &self,
+        object: &ArchiveObjectRef,
+        byte_range: Option<Range<u64>>,
+    ) -> Result<ArchiveByteStream, ArchiveError> {
+        let replica = self.replica(object)?;
+        let metadata = stat(&replica).await.map_err(status_error)?;
+        if metadata.size < 0 || metadata.size as u64 != object.byte_len {
+            return Err(ArchiveError::Corrupt(object.key.clone()));
+        }
+        read_bytes(&replica, metadata, byte_range.unwrap_or(0..object.byte_len)).await
+    }
+}
+
+/// A larger CAS register stored in a GCS object body. Each update replaces the
+/// body using the observed generation, never delete/recreate. It remains a
+/// bounded control register; archive history belongs in paged catalog objects.
+pub struct GcsBodyManifestStore {
+    replica: GrpcReplica,
+    max_directory_bytes: usize,
+}
+
+impl GcsBodyManifestStore {
+    /// Bind an ordinary regional object and its advertised directory budget.
+    pub fn new(
+        factory: GrpcReplicaFactory,
+        object: impl Into<String>,
+        max_directory_bytes: usize,
+    ) -> Result<Self, Error> {
+        let object = object.into();
+        if object.is_empty() || max_directory_bytes == 0 {
+            return Err(Error::InvalidConfig(
+                "body manifest requires an object and nonzero capacity",
+            ));
+        }
+        Ok(Self {
+            replica: bind(&factory, object),
+            max_directory_bytes,
+        })
+    }
+
+    async fn put(
+        &self,
+        generation: i64,
+        fields: HashMap<String, String>,
+    ) -> Result<VersionedManifest, ManifestStoreError> {
+        let bytes = Bytes::from(
+            serde_json::to_vec(&fields).map_err(|e| ManifestStoreError::Backend(e.to_string()))?,
+        );
+        if bytes.len() as u64 > self.max_body_bytes() {
+            return Err(ManifestStoreError::Backend(
+                "manifest body exceeds configured limit".into(),
+            ));
+        }
+        let reference = ArchiveObjectRef::for_bytes("manifest", &bytes);
+        let object = write_bytes(
+            self.replica.clone(),
+            generation,
+            reference,
+            crate::archive::bytes_stream(bytes),
+        )
+        .await
+        .map_err(|e| match e {
+            ArchiveError::Corrupt(message) if message == "conditional write conflict" => {
+                if generation == 0 {
+                    ManifestStoreError::AlreadyExists
+                } else {
+                    ManifestStoreError::Conflict
+                }
+            }
+            ArchiveError::Unavailable(message) => ManifestStoreError::Unavailable(message),
+            error => ManifestStoreError::Backend(error.to_string()),
+        })?;
+        Ok(VersionedManifest {
+            version: ManifestVersion(object.generation as u64),
+            fields,
+        })
+    }
+
+    fn max_body_bytes(&self) -> u64 {
+        // JSON escaping can expand the directory up to sixfold.
+        (self.max_directory_bytes as u64)
+            .saturating_mul(6)
+            .saturating_add(16384)
+            .min(i64::MAX as u64)
+    }
+}
+
+#[async_trait]
+impl ManifestStore for GcsBodyManifestStore {
+    fn max_directory_bytes(&self) -> usize {
+        self.max_directory_bytes
+    }
+    async fn read(&self) -> Result<Option<VersionedManifest>, ManifestStoreError> {
+        let object = match stat(&self.replica).await {
+            Ok(object) => object,
+            Err(status) if status.code() == Code::NotFound => return Ok(None),
+            Err(status) => return Err(manifest_read_error(status_error(status))),
+        };
+        let version = ManifestVersion(object.generation as u64);
+        if object.size < 0 || object.size as u64 > self.max_body_bytes() {
+            return Err(ManifestStoreError::Backend(
+                "manifest body exceeds configured limit".into(),
+            ));
+        }
+        let size = object.size as u64;
+        let mut stream = read_bytes(&self.replica, object, 0..size)
+            .await
+            .map_err(manifest_read_error)?;
+        let mut bytes = Vec::new();
+        while let Some(chunk) = stream.next().await {
+            bytes.extend_from_slice(&chunk.map_err(manifest_read_error)?);
+        }
+        let fields = serde_json::from_slice(&bytes)
+            .map_err(|e| ManifestStoreError::Backend(e.to_string()))?;
+        Ok(Some(VersionedManifest { version, fields }))
+    }
+    async fn create(
+        &self,
+        fields: HashMap<String, String>,
+    ) -> Result<VersionedManifest, ManifestStoreError> {
+        self.put(0, fields).await
+    }
+    async fn update(
+        &self,
+        version: ManifestVersion,
+        fields: HashMap<String, String>,
+    ) -> Result<VersionedManifest, ManifestStoreError> {
+        let generation = i64::try_from(version.0)
+            .map_err(|_| ManifestStoreError::Backend("invalid GCS generation".into()))?;
+        if generation == 0 {
+            return Err(ManifestStoreError::Conflict);
+        }
+        self.put(generation, fields).await
+    }
+}

--- a/rust/client/src/grpc_internal_tests.rs
+++ b/rust/client/src/grpc_internal_tests.rs
@@ -15,6 +15,8 @@ use chorus_fake_gcs::{FakeGcs, LatencyProfile, Operation, SimulatedLatency};
 use futures::{stream::FuturesUnordered, StreamExt, TryStreamExt};
 use tonic::Code;
 
+mod archive;
+
 async fn factory_cluster() -> (
     Vec<chorus_fake_gcs::RunningFake>,
     Vec<Arc<dyn ReplicaFactory>>,

--- a/rust/client/src/grpc_internal_tests/archive.rs
+++ b/rust/client/src/grpc_internal_tests/archive.rs
@@ -1,0 +1,597 @@
+use super::*;
+use crate::archive::{
+    bytes_stream, read_all, tests::MemoryArchive, ArchiveConfig, ArchiveObjectRef,
+};
+use crate::manifest::Manifest;
+use crate::{
+    ArchivePolicy, ArchiveStore, GcsArchiveStore, GcsBodyManifestStore, ManifestStore,
+    ManifestStoreError, ManifestVersion, VersionedManifest,
+};
+use bytes::Bytes;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use tokio::sync::Notify;
+
+struct PausedFrontierManifest {
+    inner: Arc<dyn ManifestStore>,
+    old_tail: String,
+    armed: AtomicBool,
+    entered: Notify,
+    resume: Notify,
+    conflicts: AtomicUsize,
+}
+
+#[async_trait::async_trait]
+impl ManifestStore for PausedFrontierManifest {
+    fn max_directory_bytes(&self) -> usize {
+        self.inner.max_directory_bytes()
+    }
+
+    async fn read(&self) -> Result<Option<VersionedManifest>, ManifestStoreError> {
+        self.inner.read().await
+    }
+
+    async fn create(
+        &self,
+        fields: HashMap<String, String>,
+    ) -> Result<VersionedManifest, ManifestStoreError> {
+        self.inner.create(fields).await
+    }
+
+    async fn update(
+        &self,
+        version: ManifestVersion,
+        fields: HashMap<String, String>,
+    ) -> Result<VersionedManifest, ManifestStoreError> {
+        // Claim preserves the tail. Its later replacement uses a recovery
+        // catalog already adopted from that claimed manifest snapshot.
+        if fields.get("chorus.tail_id") != Some(&self.old_tail)
+            && self.armed.swap(false, Ordering::SeqCst)
+        {
+            self.entered.notify_one();
+            self.resume.notified().await;
+        }
+        let result = self.inner.update(version, fields).await;
+        if matches!(result, Err(ManifestStoreError::Conflict)) {
+            self.conflicts.fetch_add(1, Ordering::SeqCst);
+        }
+        result
+    }
+}
+
+async fn archive_during_recovery(initially_archived: bool, checkpoint: u64) {
+    let (_servers, factories, regional) = factory_cluster().await;
+    let prefix = "archive-recovery-snapshot";
+    let archive = Arc::new(MemoryArchive::default());
+    let policy = ArchivePolicy {
+        keep_sealed_segments: 1,
+    };
+    let volume = volume(factories.clone(), regional.clone(), prefix)
+        .with_archive(archive.clone(), policy)
+        .unwrap();
+    let mut writer = volume.recover_writer().await.unwrap();
+    for value in [b"a", b"b", b"c", b"d"] {
+        append_one(&mut writer, value).await;
+        writer.rotate().await.unwrap();
+    }
+    drop(writer);
+    let mut manifest = manifest_for(&regional, prefix).await;
+    let config = ArchiveConfig {
+        store: archive.clone(),
+        policy,
+    };
+    if initially_archived {
+        assert!(
+            crate::segment::archive_one(&config, &factories, prefix, &mut manifest)
+                .await
+                .unwrap()
+        );
+        crate::segment::cleanup_archived_one(&config, &factories, prefix, &mut manifest)
+            .await
+            .unwrap();
+    }
+    let old_tail = manifest.record().tail_id.clone().unwrap();
+    // A missing empty frontier forces a CAS during recovery preparation.
+    for factory in &factories {
+        let replica = factory.replica(&segment_object(prefix, &old_tail));
+        replica
+            .delete(replica.stat().await.unwrap().generation)
+            .await
+            .unwrap();
+    }
+    let paused = Arc::new(PausedFrontierManifest {
+        inner: manifest.store(),
+        old_tail,
+        armed: AtomicBool::new(true),
+        entered: Notify::new(),
+        resume: Notify::new(),
+        conflicts: AtomicUsize::new(0),
+    });
+    let volume = SegmentedVolume::new_with_factories_and_manifest_store(
+        factories.clone(),
+        paused.clone(),
+        prefix,
+        test_config(),
+    )
+    .unwrap()
+    .with_archive(archive, policy)
+    .unwrap();
+    let recover = volume.recover(WalSeqNo::record(checkpoint));
+    let publish = async {
+        paused.entered.notified().await;
+        // Move an entry out of the adopted hot catalog and remove every hot
+        // copy. Replay must resolve its exact identity through archive fallback.
+        assert!(
+            crate::segment::archive_one(&config, &factories, prefix, &mut manifest)
+                .await
+                .unwrap()
+        );
+        crate::segment::cleanup_archived_one(&config, &factories, prefix, &mut manifest)
+            .await
+            .unwrap();
+        paused.resume.notify_one();
+    };
+    let (recovery, ()) = tokio::time::timeout(Duration::from_secs(10), async {
+        tokio::join!(recover, publish)
+    })
+    .await
+    .expect("recovery did not reach and retry the frontier CAS");
+    assert!(paused.conflicts.load(Ordering::SeqCst) > 0);
+    let mut recovery = recovery.unwrap();
+    assert_eq!(recovery.end, WalSeqNo::record(4));
+    let records = (&mut recovery).try_collect::<Vec<_>>().await.unwrap();
+    assert_eq!(
+        records
+            .iter()
+            .map(|record| record.seqno.record_index)
+            .collect::<Vec<_>>(),
+        (checkpoint..4).collect::<Vec<_>>(),
+        "initially_archived={initially_archived}, checkpoint={checkpoint}"
+    );
+    for record in records {
+        assert_eq!(
+            record.payload.as_ref(),
+            &[b'a' + record.seqno.record_index as u8]
+        );
+    }
+    shutdown_engine(recovery.start(WalEngineConfig::default()).await.unwrap()).await;
+}
+
+#[tokio::test]
+async fn archive_recovery_keeps_adopted_empty_root_during_publication() {
+    archive_during_recovery(false, 0).await;
+}
+
+#[tokio::test]
+async fn archive_recovery_keeps_adopted_root_during_publication() {
+    for checkpoint in [0, 1, 2] {
+        archive_during_recovery(true, checkpoint).await;
+    }
+}
+
+async fn manifest_for(factory: &Arc<dyn ReplicaFactory>, prefix: &str) -> Manifest {
+    Manifest::open(
+        Arc::new(crate::manifest_store::GcsManifestStore::new(
+            factory.replica(&format!("{prefix}/manifest")),
+        )),
+        test_config(),
+        Arc::new(crate::metrics::Metrics::new(&crate::NoopMetricsRecorder, 3)),
+        3,
+        (0..3).map(|i| format!("zone-{i}")).collect(),
+    )
+    .await
+    .unwrap()
+}
+
+#[tokio::test]
+async fn archive_eviction_preserves_recovery_and_stale_readers() {
+    let (servers, factories, regional) = factory_cluster().await;
+    let prefix = "archive-recovery";
+    let archive_factory =
+        GrpcReplicaFactory::connect(3, &servers[3].endpoint, "projects/_/buckets/regional", None)
+            .await
+            .unwrap();
+    let store =
+        Arc::new(GcsArchiveStore::new(archive_factory, format!("{prefix}/archive")).unwrap());
+    let policy = ArchivePolicy {
+        keep_sealed_segments: 1,
+    };
+    let plain = volume(factories.clone(), regional.clone(), prefix);
+    assert!(plain
+        .clone()
+        .with_archive(
+            store.clone(),
+            ArchivePolicy {
+                keep_sealed_segments: 0
+            }
+        )
+        .is_err());
+    assert!(plain
+        .clone()
+        .with_archive(
+            store.clone(),
+            ArchivePolicy {
+                keep_sealed_segments: usize::MAX
+            }
+        )
+        .is_err());
+    let volume = plain.clone().with_archive(store.clone(), policy).unwrap();
+    let mut writer = volume.recover_writer().await.unwrap();
+    for value in [b"a", b"b", b"c"] {
+        append_one(&mut writer, value).await;
+        writer.rotate().await.unwrap();
+    }
+    drop(writer);
+    // The reader caches a hot-only manifest, then loses those zonal objects.
+    let mut follower = volume.open_readonly(WalSeqNo::ZERO).await.unwrap();
+    let mut manifest = manifest_for(&regional, prefix).await;
+    let ids: Vec<_> = manifest
+        .record()
+        .segments
+        .iter()
+        .map(|entry| entry.id.clone())
+        .collect();
+    let config = ArchiveConfig {
+        store: store.clone(),
+        policy,
+    };
+    assert!(
+        crate::segment::archive_one(&config, &factories, prefix, &mut manifest)
+            .await
+            .unwrap()
+    );
+    assert!(
+        crate::segment::archive_one(&config, &factories, prefix, &mut manifest)
+            .await
+            .unwrap()
+    );
+    assert!(
+        !crate::segment::archive_one(&config, &factories, prefix, &mut manifest)
+            .await
+            .unwrap()
+    );
+    for _ in 0..2 {
+        crate::segment::cleanup_archived_one(&config, &factories, prefix, &mut manifest)
+            .await
+            .unwrap();
+    }
+    assert_eq!(manifest.record().trunc, 0);
+    assert_eq!(manifest.record().segments.len(), 1);
+    assert_eq!(manifest.record().archive.as_ref().unwrap().cleaned, 2);
+    for factory in &factories {
+        for id in &ids[..2] {
+            assert_eq!(
+                factory
+                    .replica(&segment_object(prefix, id))
+                    .stat()
+                    .await
+                    .unwrap_err()
+                    .code,
+                TransportCode::NotFound
+            );
+        }
+    }
+    for (index, expected) in [b"a", b"b", b"c"].iter().enumerate() {
+        let record = tokio::time::timeout(Duration::from_secs(5), follower.try_next())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(record.seqno.record_index, index as u64);
+        assert_eq!(record.payload.as_ref(), *expected);
+    }
+    drop(follower);
+    assert!(matches!(
+        plain.recover(WalSeqNo::ZERO).await,
+        Err(Error::InvalidConfig(_))
+    ));
+    let mut recovery = volume.recover(WalSeqNo::ZERO).await.unwrap();
+    let records = (&mut recovery).try_collect::<Vec<_>>().await.unwrap();
+    assert_eq!(
+        records
+            .iter()
+            .map(|r| r.payload.clone())
+            .collect::<Vec<_>>(),
+        vec![
+            Bytes::from_static(b"a"),
+            Bytes::from_static(b"b"),
+            Bytes::from_static(b"c")
+        ]
+    );
+    let handle = recovery.start(WalEngineConfig::default()).await.unwrap();
+    handle.truncate_before(WalSeqNo::record(3)).await.unwrap();
+    let mut historical = volume.open_readonly(WalSeqNo::ZERO).await.unwrap();
+    assert_eq!(
+        historical
+            .try_next()
+            .await
+            .unwrap()
+            .unwrap()
+            .payload
+            .as_ref(),
+        b"a"
+    );
+    drop(historical);
+    shutdown_engine(handle).await;
+}
+
+#[tokio::test]
+async fn archive_failure_and_unavailable_zone_do_not_lose_history_or_hold_slots() {
+    let (servers, factories, regional) = factory_cluster().await;
+    let prefix = "archive-faults";
+    let store = Arc::new(MemoryArchive::default());
+    let policy = ArchivePolicy {
+        keep_sealed_segments: 1,
+    };
+    let volume = volume(factories.clone(), regional.clone(), prefix)
+        .with_archive(store.clone(), policy)
+        .unwrap();
+    let mut writer = volume.recover_writer().await.unwrap();
+    for _ in 0..3 {
+        append_one(&mut writer, b"a").await;
+        writer.rotate().await.unwrap();
+    }
+    drop(writer);
+    let mut manifest = manifest_for(&regional, prefix).await;
+    let config = ArchiveConfig {
+        store: store.clone(),
+        policy,
+    };
+    let before = manifest.record().clone();
+    store.lose_write_response.store(true, Ordering::SeqCst);
+    assert!(
+        crate::segment::archive_one(&config, &factories, prefix, &mut manifest)
+            .await
+            .is_err()
+    );
+    assert_eq!(manifest.record(), &before);
+    store.unavailable.store(true, Ordering::SeqCst);
+    assert!(
+        crate::segment::archive_one(&config, &factories, prefix, &mut manifest)
+            .await
+            .is_err()
+    );
+    assert_eq!(manifest.record(), &before);
+    store.unavailable.store(false, Ordering::SeqCst);
+    assert!(
+        crate::segment::archive_one(&config, &factories, prefix, &mut manifest)
+            .await
+            .unwrap()
+    );
+    servers[0].service.set_crashed(true).await;
+    crate::segment::cleanup_archived_one(&config, &factories, prefix, &mut manifest)
+        .await
+        .unwrap();
+    assert_eq!(manifest.record().segments.len(), 2);
+    assert_eq!(manifest.record().archive.as_ref().unwrap().cleaned, 0);
+    servers[0].service.set_crashed(false).await;
+    crate::segment::cleanup_archived_one(&config, &factories, prefix, &mut manifest)
+        .await
+        .unwrap();
+    assert_eq!(manifest.record().archive.as_ref().unwrap().cleaned, 1);
+}
+
+#[tokio::test]
+async fn archive_gcs_streams_immutable_objects_and_body_manifest_cas() {
+    let server = FakeGcs::default().start().await.unwrap();
+    let factory =
+        GrpcReplicaFactory::connect(0, &server.endpoint, "projects/_/buckets/archive", None)
+            .await
+            .unwrap();
+    let store = GcsArchiveStore::new(factory.clone(), "wal").unwrap();
+    let bytes = Bytes::from(vec![37; 700_000]);
+    let object = ArchiveObjectRef::for_bytes("segments", &bytes);
+    store
+        .put_if_absent(&object, bytes_stream(bytes.clone()))
+        .await
+        .unwrap();
+    store
+        .put_if_absent(&object, bytes_stream(bytes.clone()))
+        .await
+        .unwrap();
+    assert_eq!(read_all(&store, &object).await.unwrap(), bytes);
+    let chunks = store
+        .read(&object, Some(123..456))
+        .await
+        .unwrap()
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+    assert_eq!(chunks.concat(), bytes[123..456]);
+    let mut conflicting = ArchiveObjectRef::for_bytes("segments", b"different");
+    conflicting.key = object.key.clone();
+    assert!(store
+        .put_if_absent(&conflicting, bytes_stream(Bytes::from_static(b"different")))
+        .await
+        .is_err());
+    let manifest = GcsBodyManifestStore::new(factory, "manifest", 100_000).unwrap();
+    let first = manifest
+        .create(HashMap::from([("payload".into(), "x".repeat(9000))]))
+        .await
+        .unwrap();
+    assert_eq!(manifest.read().await.unwrap().unwrap().fields, first.fields);
+    let second = manifest
+        .update(
+            first.version,
+            HashMap::from([("payload".into(), "new".into())]),
+        )
+        .await
+        .unwrap();
+    assert_ne!(first.version, second.version);
+    assert!(matches!(
+        manifest.update(first.version, first.fields).await,
+        Err(crate::ManifestStoreError::Conflict)
+    ));
+}
+
+#[tokio::test]
+async fn archive_policy_relieves_full_body_manifest_without_raising_floor() {
+    let (servers, factories, _) = factory_cluster().await;
+    let regional =
+        GrpcReplicaFactory::connect(3, &servers[3].endpoint, "projects/_/buckets/regional", None)
+            .await
+            .unwrap();
+    let manifest_store =
+        Arc::new(GcsBodyManifestStore::new(regional, "archive-auto/manifest", 512).unwrap());
+    let archive = Arc::new(MemoryArchive::default());
+    let volume = SegmentedVolume::new_with_factories_and_manifest_store(
+        factories,
+        manifest_store.clone(),
+        "archive-auto",
+        test_config(),
+    )
+    .unwrap()
+    .with_archive(
+        archive.clone(),
+        ArchivePolicy {
+            keep_sealed_segments: 1,
+        },
+    )
+    .unwrap();
+    let mut writer = volume.recover_writer().await.unwrap();
+    let mut rotations = 0;
+    loop {
+        append_one(&mut writer, b"x").await;
+        if !writer.rotation_due(1) {
+            break;
+        }
+        writer.rotate().await.unwrap();
+        rotations += 1;
+        assert!(rotations < 16);
+    }
+    assert!(rotations >= 2);
+    let next = writer.committed_record_end();
+    archive.unavailable.store(true, Ordering::SeqCst);
+    let mut handle = WalEngine::start(
+        writer,
+        WalEngineConfig {
+            max_record_bytes: 1,
+            max_inflight_bytes: 5,
+            max_replica_lag_bytes: 5,
+            max_segment_bytes: 1,
+            max_active_segment_bytes: 5,
+            repair_interval: None,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert!(matches!(
+        handle
+            .enqueue_append(WalSeqNo::record(next), Bytes::from_static(b"y"))
+            .await,
+        Err(Error::ActiveSegmentFull { .. })
+    ));
+    archive.unavailable.store(false, Ordering::SeqCst);
+    tokio::time::timeout(Duration::from_secs(15), async {
+        for index in next..next + 20 {
+            loop {
+                match handle
+                    .enqueue_append(WalSeqNo::record(index), Bytes::from_static(b"y"))
+                    .await
+                {
+                    Err(Error::ActiveSegmentFull { .. }) => {
+                        tokio::time::sleep(Duration::from_millis(10)).await
+                    }
+                    result => {
+                        result.unwrap().await.unwrap();
+                        break;
+                    }
+                }
+            }
+        }
+    })
+    .await
+    .expect("archival did not relieve directory backpressure");
+    tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            let state = match manifest_store.read().await {
+                Err(crate::ManifestStoreError::Unavailable(_)) => {
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                    continue;
+                }
+                result => result.unwrap().unwrap(),
+            };
+            assert_eq!(state.fields["chorus.trunc"], "0");
+            if !state.fields["chorus.segments"].contains(',') {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("hot retention target did not converge");
+    shutdown_engine(handle).await;
+    let mut recovery = volume.recover(WalSeqNo::ZERO).await.unwrap();
+    let records = (&mut recovery).try_collect::<Vec<_>>().await.unwrap();
+    assert_eq!(records.len() as u64, next + 20);
+    for (index, record) in records.iter().enumerate() {
+        assert_eq!(record.seqno.record_index, index as u64);
+    }
+}
+
+#[tokio::test]
+async fn archive_publication_revalidates_parent_and_preserves_checkpoint() {
+    let (_servers, factories, regional) = factory_cluster().await;
+    let store = Arc::new(MemoryArchive::default());
+    let policy = ArchivePolicy {
+        keep_sealed_segments: 1,
+    };
+    let prefix = "archive-cas";
+    let volume = volume(factories.clone(), regional.clone(), prefix)
+        .with_archive(store.clone(), policy)
+        .unwrap();
+    let mut writer = volume.recover_writer().await.unwrap();
+    for _ in 0..3 {
+        append_one(&mut writer, b"a").await;
+        writer.rotate().await.unwrap();
+    }
+    drop(writer);
+    let mut stale = manifest_for(&regional, prefix).await;
+    let first = stale.record().segments[0].clone();
+    let bytes = record(b"a").encode().unwrap();
+    let entry = crate::archive::ArchivedSegment {
+        id: first.id,
+        start: 0,
+        end: 1,
+        crc32c: first.crc32c,
+        object: ArchiveObjectRef::for_bytes("segments", &bytes),
+    };
+    store
+        .put_if_absent(&entry.object, bytes_stream(bytes))
+        .await
+        .unwrap();
+    let root = crate::archive::ArchiveCatalog::new(store.clone())
+        .prepare_append(None, entry.clone())
+        .await
+        .unwrap();
+    let mut other = manifest_for(&regional, prefix).await;
+    other.raise_trunc(3).await.unwrap();
+    let mut wrong = entry.clone();
+    wrong.end = 2;
+    assert!(!stale.publish_archive(None, &root, &wrong).await.unwrap());
+    assert!(stale.publish_archive(None, &root, &entry).await.unwrap());
+    assert_eq!(stale.record().trunc, 3);
+    assert!(other.publish_archive(None, &root, &entry).await.unwrap());
+    let config = ArchiveConfig { store, policy };
+    assert!(
+        crate::segment::archive_one(&config, &factories, prefix, &mut other)
+            .await
+            .unwrap()
+    );
+    // An idempotent success from a cached view is harmless: it cannot write
+    // the old root back. Refresh before checking a genuinely stale parent.
+    stale.refreshed_record().await.unwrap();
+    assert!(!stale.publish_archive(None, &root, &entry).await.unwrap());
+    assert_eq!(
+        stale
+            .record()
+            .archive
+            .as_ref()
+            .unwrap()
+            .root
+            .as_ref()
+            .unwrap()
+            .end,
+        2
+    );
+    assert_eq!(stale.record().trunc, 3);
+}

--- a/rust/client/src/grpc_internal_tests/archive.rs
+++ b/rust/client/src/grpc_internal_tests/archive.rs
@@ -399,10 +399,28 @@ async fn archive_gcs_streams_immutable_objects_and_body_manifest_cas() {
     assert_eq!(chunks.concat(), bytes[123..456]);
     let mut conflicting = ArchiveObjectRef::for_bytes("segments", b"different");
     conflicting.key = object.key.clone();
-    assert!(store
-        .put_if_absent(&conflicting, bytes_stream(Bytes::from_static(b"different")))
+    assert!(matches!(
+        store
+            .put_if_absent(&conflicting, bytes_stream(Bytes::from_static(b"different")))
+            .await,
+        Err(crate::ArchiveError::Corrupt(_))
+    ));
+    let corrupt_bytes = Bytes::from_static(b"genuine-corruption-error");
+    let corrupt = ArchiveObjectRef::for_bytes("segments", &corrupt_bytes);
+    server
+        .service
+        .inject(Operation::BidiWrite, Code::DataLoss)
+        .await;
+    assert!(matches!(
+        store
+            .put_if_absent(&corrupt, bytes_stream(corrupt_bytes.clone()))
+            .await,
+        Err(crate::ArchiveError::Corrupt(_))
+    ));
+    store
+        .put_if_absent(&corrupt, bytes_stream(corrupt_bytes))
         .await
-        .is_err());
+        .unwrap();
     let manifest = GcsBodyManifestStore::new(factory, "manifest", 100_000).unwrap();
     let first = manifest
         .create(HashMap::from([("payload".into(), "x".repeat(9000))]))

--- a/rust/client/src/grpc_internal_tests/engine.rs
+++ b/rust/client/src/grpc_internal_tests/engine.rs
@@ -1,4 +1,75 @@
 use super::*;
+use std::sync::atomic::Ordering;
+
+struct FailFirstReadAfterRemoval {
+    inner: Arc<dyn crate::ManifestStore>,
+    last_segments: std::sync::Mutex<Option<String>>,
+    armed: std::sync::atomic::AtomicBool,
+    fail_next_read: std::sync::atomic::AtomicBool,
+    failed_reads: std::sync::atomic::AtomicUsize,
+}
+
+impl FailFirstReadAfterRemoval {
+    fn remember(&self, state: &crate::VersionedManifest) {
+        *self.last_segments.lock().unwrap() = state.fields.get("chorus.segments").cloned();
+    }
+
+    fn entry_count(encoded: Option<&String>) -> usize {
+        encoded.map_or(0, |value| {
+            if value.is_empty() {
+                0
+            } else {
+                value.matches(',').count() + 1
+            }
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl crate::ManifestStore for FailFirstReadAfterRemoval {
+    fn max_directory_bytes(&self) -> usize {
+        self.inner.max_directory_bytes()
+    }
+
+    async fn read(&self) -> Result<Option<crate::VersionedManifest>, crate::ManifestStoreError> {
+        if self.fail_next_read.swap(false, Ordering::SeqCst) {
+            self.failed_reads.fetch_add(1, Ordering::SeqCst);
+            return Err(crate::ManifestStoreError::Unavailable(
+                "injected capacity refresh failure".into(),
+            ));
+        }
+        let state = self.inner.read().await?;
+        if let Some(state) = &state {
+            self.remember(state);
+        }
+        Ok(state)
+    }
+
+    async fn create(
+        &self,
+        fields: HashMap<String, String>,
+    ) -> Result<crate::VersionedManifest, crate::ManifestStoreError> {
+        let state = self.inner.create(fields).await?;
+        self.remember(&state);
+        Ok(state)
+    }
+
+    async fn update(
+        &self,
+        version: crate::ManifestVersion,
+        fields: HashMap<String, String>,
+    ) -> Result<crate::VersionedManifest, crate::ManifestStoreError> {
+        let before = self.last_segments.lock().unwrap().clone();
+        let state = self.inner.update(version, fields).await?;
+        let removed = Self::entry_count(state.fields.get("chorus.segments"))
+            < Self::entry_count(before.as_ref());
+        self.remember(&state);
+        if removed && self.armed.swap(false, Ordering::SeqCst) {
+            self.fail_next_read.store(true, Ordering::SeqCst);
+        }
+        Ok(state)
+    }
+}
 
 #[tokio::test]
 async fn caller_numbered_appends_admit_in_order_and_refill_the_pipeline() {
@@ -384,7 +455,26 @@ async fn engine_configuration_is_validated_without_panicking() {
 #[tokio::test]
 async fn active_segment_ceiling_backpressures_cleanly_until_truncation_frees_rotation() {
     let (_servers, factories, manifest_factory) = factory_cluster().await;
-    let volume = volume(factories, manifest_factory, "active-segment-ceiling-wal");
+    let prefix = "active-segment-ceiling-wal";
+    let manifest = Arc::new(FailFirstReadAfterRemoval {
+        inner: Arc::new(crate::manifest_store::GcsManifestStore::new(
+            manifest_factory.replica(&format!("{prefix}/manifest")),
+        )),
+        last_segments: std::sync::Mutex::new(None),
+        armed: std::sync::atomic::AtomicBool::new(false),
+        fail_next_read: std::sync::atomic::AtomicBool::new(false),
+        failed_reads: std::sync::atomic::AtomicUsize::new(0),
+    });
+    let volume = SegmentedVolume::new_with_factories_and_manifest_store(
+        factories,
+        manifest.clone(),
+        prefix,
+        ClientConfig {
+            max_retries: 0,
+            retry_base: Duration::ZERO,
+        },
+    )
+    .unwrap();
     let mut writer = volume.recover_writer().await.unwrap();
 
     // Fill the real register directory with one-record sealed segments. The
@@ -437,11 +527,19 @@ async fn active_segment_ceiling_backpressures_cleanly_until_truncation_frees_rot
         Err(Error::ActiveSegmentFull { .. })
     ));
 
+    manifest.armed.store(true, Ordering::SeqCst);
     let report = handle
         .truncate_before(WalSeqNo::record(active_base))
         .await
         .unwrap();
     assert!(report.deleted_segments > 0);
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while manifest.failed_reads.load(Ordering::SeqCst) == 0 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("the first post-truncation capacity refresh did not fail");
     let completion = tokio::time::timeout(Duration::from_secs(20), async {
         loop {
             match handle
@@ -454,7 +552,7 @@ async fn active_segment_ceiling_backpressures_cleanly_until_truncation_frees_rot
         }
     })
     .await
-    .expect("rotation did not resume after truncation freed directory capacity")
+    .expect("retained refresh retry did not resume rotation after truncation")
     .unwrap();
     completion.await.unwrap();
     shutdown_engine(handle).await;

--- a/rust/client/src/lib.rs
+++ b/rust/client/src/lib.rs
@@ -72,6 +72,7 @@
 #![doc = include_str!("../examples/database_wal.rs")]
 #![doc = "```"]
 
+mod archive;
 mod auth;
 mod engine;
 mod error;
@@ -88,10 +89,11 @@ mod transport;
 #[cfg(test)]
 mod grpc_internal_tests;
 
+pub use archive::{ArchiveByteStream, ArchiveError, ArchiveObjectRef, ArchivePolicy, ArchiveStore};
 pub use auth::{AccessTokenSource, BearerAuth, RefreshingAuthConfig};
 pub use engine::{AppendCompletion, AppendReceipt, WalEngineConfig, WalHandle};
 pub use error::Error;
-pub use grpc::GrpcReplicaFactory;
+pub use grpc::{GcsArchiveStore, GcsBodyManifestStore, GrpcReplicaFactory};
 pub use manifest_store::{ManifestStore, ManifestStoreError, ManifestVersion, VersionedManifest};
 pub use metrics::{
     CounterFn, GaugeFn, HistogramFn, MetricsRecorder, NoopMetricsRecorder, UpDownCounterFn,

--- a/rust/client/src/maintenance.rs
+++ b/rust/client/src/maintenance.rs
@@ -124,6 +124,7 @@ impl MaintenanceHandle {
 }
 
 pub(crate) struct MaintenanceConfig {
+    pub archive: Option<crate::archive::ArchiveConfig>,
     pub factories: Vec<Arc<dyn ReplicaFactory>>,
     pub manifest_store: Arc<dyn ManifestStore>,
     pub bucket_names: Vec<String>,
@@ -138,11 +139,19 @@ pub(crate) fn start(
     config: MaintenanceConfig,
     catalog: watch::Receiver<Vec<SegmentDescriptor>>,
     metrics: Arc<Metrics>,
+    rotation_recheck: mpsc::Sender<()>,
 ) -> (MaintenanceHandle, tokio::task::JoinHandle<()>) {
     let (tx, rx) = mpsc::channel(MAINTENANCE_COMMAND_CAPACITY);
     let (shutdown, shutdown_rx) = watch::channel(false);
     let task_metrics = Arc::clone(&metrics);
-    let task = tokio::spawn(run(config, catalog, rx, shutdown_rx, task_metrics));
+    let task = tokio::spawn(run(
+        config,
+        catalog,
+        rx,
+        shutdown_rx,
+        task_metrics,
+        rotation_recheck,
+    ));
     (
         MaintenanceHandle {
             tx,
@@ -154,6 +163,9 @@ pub(crate) fn start(
 }
 
 struct MaintenanceState {
+    archive: Option<crate::archive::ArchiveConfig>,
+    archived_end: u64,
+    rotation_recheck: mpsc::Sender<()>,
     factories: Vec<Arc<dyn ReplicaFactory>>,
     manifest_store: Arc<dyn ManifestStore>,
     bucket_names: Vec<String>,
@@ -185,8 +197,16 @@ async fn run(
     mut commands: mpsc::Receiver<MaintenanceCmd>,
     mut shutdown: watch::Receiver<bool>,
     metrics: Arc<Metrics>,
+    rotation_recheck: mpsc::Sender<()>,
 ) {
+    let periodic_repair = config.repair_interval.is_some();
+    let repair_interval = config
+        .repair_interval
+        .or_else(|| config.archive.as_ref().map(|_| Duration::from_secs(1)));
     let mut task = MaintenanceState {
+        archive: config.archive,
+        archived_end: 0,
+        rotation_recheck,
         factories: config.factories,
         manifest_store: config.manifest_store,
         bucket_names: config.bucket_names,
@@ -200,7 +220,7 @@ async fn run(
         manifest: None,
         metrics,
     };
-    let mut interval = config.repair_interval.map(|period| {
+    let mut interval = repair_interval.map(|period| {
         let mut interval = tokio::time::interval_at(Instant::now() + period, period);
         interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
         interval
@@ -210,22 +230,25 @@ async fn run(
     // repair never spends work on a tombstone the committed floor already
     // made unreachable.
     let mut pending = PendingCommands::default();
-    if maintenance_pass_or_shutdown(&mut task, &mut catalog_rx, &mut shutdown).await {
+    if maintenance_pass_or_shutdown(&mut task, &mut catalog_rx, &mut shutdown, true).await {
         commands.close();
         while let Some(command) = next_command(&mut commands, &mut pending).await {
             execute_command(&mut task, &mut catalog_rx, command).await;
         }
         return;
     }
+    let mut command_turn = false;
     loop {
-        // `biased` keeps the poll order deterministic (an unbiased `select!`
-        // randomizes its starting branch per call). Shutdown wins even when
-        // every maintenance pass overruns a hot interval. An overdue tick then
-        // wins before each logical command, so a sustained command flood cannot
-        // starve autonomous cleanup and repair.
-        tokio::select! {
-            biased;
-            _ = shutdown.changed() => {
+        match next_maintenance_event(
+            &mut commands,
+            &mut pending,
+            &mut shutdown,
+            &mut interval,
+            command_turn,
+        )
+        .await
+        {
+            MaintenanceEvent::Shutdown => {
                 // Graceful shutdown is signaled only after the engine has
                 // stopped producing seals. Close ingress, then drain every
                 // buffered command without periodic ticks interleaving; a
@@ -233,16 +256,29 @@ async fn run(
                 commands.close();
                 break;
             }
-            () = tick(&mut interval) => {
-                if maintenance_pass_or_shutdown(&mut task, &mut catalog_rx, &mut shutdown).await {
+            MaintenanceEvent::Tick => {
+                if maintenance_pass_or_shutdown(
+                    &mut task,
+                    &mut catalog_rx,
+                    &mut shutdown,
+                    periodic_repair,
+                )
+                .await
+                {
                     commands.close();
                     break;
                 }
+                // The next ready command wins over another overdue tick. After
+                // that command, an overdue tick wins again. This gives both
+                // autonomous maintenance and command work deterministic
+                // progress even when every pass exceeds the timer period.
+                command_turn = true;
             }
-            command = next_command(&mut commands, &mut pending) => match command {
-                Some(command) => execute_command(&mut task, &mut catalog_rx, command).await,
-                None => return,
-            },
+            MaintenanceEvent::Command(Some(command)) => {
+                execute_command(&mut task, &mut catalog_rx, command).await;
+                command_turn = false;
+            }
+            MaintenanceEvent::Command(None) => return,
         }
     }
 
@@ -251,10 +287,41 @@ async fn run(
     }
 }
 
+enum MaintenanceEvent {
+    Shutdown,
+    Tick,
+    Command(Option<ReadyCommand>),
+}
+
+async fn next_maintenance_event(
+    commands: &mut mpsc::Receiver<MaintenanceCmd>,
+    pending: &mut PendingCommands,
+    shutdown: &mut watch::Receiver<bool>,
+    interval: &mut Option<Interval>,
+    command_turn: bool,
+) -> MaintenanceEvent {
+    if command_turn {
+        tokio::select! {
+            biased;
+            _ = shutdown.changed() => MaintenanceEvent::Shutdown,
+            command = next_command(commands, pending) => MaintenanceEvent::Command(command),
+            () = tick(interval) => MaintenanceEvent::Tick,
+        }
+    } else {
+        tokio::select! {
+            biased;
+            _ = shutdown.changed() => MaintenanceEvent::Shutdown,
+            () = tick(interval) => MaintenanceEvent::Tick,
+            command = next_command(commands, pending) => MaintenanceEvent::Command(command),
+        }
+    }
+}
+
 async fn maintenance_pass_or_shutdown(
     task: &mut MaintenanceState,
     catalog_rx: &mut watch::Receiver<Vec<SegmentDescriptor>>,
     shutdown: &mut watch::Receiver<bool>,
+    repair: bool,
 ) -> bool {
     tokio::select! {
         biased;
@@ -264,7 +331,9 @@ async fn maintenance_pass_or_shutdown(
             task.adopt_catalog(catalog_rx);
             task.sweep_dead_segments_once().await;
             task.cleanup_tombstones_once().await;
-            task.repair_once().await;
+            task.archive_once().await;
+            // Archive retries must not re-enable disabled periodic repair.
+            if repair { task.repair_once().await; }
         } => false,
     }
 }
@@ -285,6 +354,7 @@ async fn execute_command(
         ReadyCommandKind::SealSegment { segment, enforced } => {
             task.seal_segment(*segment, enforced, catalog_rx).await;
             task.adopt_catalog(catalog_rx);
+            task.archive_once().await;
         }
         ReadyCommandKind::Truncate { floor, responses } => {
             task.adopt_catalog(catalog_rx);
@@ -605,7 +675,12 @@ impl MaintenanceState {
     fn adopt_catalog(&mut self, rx: &mut watch::Receiver<Vec<SegmentDescriptor>>) {
         let snapshot = rx.borrow_and_update().clone();
         let mut merged = snapshot;
-        merged.retain(|segment| !self.deleted.contains(&segment.base_record_index));
+        merged.retain(|segment| {
+            segment.base_record_index >= self.archived_end
+                && !self.deleted.contains(&segment.base_record_index)
+        });
+        self.deleted.retain(|base| *base >= self.archived_end);
+        self.sealed.retain(|base| *base >= self.archived_end);
         for segment in &mut merged {
             if segment.seal_pending && self.sealed.contains(&segment.base_record_index) {
                 segment.seal_pending = false;
@@ -712,10 +787,56 @@ impl MaintenanceState {
         }
     }
 
+    async fn archive_once(&mut self) {
+        let Some(config) = self.archive.clone() else {
+            return;
+        };
+        if let Err(error) = self.ensure_manifest().await {
+            tracing::warn!(%error, "archive manifest unavailable");
+            return;
+        }
+        let mut manifest = self.manifest.take().unwrap();
+        let result =
+            crate::segment::archive_one(&config, &self.factories, &self.prefix, &mut manifest)
+                .await;
+        if let Some(root) = manifest
+            .record()
+            .archive
+            .as_ref()
+            .and_then(|a| a.root.as_ref())
+        {
+            self.archived_end = root.end;
+            self.catalog
+                .retain(|segment| segment.base_record_index >= root.end);
+        }
+        match result {
+            Ok(true) => {
+                let _ = self.rotation_recheck.try_send(());
+            }
+            Ok(false) => {}
+            Err(error) => tracing::warn!(%error, "archival deferred; hot copies retained"),
+        }
+        if let Err(error) = crate::segment::cleanup_archived_one(
+            &config,
+            &self.factories,
+            &self.prefix,
+            &mut manifest,
+        )
+        .await
+        {
+            tracing::warn!(%error, "archived zonal cleanup deferred");
+        }
+        self.manifest = Some(manifest);
+    }
+
     async fn repair_once(&mut self) {
         let floor = match self.ensure_manifest().await {
             Ok(manifest) => match manifest.refreshed_record().await {
-                Ok(record) => record.trunc,
+                Ok(record) => record
+                    .archive
+                    .as_ref()
+                    .and_then(|a| a.root.as_ref())
+                    .map_or(record.trunc, |r| r.end.max(record.trunc)),
                 Err(error) => {
                     tracing::warn!(%error, "repair manifest refresh unavailable");
                     self.manifest = None;
@@ -777,7 +898,11 @@ impl MaintenanceState {
     async fn repair_segment_once(&mut self, segment: SegmentDescriptor) {
         let floor = match self.ensure_manifest().await {
             Ok(manifest) => match manifest.refreshed_record().await {
-                Ok(record) => record.trunc,
+                Ok(record) => record
+                    .archive
+                    .as_ref()
+                    .and_then(|a| a.root.as_ref())
+                    .map_or(record.trunc, |r| r.end.max(record.trunc)),
                 Err(error) => {
                     tracing::warn!(
                         %error,
@@ -868,6 +993,7 @@ impl MaintenanceState {
         self.manifest = Some(manifest);
         let report = result?;
         self.remember_catalog_deletions(before);
+        self.archive_once().await;
         Ok(report)
     }
 
@@ -975,5 +1101,39 @@ mod tests {
             repaired_requests + queued_requests,
             MAINTENANCE_COMMAND_CAPACITY
         );
+    }
+
+    #[tokio::test]
+    async fn overdue_maintenance_tick_yields_once_to_a_queued_command() {
+        let (tx, mut rx) = mpsc::channel(MAINTENANCE_COMMAND_CAPACITY);
+        let (_shutdown_tx, mut shutdown) = watch::channel(false);
+        let mut pending = PendingCommands::default();
+        let mut interval = Some(tokio::time::interval(Duration::from_millis(10)));
+
+        assert!(matches!(
+            next_maintenance_event(&mut rx, &mut pending, &mut shutdown, &mut interval, false)
+                .await,
+            MaintenanceEvent::Tick
+        ));
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        let (response, _receiver) = oneshot::channel();
+        tx.send(MaintenanceCmd::Truncate {
+            floor: WalSeqNo::record(1),
+            response,
+        })
+        .await
+        .unwrap();
+        assert!(matches!(
+            next_maintenance_event(&mut rx, &mut pending, &mut shutdown, &mut interval, true).await,
+            MaintenanceEvent::Command(Some(ReadyCommand {
+                kind: ReadyCommandKind::Truncate { .. },
+                ..
+            }))
+        ));
+        assert!(matches!(
+            next_maintenance_event(&mut rx, &mut pending, &mut shutdown, &mut interval, false)
+                .await,
+            MaintenanceEvent::Tick
+        ));
     }
 }

--- a/rust/client/src/manifest.rs
+++ b/rust/client/src/manifest.rs
@@ -26,15 +26,17 @@
 //! The register also carries the sealed segment directory
 //! (`chorus.segments`): every committed seal joins it in the seal's own CAS,
 //! and truncation removes an entry only after the segment's copy is
-//! confirmed deleted on every zone. The directory is the chain authority —
-//! recovery adopts it without listing buckets or re-reading sealed bytes —
-//! and its byte budget caps how many sealed segments the WAL retains.
+//! confirmed deleted on every zone. With archival enabled, publishing the
+//! immutable archive root removes the corresponding hot entry in the same CAS,
+//! before redundant zonal cleanup. The root and hot directory together are
+//! the chain authority; the directory budget bounds hot metadata, not history.
 
 use std::collections::hash_map::RandomState;
 use std::collections::{HashMap, HashSet};
 use std::hash::{BuildHasher, Hasher};
 use std::sync::Arc;
 
+use crate::archive::{ArchiveRoot, ArchiveState, ArchivedSegment};
 use crate::manifest_store::{ManifestStore, ManifestStoreError, ManifestVersion};
 use crate::metrics::Metrics;
 use crate::protocol::{retry_sleep, ClientConfig, ProtocolError, SUPPORTED_REPLICA_COUNTS};
@@ -43,7 +45,8 @@ use crate::protocol::{retry_sleep, ClientConfig, ProtocolError, SUPPORTED_REPLIC
 pub(crate) const MANIFEST_OBJECT: &str = "manifest";
 
 const META_FORMAT: &str = "chorus.format";
-/// The one supported register format. Structural validation does the real
+/// The non-archival register format; archival activation upgrades it to 2.
+/// Structural validation does the real
 /// gating: a register without the authoritative `chorus.segments` directory,
 /// a directory entry that lacks its CRC32C, or the ordered `chorus.buckets`
 /// replica binding is rejected at decode rather than migrated. Development
@@ -61,6 +64,7 @@ const META_SEAL_DIGEST: &str = "chorus.seal_digest";
 const META_TRUNC: &str = "chorus.trunc";
 const META_SEGMENTS: &str = "chorus.segments";
 const META_BUCKETS: &str = "chorus.buckets";
+const META_ARCHIVE: &str = "chorus.archive";
 
 const MAX_CAS_ROUNDS: usize = 16;
 
@@ -82,6 +86,7 @@ pub(crate) struct DirectoryEntry {
 #[derive(Clone, Debug, Eq, PartialEq)]
 /// The manifest register contents.
 pub(crate) struct ManifestRecord {
+    pub archive: Option<ArchiveState>,
     /// Highest writer epoch granted.
     pub epoch: u64,
     /// Random incarnation id the epoch was granted to.
@@ -148,6 +153,7 @@ fn validate_bucket_names(buckets: &[String]) -> Result<(), ProtocolError> {
 impl ManifestRecord {
     fn initial(buckets: Vec<String>) -> Self {
         Self {
+            archive: None,
             epoch: 0,
             owner: String::new(),
             tail_base: 0,
@@ -239,6 +245,13 @@ impl ManifestRecord {
             ),
             (META_BUCKETS.to_string(), self.buckets.join(",")),
         ]);
+        if let Some(archive) = &self.archive {
+            metadata.insert(META_FORMAT.into(), "2".into());
+            metadata.insert(
+                META_ARCHIVE.into(),
+                serde_json::to_string(archive).expect("serializable archive state"),
+            );
+        }
         if let Some(tail_id) = &self.tail_id {
             metadata.insert(META_TAIL_ID.to_string(), tail_id.clone());
         }
@@ -258,9 +271,12 @@ impl ManifestRecord {
     }
 
     fn decode(metadata: &HashMap<String, String>) -> Result<Self, ProtocolError> {
-        if metadata.get(META_FORMAT).map(String::as_str) != Some(FORMAT_VERSION) {
+        let format = metadata.get(META_FORMAT).map(String::as_str);
+        if !matches!(format, Some("1" | "2"))
+            || (format == Some("2")) != metadata.contains_key(META_ARCHIVE)
+        {
             return Err(ProtocolError::InvalidManifest(
-                "manifest does not use chorus.format=1".into(),
+                "unsupported or inconsistent chorus.format".into(),
             ));
         }
         let segments = Self::decode_segments(metadata.get(META_SEGMENTS).ok_or_else(|| {
@@ -286,6 +302,14 @@ impl ManifestRecord {
             ProtocolError::InvalidManifest("manifest lacks chorus.buckets".into())
         })?)?;
         let record = Self {
+            archive: metadata
+                .get(META_ARCHIVE)
+                .map(|value| {
+                    serde_json::from_str(value).map_err(|e| {
+                        ProtocolError::InvalidManifest(format!("invalid archive state: {e}"))
+                    })
+                })
+                .transpose()?,
             epoch: field(META_EPOCH)?,
             owner: metadata.get(META_OWNER).cloned().unwrap_or_default(),
             tail_base: field(META_TAIL_BASE)?,
@@ -304,6 +328,36 @@ impl ManifestRecord {
 
     fn validate(&self) -> Result<(), ProtocolError> {
         let invalid = |message: String| ProtocolError::InvalidManifest(message);
+        if let Some(archive) = &self.archive {
+            if !crate::archive::valid_namespace(&archive.namespace)
+                || serde_json::to_vec(archive).map_or(true, |bytes| bytes.len() > 1024)
+                || archive.start > self.trunc
+                || archive.cleaned < archive.start
+            {
+                return Err(invalid("invalid archive binding or boundaries".into()));
+            }
+            if let Some(root) = &archive.root {
+                if root.format != 1
+                    || root.height > 16
+                    || root.object.byte_len > 64 * 1024
+                    || root.object.key.len() > 80
+                    || root.start > archive.start
+                    || root.end <= archive.start
+                    || root.end > self.tail_base
+                    || archive.cleaned > root.end
+                    || self
+                        .segments
+                        .first()
+                        .is_none_or(|entry| entry.base != root.end)
+                {
+                    return Err(invalid(
+                        "archive root does not join the hot directory".into(),
+                    ));
+                }
+            } else if archive.cleaned != archive.start {
+                return Err(invalid("archive cleanup without a published root".into()));
+            }
+        }
         if self.seal_base.is_some() != self.seal_digest.is_some() {
             return Err(invalid(
                 "seal_base and seal_digest must appear together".into(),
@@ -382,6 +436,15 @@ impl ManifestRecord {
         ids: &HashSet<String>,
         witnessed_floor: u64,
     ) -> Result<(), ProtocolError> {
+        if self
+            .archive
+            .as_ref()
+            .is_some_and(|archive| witnessed_floor > archive.start)
+        {
+            return Err(ProtocolError::InvalidManifest(
+                "unarchived history cannot be removed by truncation".into(),
+            ));
+        }
         if witnessed_floor > self.trunc {
             return Err(ProtocolError::InvalidManifest(format!(
                 "segment removal floor {witnessed_floor} exceeds committed truncation floor {}",
@@ -1061,6 +1124,106 @@ impl Manifest {
         .await
     }
 
+    pub(crate) async fn configure_archive(&mut self, namespace: &str) -> Result<(), ProtocolError> {
+        let epoch = self.epoch;
+        let owner = self.owner.clone();
+        self.cas_transform(ProtocolError::ManifestUnavailable, |record| {
+            Self::check_claim(record, epoch, &owner)?;
+            if let Some(archive) = &record.archive {
+                if archive.namespace != namespace {
+                    return Err(ProtocolError::InvalidManifest(
+                        "archive namespace mismatch".into(),
+                    ));
+                }
+                return Ok(CasTransform::Done(()));
+            }
+            let mut next = record.clone();
+            next.archive = Some(ArchiveState {
+                namespace: namespace.into(),
+                start: record.trunc,
+                cleaned: record.trunc,
+                root: None,
+            });
+            Ok(CasTransform::Update {
+                record: Box::new(next),
+                value: (),
+            })
+        })
+        .await
+    }
+
+    /// Publish only a verified, contiguous oldest seal. Revalidate its exact
+    /// identity and parent root on every CAS retry. The current seal remains hot
+    /// because recovery may still need to enforce its finalization.
+    pub(crate) async fn publish_archive(
+        &mut self,
+        previous: Option<&ArchiveRoot>,
+        root: &ArchiveRoot,
+        segment: &ArchivedSegment,
+    ) -> Result<bool, ProtocolError> {
+        self.cas_transform(ProtocolError::ManifestUnavailable, |record| {
+            let Some(archive) = &record.archive else {
+                return Err(ProtocolError::InvalidManifest(
+                    "archive not configured".into(),
+                ));
+            };
+            if archive.root.as_ref() == Some(root) {
+                return Ok(CasTransform::Done(true));
+            }
+            if archive.root.as_ref() != previous {
+                return Ok(CasTransform::Done(false));
+            }
+            let Some(first) = record.segments.first() else {
+                return Ok(CasTransform::Done(false));
+            };
+            let Some(second) = record.segments.get(1) else {
+                return Ok(CasTransform::Done(false));
+            };
+            if first.id != segment.id
+                || first.base != segment.start
+                || first.crc32c != segment.crc32c
+                || second.base != segment.end
+                || record.seal_id.as_deref() == Some(first.id.as_str())
+                || root.end != segment.end
+                || root.start != previous.map_or(segment.start, |old| old.start)
+            {
+                return Ok(CasTransform::Done(false));
+            }
+            let mut next = record.clone();
+            next.archive.as_mut().unwrap().root = Some(root.clone());
+            next.segments.remove(0);
+            Ok(CasTransform::Update {
+                record: Box::new(next),
+                value: true,
+            })
+        })
+        .await
+    }
+
+    pub(crate) async fn archive_cleaned(&mut self, end: u64) -> Result<(), ProtocolError> {
+        self.cas_transform(ProtocolError::ManifestUnavailable, |record| {
+            let archive = record
+                .archive
+                .as_ref()
+                .ok_or_else(|| ProtocolError::InvalidManifest("archive not configured".into()))?;
+            if archive.cleaned >= end {
+                return Ok(CasTransform::Done(()));
+            }
+            if archive.root.as_ref().is_none_or(|root| end > root.end) {
+                return Err(ProtocolError::InvalidManifest(
+                    "archive cleanup exceeds published root".into(),
+                ));
+            }
+            let mut next = record.clone();
+            next.archive.as_mut().unwrap().cleaned = end;
+            Ok(CasTransform::Update {
+                record: Box::new(next),
+                value: (),
+            })
+        })
+        .await
+    }
+
     /// Drop directory entries whose every zonal copy is confirmed deleted.
     /// Epoch-free like [`Self::raise_trunc`] — the truncator discipline only
     /// removes entries wholly below `witnessed_floor`, which must itself be no
@@ -1196,6 +1359,7 @@ mod tests {
 
     fn valid_record() -> ManifestRecord {
         ManifestRecord {
+            archive: None,
             epoch: 7,
             owner: "abc".into(),
             tail_base: 10,

--- a/rust/client/src/manifest_store.rs
+++ b/rust/client/src/manifest_store.rs
@@ -109,7 +109,8 @@ pub(crate) struct GcsManifestStore {
 }
 
 /// GCS caps all custom object metadata at roughly 8 KiB. The fixed manifest
-/// fields stay below 500 bytes, leaving this conservative budget for the
+/// fields and bounded archive reference reserve the remaining space, leaving
+/// this conservative budget for the
 /// encoded sealed-segment directory.
 pub(crate) const GCS_MAX_DIRECTORY_BYTES: usize = 6144;
 

--- a/rust/client/src/segment.rs
+++ b/rust/client/src/segment.rs
@@ -90,6 +90,7 @@ impl From<&SegmentDescriptor> for CatalogSegment {
 /// WAL namespace: the zonal replica factories for segment data (one per
 /// zone) plus one regional factory hosting the manifest control register.
 pub struct SegmentedVolume {
+    archive: Option<crate::archive::ArchiveConfig>,
     factories: Vec<Arc<dyn ReplicaFactory>>,
     manifest_store: Arc<dyn ManifestStore>,
     bucket_names: Vec<String>,
@@ -334,6 +335,9 @@ pub(crate) struct DeadSegmentSweepReport {
 /// chain, the replay boundary, and the identity the writer starts from.
 struct RecoveredWriterState {
     sealed_segments: Vec<SegmentDescriptor>,
+    /// Captured with the adopted hot directory, before recovery CAS retries can
+    /// refresh the manifest. A newer root can overlap `sealed_segments`.
+    archive_root: Option<crate::archive::ArchiveRoot>,
     base_record_index: u64,
     checkpoint_floor: u64,
     active_id: String,
@@ -449,6 +453,7 @@ impl Recovery {
 
 /// Low-level recovered chain used by the engine and internal tests.
 pub(crate) struct SegmentedWriter {
+    archive: Option<crate::archive::ArchiveConfig>,
     manifest: Manifest,
     factories: Vec<Arc<dyn ReplicaFactory>>,
     prefix: String,
@@ -819,6 +824,7 @@ mod recovery {
                 .collect();
             let replica_count = factories.len();
             Ok(Self {
+                archive: None,
                 factories,
                 manifest_store,
                 bucket_names,
@@ -832,9 +838,57 @@ mod recovery {
             majority(self.factories.len())
         }
 
+        /// Enable automatic archival. The immutable store must be scoped to a
+        /// stable namespace unique to this WAL. Enabling is persisted during
+        /// writer recovery; subsequent opens require the same archive store.
+        /// History before that activation's checkpoint is not recoverable from
+        /// the archive. The newest seal is always retained for finalization.
+        pub fn with_archive(
+            mut self,
+            store: Arc<dyn crate::ArchiveStore>,
+            policy: crate::ArchivePolicy,
+        ) -> Result<Self, Error> {
+            if policy.keep_sealed_segments == 0
+                || !crate::archive::valid_namespace(store.namespace())
+            {
+                return Err(Error::InvalidConfig(
+                    "archive requires a stable namespace and at least one hot sealed segment",
+                ));
+            }
+            // Reserve room for the active/pending pipeline's next folds as
+            // well as the configured target. Otherwise the target itself
+            // could prevent archival from ever relieving a full register.
+            if !crate::manifest::directory_has_room_for(
+                0,
+                policy.keep_sealed_segments.saturating_add(2),
+                self.manifest_store.max_directory_bytes(),
+            ) {
+                return Err(Error::InvalidConfig(
+                    "archive hot target exceeds manifest capacity",
+                ));
+            }
+            self.archive = Some(crate::archive::ArchiveConfig { store, policy });
+            Ok(self)
+        }
+
+        fn check_archive(&self, record: &ManifestRecord) -> Result<(), Error> {
+            if let Some(state) = &record.archive {
+                if self
+                    .archive
+                    .as_ref()
+                    .is_none_or(|config| config.store.namespace() != state.namespace)
+                {
+                    return Err(Error::InvalidConfig(
+                        "volume requires its configured archive namespace",
+                    ));
+                }
+            }
+            Ok(())
+        }
+
         /// Open the manifest register for this WAL prefix.
         async fn open_manifest(&self) -> Result<Manifest, Error> {
-            Manifest::open(
+            let manifest = Manifest::open(
                 Arc::clone(&self.manifest_store),
                 self.client_config.clone(),
                 Arc::clone(&self.metrics),
@@ -842,11 +896,13 @@ mod recovery {
                 self.bucket_names.clone(),
             )
             .await
-            .map_err(Into::into)
+            .map_err(Error::from)?;
+            self.check_archive(manifest.record())?;
+            Ok(manifest)
         }
 
         async fn open_existing_manifest(&self) -> Result<Option<Manifest>, Error> {
-            Manifest::open_existing(
+            let manifest = Manifest::open_existing(
                 Arc::clone(&self.manifest_store),
                 self.client_config.clone(),
                 Arc::clone(&self.metrics),
@@ -854,7 +910,11 @@ mod recovery {
                 self.bucket_names.clone(),
             )
             .await
-            .map_err(Into::into)
+            .map_err(Error::from)?;
+            if let Some(manifest) = &manifest {
+                self.check_archive(manifest.record())?;
+            }
+            Ok(manifest)
         }
 
         /// Open a non-coordinating follower at `checkpoint`.
@@ -865,8 +925,10 @@ mod recovery {
         ///
         /// The application must retain WAL history until every follower has
         /// durably advanced its own checkpoint. No reader registration is
-        /// performed; if truncation overtakes this checkpoint, the stream
-        /// returns [`crate::Error::ReadOnlyLagged`].
+        /// performed; without archival, truncation overtaking this checkpoint
+        /// returns [`crate::Error::ReadOnlyLagged`]. With archival, the earliest
+        /// readable position is the floor recorded when archival was enabled.
+        /// Drop the stream to stop early; no reader registration needs cleanup.
         pub async fn open_readonly(&self, checkpoint: WalSeqNo) -> Result<ReadOnlyFollower, Error> {
             self.open_readonly_with_config(checkpoint, ReadOnlyConfig::default())
                 .await
@@ -900,6 +962,7 @@ mod recovery {
             checkpoint: WalSeqNo,
             config: ReadOnlyConfig,
         ) -> StartupReplayStream {
+            let volume = self.clone();
             let factories = self.factories.clone();
             let prefix = self.prefix.clone();
             let metrics = Arc::clone(&self.metrics);
@@ -912,7 +975,16 @@ mod recovery {
                 let mut record = initial_record?;
                 let mut active = None;
                 'follow: loop {
+                    volume.check_archive(&record)?;
                     check_readonly_floor(&record, next)?;
+                    if let Some(root) = record.archive.as_ref().and_then(|state| state.root.clone()) {
+                        let mut archived = volume.scan_archive(root, next, WalSeqNo::record(record.tail_base));
+                        while let Some(wal_record) = archived.next().await {
+                            let wal_record = wal_record?;
+                            next = wal_record.next_seqno();
+                            yield wal_record;
+                        }
+                    }
                     let sealed_end = WalSeqNo::record(record.tail_base);
                     let segments = readonly_segments(&record)?;
                     for segment in segments {
@@ -921,15 +993,9 @@ mod recovery {
                         {
                             continue;
                         }
-                        let object = format!("{prefix}/segments/{}", segment.id);
                         // Only the pending seal can be listed before its copies
                         // are finalized; older entries were finalized or repaired.
-                        let frames = match read_sealed_segment(
-                            &factories,
-                            &object,
-                            &segment,
-                            segment.seal_pending,
-                        )
+                        let frames = match volume.read_available_segment(&segment, segment.seal_pending)
                         .await
                         {
                             Ok(frames) => frames,
@@ -1102,7 +1168,12 @@ mod recovery {
                 replay_end = end.record_index,
                 "WAL recovery replay range prepared"
             );
-            let inner = self.scan_sealed_range(&writer_state.sealed_segments, checkpoint, end);
+            let inner = self.scan_sealed_range(
+                &writer_state.sealed_segments,
+                checkpoint,
+                end,
+                writer_state.archive_root.clone(),
+            );
             Ok(Recovery {
                 from: checkpoint,
                 end,
@@ -1152,6 +1223,7 @@ mod recovery {
                 &writer_state.sealed_segments,
                 checkpoint,
                 WalSeqNo::record(writer_state.base_record_index),
+                writer_state.archive_root.clone(),
             );
             while let Some(record) = replay.next().await {
                 record?;
@@ -1164,6 +1236,12 @@ mod recovery {
             checkpoint: WalSeqNo,
             manifest: &mut Manifest,
         ) -> Result<RecoveredWriterState, Error> {
+            // A concurrent recovery can bind an archive between our initial
+            // manifest read and the successful epoch claim.
+            self.check_archive(manifest.record())?;
+            if let Some(config) = &self.archive {
+                manifest.configure_archive(config.store.namespace()).await?;
+            }
             let adopted: ManifestRecord = manifest.record().clone();
             let claimed_epoch = adopted.epoch;
             let bootstrap_id = segment_id(claimed_epoch, 0);
@@ -1177,7 +1255,7 @@ mod recovery {
             if checkpoint.record_index < adopted.trunc {
                 return Err(Error::InvalidCatalog(format!(
                     "checkpoint {} lies below the committed truncation floor {}: \
-                 those records were deleted after the database checkpointed them",
+                 use a readonly stream for historical archival replay",
                     checkpoint.record_index, adopted.trunc
                 )));
             }
@@ -1232,7 +1310,14 @@ mod recovery {
                 chain.push((entry.id.clone(), entry.base, end, entry.crc32c));
             }
             if let Some((_, first_base, _, _)) = chain.first() {
-                if *first_base > checkpoint.record_index && *first_base > adopted.trunc {
+                if *first_base > checkpoint.record_index
+                    && *first_base > adopted.trunc
+                    && !adopted
+                        .archive
+                        .as_ref()
+                        .and_then(|a| a.root.as_ref())
+                        .is_some_and(|r| r.start <= checkpoint.record_index && r.end >= *first_base)
+                {
                     return Err(Error::InvalidCatalog(format!(
                         "oldest segment starts at {first_base}, after checkpoint boundary {}",
                         checkpoint.record_index
@@ -1631,6 +1716,7 @@ mod recovery {
             }
             Ok(RecoveredWriterState {
                 sealed_segments,
+                archive_root: adopted.archive.as_ref().and_then(|a| a.root.clone()),
                 base_record_index: next_record_index,
                 checkpoint_floor,
                 active_id,
@@ -1649,6 +1735,7 @@ mod recovery {
         ) -> Result<SegmentedWriter, Error> {
             let RecoveredWriterState {
                 sealed_segments,
+                archive_root: _,
                 base_record_index,
                 checkpoint_floor,
                 active_id,
@@ -1697,6 +1784,7 @@ mod recovery {
             manifest.validate_owner().await.map_err(Error::from)?;
             let spare_registered = pending_fold.is_none();
             Ok(SegmentedWriter {
+                archive: self.archive.clone(),
                 factories: self.factories.clone(),
                 prefix: self.prefix.clone(),
                 client_config: self.client_config.clone(),
@@ -1725,22 +1813,22 @@ mod recovery {
             segments: &[SegmentDescriptor],
             from: WalSeqNo,
             end: WalSeqNo,
+            archive_root: Option<crate::archive::ArchiveRoot>,
         ) -> StartupReplayStream {
             debug_assert!(from.record_index <= end.record_index);
             let segments = segments.to_vec();
-            let factories = self.factories.clone();
-            let prefix = self.prefix.clone();
+            let volume = self.clone();
             async_stream::try_stream! {
+            if let Some(root) = archive_root {
+                let mut archived = volume.scan_archive(root, from, end);
+                while let Some(record) = archived.next().await { yield record?; }
+            }
             for segment in segments {
                 let segment_end = segment.end_record_index;
                 if segment_end < from.record_index || segment.base_record_index >= end.record_index {
                     continue;
                 }
-                let records = read_sealed_segment(
-                    &factories,
-                    &format!("{prefix}/segments/{}", segment.id),
-                    &segment, false,
-)
+                let records = volume.read_available_segment(&segment, false)
                 .await?;
                 for record in replay_records(&segment, &records, from, end)? {
                     yield record;
@@ -1748,6 +1836,72 @@ mod recovery {
             }
         }
         .boxed()
+        }
+
+        fn scan_archive(
+            &self,
+            root: crate::archive::ArchiveRoot,
+            from: WalSeqNo,
+            end: WalSeqNo,
+        ) -> StartupReplayStream {
+            let config = self.archive.clone();
+            async_stream::try_stream! {
+                let config = config.ok_or(Error::InvalidConfig("archive store missing"))?;
+                let catalog = crate::archive::ArchiveCatalog::new(config.store.clone());
+                let mut entries = catalog.scan_from(root, from.record_index);
+                while let Some(entry) = entries.next().await {
+                    let entry = entry?;
+                    if entry.start >= end.record_index { break; }
+                    let frames = read_archived_segment(config.store.as_ref(), &entry).await?;
+                    let segment = archived_descriptor(&entry);
+                    for record in replay_records(&segment, &frames, from, end)? { yield record; }
+                }
+            }
+            .boxed()
+        }
+
+        async fn read_available_segment(
+            &self,
+            segment: &SegmentDescriptor,
+            pending: bool,
+        ) -> Result<Vec<RecordFrame>, Error> {
+            let hot = read_sealed_segment(
+                &self.factories,
+                &segment_object(&self.prefix, &segment.id),
+                segment,
+                pending,
+            )
+            .await;
+            if hot.is_ok() || self.archive.is_none() {
+                return hot;
+            }
+            // A cached hot descriptor can be evicted during a read. Only a
+            // published catalog entry with the exact identity authorizes fallback.
+            let manifest = self
+                .open_existing_manifest()
+                .await?
+                .ok_or(Error::Uninitialized)?;
+            if let Some(root) = manifest
+                .record()
+                .archive
+                .as_ref()
+                .and_then(|state| state.root.clone())
+            {
+                let config = self.archive.as_ref().unwrap();
+                let mut entries = crate::archive::ArchiveCatalog::new(config.store.clone())
+                    .scan_from(root, segment.base_record_index);
+                if let Some(entry) = entries.next().await {
+                    let entry = entry?;
+                    if entry.id == segment.id
+                        && entry.start == segment.base_record_index
+                        && entry.end == segment.end_record_index + 1
+                        && entry.crc32c == segment.crc32c
+                    {
+                        return read_archived_segment(config.store.as_ref(), &entry).await;
+                    }
+                }
+            }
+            hot
         }
 
         async fn finalized_segment_descriptor(
@@ -2140,6 +2294,16 @@ mod writer {
                 .refreshed_record()
                 .await
                 .map_err(Error::from)?;
+            if let Some(root) = self
+                .manifest
+                .record()
+                .archive
+                .as_ref()
+                .and_then(|a| a.root.as_ref())
+            {
+                self.sealed_segments
+                    .retain(|segment| segment.base_record_index >= root.end);
+            }
             Ok(self.rotation_due(max_segment_bytes))
         }
 
@@ -2472,6 +2636,7 @@ mod writer {
             repair_interval: Option<std::time::Duration>,
         ) -> crate::maintenance::MaintenanceConfig {
             crate::maintenance::MaintenanceConfig {
+                archive: self.archive.clone(),
                 factories: self.factories.clone(),
                 manifest_store: self.manifest.store(),
                 bucket_names: self.manifest.bucket_names().to_vec(),
@@ -3353,7 +3518,10 @@ mod maintenance {
         manifest: &mut Manifest,
     ) -> Result<TruncationReport, Error> {
         let record = manifest.record().clone();
-        let floor = record.trunc;
+        let floor = record
+            .archive
+            .as_ref()
+            .map_or(record.trunc, |archive| archive.start);
         let directory = record.segments.clone();
         // A swap whose maintenance seal has not settled yet is published with
         // `seal_pending` in the chain snapshot (the engine sends the snapshot
@@ -3514,6 +3682,146 @@ pub(crate) use maintenance::{
     truncate_pass,
 };
 
+fn archived_descriptor(entry: &crate::archive::ArchivedSegment) -> SegmentDescriptor {
+    SegmentDescriptor {
+        id: entry.id.clone(),
+        base_record_index: entry.start,
+        end_record_index: entry.end - 1,
+        crc32c: entry.crc32c,
+        copies: 0,
+        finalized_copies: 0,
+        seal_pending: false,
+    }
+}
+
+async fn read_archived_segment(
+    store: &dyn crate::ArchiveStore,
+    entry: &crate::archive::ArchivedSegment,
+) -> Result<Vec<RecordFrame>, Error> {
+    let bytes = crate::archive::read_all(store, &entry.object).await?;
+    if crc32c::crc32c(&bytes) != entry.crc32c {
+        return Err(Error::InvalidSegmentData(
+            "archived segment CRC32C mismatch".into(),
+        ));
+    }
+    let frames = RecordFrame::decode_all(&bytes)?;
+    if frames.len() as u64 != entry.end - entry.start {
+        return Err(Error::InvalidSegmentData(
+            "archived segment record count mismatch".into(),
+        ));
+    }
+    Ok(frames)
+}
+
+/// A bounded archive step. Only a predecessor of the current seal can move:
+/// the next fold proves that predecessor's finalization gate completed.
+pub(crate) async fn archive_one(
+    config: &crate::archive::ArchiveConfig,
+    factories: &[Arc<dyn ReplicaFactory>],
+    prefix: &str,
+    manifest: &mut Manifest,
+) -> Result<bool, Error> {
+    let record = manifest.refreshed_record().await?;
+    let state = record
+        .archive
+        .as_ref()
+        .ok_or(Error::InvalidConfig("archive not enabled"))?;
+    if state.namespace != config.store.namespace() {
+        return Err(Error::InvalidConfig("archive namespace mismatch"));
+    }
+    let Some(second) = record.segments.get(1) else {
+        return Ok(false);
+    };
+    let first = &record.segments[0];
+    if second.base <= state.start
+        || record.seal_id.as_deref() == Some(first.id.as_str())
+        || (record.segments.len() <= config.policy.keep_sealed_segments
+            && second.base > record.trunc)
+    {
+        return Ok(false);
+    }
+    let descriptor = SegmentDescriptor {
+        id: first.id.clone(),
+        base_record_index: first.base,
+        end_record_index: second.base - 1,
+        crc32c: first.crc32c,
+        copies: 0,
+        finalized_copies: 0,
+        seal_pending: false,
+    };
+    let frames = read_sealed_segment(
+        factories,
+        &segment_object(prefix, &first.id),
+        &descriptor,
+        false,
+    )
+    .await?;
+    let mut bytes = Vec::new();
+    for frame in frames {
+        bytes.extend_from_slice(&frame.encode()?);
+    }
+    let bytes = Bytes::from(bytes);
+    let object = crate::ArchiveObjectRef::for_bytes("segments", &bytes);
+    config
+        .store
+        .put_if_absent(&object, crate::archive::bytes_stream(bytes))
+        .await?;
+    let entry = crate::archive::ArchivedSegment {
+        id: first.id.clone(),
+        start: first.base,
+        end: second.base,
+        crc32c: first.crc32c,
+        object,
+    };
+    let catalog = crate::archive::ArchiveCatalog::new(config.store.clone());
+    let root = catalog
+        .prepare_append(state.root.as_ref(), entry.clone())
+        .await?;
+    Ok(manifest
+        .publish_archive(state.root.as_ref(), &root, &entry)
+        .await?)
+}
+
+/// The durable catalog doubles as the zonal cleanup work list. One unavailable
+/// zone holds the cleanup cursor, not a hot directory slot. No bucket listing
+/// is used and no active/pending name can be selected by this path.
+pub(crate) async fn cleanup_archived_one(
+    config: &crate::archive::ArchiveConfig,
+    factories: &[Arc<dyn ReplicaFactory>],
+    prefix: &str,
+    manifest: &mut Manifest,
+) -> Result<(), Error> {
+    let record = manifest.refreshed_record().await?;
+    let Some(state) = &record.archive else {
+        return Ok(());
+    };
+    let Some(root) = &state.root else {
+        return Ok(());
+    };
+    let mut entries = crate::archive::ArchiveCatalog::new(config.store.clone())
+        .scan_from(root.clone(), state.cleaned);
+    let Some(entry) = entries.next().await else {
+        return Ok(());
+    };
+    let entry = entry?;
+    let mut all_absent = true;
+    for replica in replicas_for(factories, &segment_object(prefix, &entry.id)) {
+        match replica.stat().await {
+            Ok(snapshot) => match replica.delete(snapshot.generation).await {
+                Ok(()) => {}
+                Err(error) if error.code == TransportCode::NotFound => {}
+                Err(_) => all_absent = false,
+            },
+            Err(error) if error.code == TransportCode::NotFound => {}
+            Err(_) => all_absent = false,
+        }
+    }
+    if all_absent {
+        manifest.archive_cleaned(entry.end).await?;
+    }
+    Ok(())
+}
+
 fn replay_records(
     segment: &SegmentDescriptor,
     frames: &[RecordFrame],
@@ -3535,10 +3843,14 @@ fn replay_records(
 }
 
 fn check_readonly_floor(record: &ManifestRecord, next: WalSeqNo) -> Result<(), Error> {
-    if next.record_index < record.trunc {
+    let floor = record
+        .archive
+        .as_ref()
+        .map_or(record.trunc, |archive| archive.start);
+    if next.record_index < floor {
         return Err(Error::ReadOnlyLagged {
             next,
-            truncation_floor: WalSeqNo::record(record.trunc),
+            truncation_floor: WalSeqNo::record(floor),
         });
     }
     Ok(())

--- a/rust/fake-gcs/src/lib.rs
+++ b/rust/fake-gcs/src/lib.rs
@@ -1279,10 +1279,14 @@ impl FakeGcs {
         check_metadata_size(&resource.metadata)?;
         let mut state = self.inner.lock().await;
         let key = object_key(&resource.bucket, &resource.name);
-        if state.objects.contains_key(&key) {
+        if let Some(existing) = state.objects.get(&key) {
             if if_generation_match == Some(0) {
                 return Err(Status::already_exists("object exists"));
             }
+            if if_generation_match != Some(existing.generation) {
+                return Err(Status::failed_precondition("generation mismatch"));
+            }
+        } else if if_generation_match.is_some_and(|generation| generation != 0) {
             return Err(Status::failed_precondition("generation mismatch"));
         }
         state.next_generation += 1;


### PR DESCRIPTION
## Summary

Add opt-in, pluggable WAL archival so sealed history can move out of the bounded hot metadata register without advancing the application truncation floor.

- Add an immutable `ArchiveStore` interface for WAL segments and copy-on-write catalog pages.
- Add regional GCS archive storage and a GCS-object-body `ManifestStore` implementation.
- Configure archival with `keep_sealed_segments`; there is no imperative archive-position API.
- Preserve ordinary record-stream behavior, including stopping a read early by dropping the stream.

## Storage and lifecycle design

Archival uploads the finalized segment and immutable catalog pages before atomically publishing the new archive root. Only after publication does maintenance remove the corresponding hot manifest entry and delete redundant zonal copies.

The hot manifest retains one bounded archive-root reference. Catalog pages form a copy-on-write tree, allowing retained history to grow independently of the hot register without rewriting or loading the entire archive index.

The retention policy keeps at least one sealed hot segment as the current recovery finalization witness. Archive failures retain hot copies and surface ordinary non-poisoning metadata backpressure rather than authorizing data loss.

## Recovery and concurrency safety

Recovery captures the archive root and hot segment directory from the same adopted manifest version. Later recovery CAS retries may refresh writer metadata, but cannot substitute a newer archive root into the captured replay plan. This keeps the archive and hot ranges disjoint during concurrent archive publication and prevents duplicate replay.

When archival or truncation frees directory capacity, the engine retains and retries a failed manifest refresh. An isolated failed read therefore cannot leave rotation permanently blocked. Maintenance also alternates overdue periodic work with ready seal or truncate commands, preventing either source of work from starving under sustained archive latency.

Archived objects are immutable and validated by identity, length, SHA-256, CRC32C, and record framing before records are yielded.

## Compatibility and limitations

Archive activation persists manifest format 2 and the archive namespace. Older clients reject the new format, and subsequent opens must supply the same archive namespace. Enabling archival does not restore history that was already truncated.

This provides retained WAL history for PITR, but the application still needs snapshots and a transaction or timestamp mapping. Superseded and orphaned archive catalog pages are intentionally not garbage-collected in this version. Live cloud GCS was not exercised; the adapters were tested against the fake gRPC GCS server.

## Verification

- Full Rust workspace tests: 161 client tests passed, 1 ignored; all remaining workspace tests passed.
- Strict workspace Clippy with warnings denied.
- 21 P model scenarios at 1,000 schedules each.
- 41 existing quorum invariants.
- 14 archive invariants and proof obligations.
- Negative proof mutations for delete-before-publish, publish-before-index, and refreshed recovery roots were all rejected.
- Two real recovery publication-race regressions covering empty and existing archive roots plus checkpoints before, at, and after the moved segment.
- Capacity-refresh fault injection and overdue-maintenance truncation fairness regressions.
- Ten-seed DST trace: 3,449 structurally valid events; PObserve accepted 3,308 protocol events and rejected its negative fixtures.
- Independent storage, proof, and lifecycle reviews; the final P1 and P2 re-reviews passed with no remaining findings in scope.

The aggregate verification wrapper could not complete in this sandbox because three CLI tests were denied permission while starting fake GCS child processes. Those same tests passed in the direct full-workspace run, and every remaining wrapper stage was run directly and passed.
