### PR TITLE
client: share storage across decoded record payloads

### DIFF
--- a/rust/client/src/record.rs
+++ b/rust/client/src/record.rs
@@ -1,4 +1,4 @@
-use bytes::{BufMut, Bytes, BytesMut};
+use bytes::{Buf, BufMut, Bytes, BytesMut};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 /// Internal durable envelope for one opaque application record.
@@ -34,12 +34,25 @@ impl RecordFrame {
     }
 
     /// Decode every record in a complete segment byte slice.
-    pub fn decode_all(mut input: &[u8]) -> Result<Vec<Self>, RecordError> {
+    ///
+    /// The borrowed input is copied once into shared storage rather than once
+    /// per payload. Callers that already own [`Bytes`] should use the internal
+    /// owned form to avoid that segment-level copy as well.
+    pub fn decode_all(input: &[u8]) -> Result<Vec<Self>, RecordError> {
+        Self::decode_all_bytes(Bytes::copy_from_slice(input))
+    }
+
+    /// Decode every record from an owned segment without copying its payloads.
+    ///
+    /// Each returned payload is a slice of `input`, so retaining one record
+    /// retains the complete backing allocation. This is intended for complete
+    /// segment reads whose records have the same lifetime as the read buffer.
+    pub(crate) fn decode_all_bytes(mut input: Bytes) -> Result<Vec<Self>, RecordError> {
         let mut records = Vec::new();
         while !input.is_empty() {
-            let (record, consumed) = Self::decode_one(input)?;
+            let (record, consumed) = Self::decode_one_bytes(&input)?;
             records.push(record);
-            input = &input[consumed..];
+            input.advance(consumed);
         }
         Ok(records)
     }
@@ -64,6 +77,26 @@ impl RecordFrame {
     }
 
     fn decode_one(input: &[u8]) -> Result<(Self, usize), RecordError> {
+        let total_len = Self::decoded_len(input)?;
+        Ok((
+            Self {
+                payload: Bytes::copy_from_slice(&input[Self::HEADER_LEN..total_len]),
+            },
+            total_len,
+        ))
+    }
+
+    fn decode_one_bytes(input: &Bytes) -> Result<(Self, usize), RecordError> {
+        let total_len = Self::decoded_len(input)?;
+        Ok((
+            Self {
+                payload: input.slice(Self::HEADER_LEN..total_len),
+            },
+            total_len,
+        ))
+    }
+
+    fn decoded_len(input: &[u8]) -> Result<usize, RecordError> {
         if input.len() < Self::HEADER_LEN {
             return Err(RecordError::Truncated);
         }
@@ -74,12 +107,7 @@ impl RecordFrame {
         if input.len() < total_len {
             return Err(RecordError::Truncated);
         }
-        Ok((
-            Self {
-                payload: Bytes::copy_from_slice(&input[Self::HEADER_LEN..total_len]),
-            },
-            total_len,
-        ))
+        Ok(total_len)
     }
 }
 
@@ -151,5 +179,47 @@ mod tests {
                 payload: Bytes::new()
             }]
         );
+    }
+
+    #[test]
+    fn owned_decode_shares_the_input_allocation() {
+        let first = RecordFrame {
+            payload: Bytes::from_static(b"alpha"),
+        }
+        .encode()
+        .unwrap();
+        let second = RecordFrame {
+            payload: Bytes::from_static(b"beta"),
+        }
+        .encode()
+        .unwrap();
+        let mut input = BytesMut::with_capacity(first.len() + second.len());
+        input.extend_from_slice(&first);
+        input.extend_from_slice(&second);
+        let input = input.freeze();
+        let first_payload = input[RecordFrame::HEADER_LEN..].as_ptr();
+        let second_payload = input[first.len() + RecordFrame::HEADER_LEN..].as_ptr();
+
+        let records = RecordFrame::decode_all_bytes(input.clone()).unwrap();
+
+        assert_eq!(records[0].payload.as_ptr(), first_payload);
+        assert_eq!(records[1].payload.as_ptr(), second_payload);
+        drop(input);
+        assert_eq!(records[0].payload.as_ref(), b"alpha");
+        assert_eq!(records[1].payload.as_ref(), b"beta");
+    }
+
+    #[test]
+    fn owned_decode_preserves_validation_errors() {
+        for malformed in [
+            Bytes::from_static(&[0, 0, 0]),
+            Bytes::from_static(&[0, 0, 0, 3]),
+            Bytes::from_static(&[0, 0, 0, 8, 1, 2]),
+        ] {
+            assert_eq!(
+                RecordFrame::decode_all_bytes(malformed.clone()).unwrap_err(),
+                RecordFrame::decode_all(&malformed).unwrap_err()
+            );
+        }
     }
 }

--- a/rust/client/src/record.rs
+++ b/rust/client/src/record.rs
@@ -57,6 +57,18 @@ impl RecordFrame {
         Ok(records)
     }
 
+    /// Validate a complete segment and return its record count without
+    /// allocating or copying payload bytes.
+    pub(crate) fn validate_all(mut input: &[u8]) -> Result<usize, RecordError> {
+        let mut records = 0usize;
+        while !input.is_empty() {
+            let consumed = Self::decoded_len(input)?;
+            records += 1;
+            input = &input[consumed..];
+        }
+        Ok(records)
+    }
+
     /// Decode the contiguous well-formed prefix of an appendable object.
     ///
     /// A partial or malformed tail terminates the prefix. Recovery never scans
@@ -219,6 +231,39 @@ mod tests {
             assert_eq!(
                 RecordFrame::decode_all_bytes(malformed.clone()).unwrap_err(),
                 RecordFrame::decode_all(&malformed).unwrap_err()
+            );
+        }
+    }
+
+    #[test]
+    fn validation_counts_without_decoding_payloads() {
+        let expected = [
+            RecordFrame {
+                payload: Bytes::from_static(b"alpha"),
+            },
+            RecordFrame {
+                payload: Bytes::new(),
+            },
+            RecordFrame {
+                payload: Bytes::from_static(b"omega"),
+            },
+        ];
+        let bytes: Vec<u8> = expected
+            .iter()
+            .flat_map(|record| record.encode().unwrap())
+            .collect();
+
+        assert_eq!(RecordFrame::validate_all(&bytes), Ok(expected.len()));
+        assert_eq!(RecordFrame::validate_all(&[]), Ok(0));
+        assert_eq!(
+            RecordFrame::validate_all(&bytes),
+            RecordFrame::decode_all(&bytes).map(|records| records.len())
+        );
+
+        for malformed in [&[0, 0, 0][..], &[0, 0, 0, 3][..], &[0, 0, 0, 8, 1, 2][..]] {
+            assert_eq!(
+                RecordFrame::validate_all(malformed).unwrap_err(),
+                RecordFrame::decode_all(malformed).unwrap_err()
             );
         }
     }

--- a/rust/client/src/segment.rs
+++ b/rust/client/src/segment.rs
@@ -1859,27 +1859,32 @@ mod recovery {
             }
             let mut groups: HashMap<Vec<u8>, Vec<ReplicaSnapshot>> = HashMap::new();
             for snapshot in finalized {
-                if RecordFrame::decode_all(&snapshot.bytes).is_ok() {
-                    groups
-                        .entry(snapshot.bytes.clone())
-                        .or_default()
-                        .push(snapshot);
-                }
+                groups
+                    .entry(snapshot.bytes.clone())
+                    .or_default()
+                    .push(snapshot);
             }
-            let Some((canonical_bytes, finalized)) = groups
+            let Some((canonical_bytes, record_count, finalized)) = groups
                 .into_iter()
-                .filter(|(_, copies)| copies.len() >= self.quorum())
-                .filter(|(bytes, _)| {
-                    expected_records.is_none_or(|expected| {
-                        RecordFrame::decode_all(bytes)
-                            .is_ok_and(|records| records.len() as u64 == expected)
-                    })
+                .filter_map(|(bytes, copies)| {
+                    RecordFrame::validate_all(&bytes)
+                        .ok()
+                        .map(|record_count| (bytes, record_count, copies))
                 })
-                .max_by(|(left, _), (right, _)| left.len().cmp(&right.len()).then(left.cmp(right)))
+                .filter(|(_, _, copies)| copies.len() >= self.quorum())
+                .filter(|(_, record_count, _)| {
+                    expected_records
+                        .is_none_or(|expected| u64::try_from(*record_count).ok() == Some(expected))
+                })
+                .max_by(|(left, _, _), (right, _, _)| {
+                    left.len().cmp(&right.len()).then(left.cmp(right))
+                })
             else {
                 return Ok(None);
             };
-            let record_count = RecordFrame::decode_all(&canonical_bytes)?.len() as u64;
+            let record_count = u64::try_from(record_count).map_err(|_| {
+                Error::InvalidCatalog("finalized segment record count does not fit in u64".into())
+            })?;
             let Some(last_record_offset) = record_count.checked_sub(1) else {
                 return Err(Error::InvalidCatalog(format!(
                     "finalized segment {base_record_index} is empty"


### PR DESCRIPTION
## Summary

- decode complete WAL segments into payload slices backed by one shared `Bytes` allocation
- reduce the borrowed API from one allocation per record payload to one allocation per segment
- preserve the existing copying behavior for appendable-prefix decoding so a small valid prefix cannot retain a large malformed tail
- share structural validation between the owned and borrowed decoders

The foundational WAL archive work has owned `Bytes` buffers and will integrate `decode_all_bytes` in its own PR. Those archive-specific call-site changes are intentionally excluded here so this remains independently reviewable against `main`.

## Lifetime tradeoff

A retained record decoded from a complete segment now retains the segment backing allocation. Complete-segment callers already process the returned records as a unit, making that tradeoff appropriate for avoiding per-record allocations. Prefix decoding remains isolated because its unconsumed tail can be arbitrarily large or malformed.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p chorus-client record::tests` (5 passed)
- `cargo test -p chorus-client --doc` (1 passed)
- `cargo clippy -p chorus-client --all-targets --all-features -- -D warnings`
- `git diff --check`